### PR TITLE
Fix enableBugsnag to work with multiple configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,19 @@ bugsnag {
 ```
 
 ## Disabling Bugsnag
-To completely disable the Bugsnag plugin, use the following configuration:
+To completely disable the Bugsnag plugin, use the extension property `enableBugsnag`, for example:
 
 ```groovy
-bugsnag {
-    enableBugsnag false
+android {
+    buildTypes {
+        debug {
+            ext.enableBugsnag = false
+        }
+    }
 }
 ```
+
+You can also declare this inside a product flavor. Conflicting values (between multiple flavors or a flavor and a build-type) are ignored and the plugin will be disabled if `false` was set anywhere.
 
 You may want to do this to speed up build types or flavors where you don't require Bugsnag's functionality. Bugsnag's generation of a UUID for each build into your manifest (see [Build UUIDs](#build-uuids)) causes the resources task to be run for each build, introducing a small delay if your build's changes don't involve resources.
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
@@ -8,5 +8,4 @@ class BugsnagPluginExtension {
     def String apiKey = null
     def boolean autoUpload = true;
     def boolean autoProguardConfig = true;
-    def boolean enableBugsnag = true;
 }


### PR DESCRIPTION
#21 is functional, but doesn't work for cases like:
```
productFlavors {
    dev {
        project.bugsnag { enableBugsnag false }
    }
    prod {
        project.bugsnag { enableBugsnag true }
    }
}
```
because all of the `project.bugsnag` statements are evaluated at configuration time--only the most recent one will "stick". I'd previously mistaken this as a closure that was only evaluated at runtime--whoops.

It looks like the easiest solution for this is to make use of Groovy's [extra properties](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.ExtraPropertiesExtension.html); we can store the `enableBugsnag` value either on the `ProductFlavor` itself or on the `BuildType`:
```
productFlavors {
    prod {}
    dev { ext.enableBugsnag = false }
}
buildTypes {
    debug { ext.enableBugsnag = false }
    release {}
}
```
Then the values won't override each other and we can fetch them when we're applying the plugin to the variant. It looks like this is [what Fabric is doing for Crashlytics](https://docs.fabric.io/android/crashlytics/build-tools.html#disabling-crashlytics-for-debug-builds).

---

Testing:
```
buildTypes {
    debug { ext.enableBugsnag = false }
    release {}
}

➜  TestApplication gw assembleDebug | grep Bugsnag
➜  TestApplication gw assembleRelease | grep Bugsnag
:app:processBugsnagReleaseManifest
:app:processBugsnagReleaseProguard
:app:uploadBugsnagReleaseMapping
```
```
productFlavors {
    prod {}
    dev { ext.enableBugsnag = false }
}
buildTypes {
    debug {}
    release {}
}

➜  TestApplication gw assembleDevDebug | grep Bugsnag
➜  TestApplication gw assembleProdDebug | grep Bugsnag
:app:processBugsnagProdDebugManifest
:app:processBugsnagProdDebugProguard
:app:uploadBugsnagProdDebugMapping
➜  TestApplication gw assembleDevRelease | grep Bugsnag
➜  TestApplication gw assembleProdRelease | grep Bugsnag
:app:processBugsnagProdReleaseManifest
:app:processBugsnagProdReleaseProguard
:app:uploadBugsnagProdReleaseMapping
```
```
productFlavors {
    prod {}
    dev { ext.enableBugsnag = false }
}
buildTypes {
    debug { ext.enableBugsnag = false }
    release {}
}

➜  TestApplication gw assembleDevDebug | grep Bugsnag
➜  TestApplication gw assembleDevDebug | grep Bugsnag
➜  TestApplication gw assembleProdDebug | grep Bugsnag
➜  TestApplication gw assembleDevRelease | grep Bugsnag
➜  TestApplication gw assembleProdRelease | grep Bugsnag
:app:processBugsnagProdReleaseManifest
:app:processBugsnagProdReleaseProguard
:app:uploadBugsnagProdReleaseMapping
```
