### PR TITLE
Update gradle android plugin version from (1.0,) to 1.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
     compile gradleApi()
     compile localGroovy()
-    compile 'com.android.tools.build:gradle:(1.0,)'
+    compile 'com.android.tools.build:gradle:1.5.0'
     compile 'org.apache.httpcomponents:httpclient:4.3.6'
     compile 'org.apache.httpcomponents:httpmime:4.3.6'
 }


### PR DESCRIPTION
Holla, the plugin version 2.0.1 works well, but!
Actually, you specified the range in `compile 'com.android.tools.build:gradle:'` to `(1.0,)`, which basically means: use an Android plugin from 1.0 to whatever is available.

It means it will use the latest version, and the latest version is currently, in repositories, 2.1.0 something.
Problem is, this is not a stable version yet, and adds a lot of lint warnings our app is not prepared yet.

Which means that, with this version of bugsnag, the lint task use this 2.1.0 version and we get a bunch of warnings, and well... We will address these lint warnings when we start using android plugin version 2.0.0, but not yet.

I think it should be safer to use a fixed version. I propose 1.5.0, but I'm pretty sure it builds as well with version 1.0.0, like it was before.

If you can do that and publish a new aar on mavenCentral I would be so happy ^_^

Thanks in advance.