### PR TITLE
Support gradle-experimental plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,8 @@ compileGroovy {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'com.android.tools.build:gradle:1.5.0'
+    compile 'com.android.tools.build:gradle:2.2.0'
+    compile 'com.android.tools.build:gradle-experimental:0.8.0'
     compile 'org.apache.httpcomponents:httpclient:4.2.1'
     compile 'org.apache.httpcomponents:httpmime:4.2.1'
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -1,11 +1,10 @@
 package com.bugsnag.android.gradle
 
+import com.android.build.gradle.api.ApplicationVariant
+import com.android.build.gradle.api.BaseVariant
+import com.android.build.gradle.api.LibraryVariant
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-
-import com.android.build.gradle.AppPlugin
-import com.android.build.gradle.api.ApplicationVariant
-
 /**
  * Gradle plugin to automatically upload ProGuard mapping files to Bugsnag.
  *
@@ -29,93 +28,113 @@ class BugsnagPlugin implements Plugin<Project> {
         project.extensions.create("bugsnag", BugsnagPluginExtension)
 
         project.afterEvaluate {
-            // Make sure the android plugin has been applied first
-            if(!project.plugins.hasPlugin(AppPlugin)) {
-                throw new IllegalStateException('Must apply \'com.android.application\' first!')
-            }
 
-            // Create tasks for each Build Variant
-            // https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/user-guide#TOC-Build-Variants
-            project.android.applicationVariants.all { ApplicationVariant variant ->
-                def hasDisabledBugsnag = {
-                    it.ext.properties.containsKey("enableBugsnag") && !it.ext.enableBugsnag
+            if (project.plugins.hasPlugin("com.android.application")) {
+                // Create tasks for each Build Variant
+                // https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/user-guide#TOC-Build-Variants
+                project.android.applicationVariants.all { ApplicationVariant variant ->
+                    configureVariant(project, variant, true)
                 }
 
-                // Ignore any conflicting properties, bail if anything has a disable flag.
-                if ((variant.productFlavors + variant.buildType).any(hasDisabledBugsnag)) {
-                    return
+            } else if (project.plugins.hasPlugin("com.android.model.application")) {
+                project.android.libraryVariants.all { LibraryVariant variant ->
+                    configureVariant(project, variant, false)
                 }
 
-                // The Android build system supports creating multiple APKs
-                // per Build Variant (Variant Outputs):
-                // https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/user-guide/apk-splits
-                //
-                // Variant Outputs share most tasks so we only need to attach
-                // Bugsnag tasks to the first output.
-                def variantOutput = variant.outputs.first()
-                def variantName = variant.name.capitalize()
-
-                // The location of the "intermediate" AndroidManifest.xml
-                def manifestPath = variantOutput.processManifest.manifestOutputFile
-
-                // Create a Bugsnag task to add a "Bugsnag recommended proguard settings" file
-                BugsnagProguardConfigTask proguardConfigTask = project.tasks.create("processBugsnag${variantName}Proguard", BugsnagProguardConfigTask)
-                proguardConfigTask.group = GROUP_NAME
-                proguardConfigTask.applicationVariant = variant
-
-                // Create a Bugsnag task to add a build UUID to AndroidManifest.xml
-                // This task must be called after "process${variantName}Manifest", since it
-                // requires that an AndroidManifest.xml exists in `build/intermediates`.
-                BugsnagManifestTask manifestTask = project.tasks.create("processBugsnag${variantName}Manifest", BugsnagManifestTask)
-                manifestTask.group = GROUP_NAME
-                manifestTask.manifestPath = manifestPath
-                manifestTask.mustRunAfter variantOutput.processManifest
-                manifestTask.onlyIf { it.shouldRun() }
-
-                // Create a Bugsnag task to upload proguard mapping file
-                BugsnagUploadTask uploadTask = project.tasks.create("uploadBugsnag${variantName}Mapping", BugsnagUploadTask)
-                uploadTask.group = GROUP_NAME
-                uploadTask.manifestPath = manifestPath
-                uploadTask.applicationId = variant.applicationId
-                uploadTask.mappingFile = variant.getMappingFile()
-                uploadTask.mustRunAfter variantOutput.packageApplication
-
-                // Automatically add the "edit proguard settings" task to the
-                // build process.
-                //
-                // This task must be called before ProGuard is run, but since
-                // the name of the ProGuard task changed between 1.0 and 1.5
-                // of the Android build tools, we'll hook into the "package"
-                // task as a dependency, since this is always run before
-                // ProGuard.
-                //
-                // For reference, in Android Build Tools 1.0, the ProGuard
-                // task was named `proguardRelease`, and in 1.5+ the ProGuard
-                // task is named `transformClassesAndResourcesWithProguardForRelease`
-                // as it is now part of the "transforms" process.
-                if(project.bugsnag.autoProguardConfig) {
-                    variantOutput.packageApplication.dependsOn proguardConfigTask
-                }
-
-                // Automatically add the "add build uuid to manifest" task to
-                // the build process.
-                //
-                // This task must be called after processManifest (see above),
-                // but before any source code is compiled, and before
-                // Bugsnag's upload task is run, since both require a UUID to
-                // be present in AndroidManifest.xml.
-                variantOutput.processResources.dependsOn manifestTask
-
-                // Automatically add the "upload proguard mappings" task to
-                // the build process.
-                //
-                // This task must be called after `packageApplication` (see
-                // above), but we also want this to run automatically as part
-                // of a typical build, so we hook into the `assemble` task.
-                if(project.bugsnag.autoUpload) {
-                    variant.getAssemble().dependsOn uploadTask
-                }
+            } else {
+                // Make sure the android plugin has been applied first
+                throw new IllegalStateException('Must apply \'com.android.application\', or \'com.android.model.application\' first! ')
             }
         }
     }
+
+    private static void configureVariant(Project project, BaseVariant variant, boolean isApplication) {
+        def hasDisabledBugsnag = {
+            it.ext.properties.containsKey("enableBugsnag") && !it.ext.enableBugsnag
+        }
+
+        // Ignore any conflicting properties, bail if anything has a disable flag.
+        if ((variant.productFlavors + variant.buildType).any(hasDisabledBugsnag)) {
+            return
+        }
+
+        // The Android build system supports creating multiple APKs
+        // per Build Variant (Variant Outputs):
+        // https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/user-guide/apk-splits
+        //
+        // Variant Outputs share most tasks so we only need to attach
+        // Bugsnag tasks to the first output.
+        def variantOutput = variant.outputs.first()
+        def variantName = variant.name.capitalize()
+
+        // The location of the "intermediate" AndroidManifest.xml
+        def manifestPath = variantOutput.processManifest.manifestOutputFile
+
+        // Create a Bugsnag task to add a "Bugsnag recommended proguard settings" file
+        BugsnagProguardConfigTask proguardConfigTask = project.tasks.create("processBugsnag${variantName}Proguard", BugsnagProguardConfigTask)
+        proguardConfigTask.group = GROUP_NAME
+        proguardConfigTask.applicationVariant = variant
+
+        // Create a Bugsnag task to add a build UUID to AndroidManifest.xml
+        // This task must be called after "process${variantName}Manifest", since it
+        // requires that an AndroidManifest.xml exists in `build/intermediates`.
+        BugsnagManifestTask manifestTask = project.tasks.create("processBugsnag${variantName}Manifest", BugsnagManifestTask)
+        manifestTask.group = GROUP_NAME
+        manifestTask.manifestPath = manifestPath
+        manifestTask.mustRunAfter variantOutput.processManifest
+        manifestTask.onlyIf { it.shouldRun() }
+
+        // Create a Bugsnag task to upload proguard mapping file
+        BugsnagUploadTask uploadTask = project.tasks.create("uploadBugsnag${variantName}Mapping", BugsnagUploadTask)
+        uploadTask.group = GROUP_NAME
+        uploadTask.manifestPath = manifestPath
+        uploadTask.applicationId = variant.applicationId
+        uploadTask.mappingFile = variant.getMappingFile()
+        if (isApplication) {
+            uploadTask.mustRunAfter variantOutput.packageApplication
+        } else {
+            uploadTask.mustRunAfter variantOutput.packageLibrary
+        }
+
+        // Automatically add the "edit proguard settings" task to the
+        // build process.
+        //
+        // This task must be called before ProGuard is run, but since
+        // the name of the ProGuard task changed between 1.0 and 1.5
+        // of the Android build tools, we'll hook into the "package"
+        // task as a dependency, since this is always run before
+        // ProGuard.
+        //
+        // For reference, in Android Build Tools 1.0, the ProGuard
+        // task was named `proguardRelease`, and in 1.5+ the ProGuard
+        // task is named `transformClassesAndResourcesWithProguardForRelease`
+        // as it is now part of the "transforms" process.
+        if(project.bugsnag.autoProguardConfig) {
+            if (isApplication) {
+                variantOutput.packageApplication.dependsOn proguardConfigTask
+            } else {
+                variantOutput.packageLibrary.dependsOn proguardConfigTask
+            }
+        }
+
+        // Automatically add the "add build uuid to manifest" task to
+        // the build process.
+        //
+        // This task must be called after processManifest (see above),
+        // but before any source code is compiled, and before
+        // Bugsnag's upload task is run, since both require a UUID to
+        // be present in AndroidManifest.xml.
+        variantOutput.processResources.dependsOn manifestTask
+
+        // Automatically add the "upload proguard mappings" task to
+        // the build process.
+        //
+        // This task must be called after `packageApplication` (see
+        // above), but we also want this to run automatically as part
+        // of a typical build, so we hook into the `assemble` task.
+        if(project.bugsnag.autoUpload) {
+            variant.getAssemble().dependsOn uploadTask
+        }
+    }
+
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -2,9 +2,18 @@ package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.BaseVariant
-import com.android.build.gradle.api.LibraryVariant
+import com.android.build.gradle.api.BaseVariantOutput
+import com.android.build.gradle.internal.scope.VariantOutputScope
+import com.android.build.gradle.internal.scope.VariantScope
+import com.android.build.gradle.internal.variant.ApkVariantOutputData
+import com.android.build.gradle.tasks.ManifestProcessorTask
+import com.android.build.gradle.tasks.MergeManifests
+import com.android.build.gradle.tasks.PackageApplication
+import com.android.build.gradle.tasks.ProcessAndroidResources
+import com.android.builder.model.BuildType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 /**
  * Gradle plugin to automatically upload ProGuard mapping files to Bugsnag.
  *
@@ -33,12 +42,19 @@ class BugsnagPlugin implements Plugin<Project> {
                 // Create tasks for each Build Variant
                 // https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/user-guide#TOC-Build-Variants
                 project.android.applicationVariants.all { ApplicationVariant variant ->
-                    configureVariant(project, variant, true)
+                    configureVariant(project, variant)
                 }
 
             } else if (project.plugins.hasPlugin("com.android.model.application")) {
-                project.android.libraryVariants.all { LibraryVariant variant ->
-                    configureVariant(project, variant, false)
+
+                project.tasks.whenTaskAdded {t ->
+
+                    if (t.name.startsWith("process") && t.name.endsWith("Manifest")) {
+                        if (t instanceof MergeManifests) {
+                            MergeManifests task = (MergeManifests) t;
+                            configureVariant(project, task)
+                        }
+                    }
                 }
 
             } else {
@@ -48,7 +64,76 @@ class BugsnagPlugin implements Plugin<Project> {
         }
     }
 
-    private static void configureVariant(Project project, BaseVariant variant, boolean isApplication) {
+    private static void configureVariant(Project project, MergeManifests task) {
+
+        project.logger.error("BugsnagGroovy: Task Added " + task.name + " " + task.getClass().toString())
+
+        String manifestPath = task.manifestOutputFile.absolutePath;
+        project.logger.error("BugsnagGroovy: manifest file " + manifestPath)
+
+        ApkVariantOutputData data = task.variantOutputData
+
+        VariantOutputScope scope = data.scope
+
+        VariantScope vscope = scope.variantScope;
+        project.logger.error("BugsnagGroovy: mapping file " + vscope.mappingFile)
+        project.logger.error("BugsnagGroovy: application Id " + vscope.variantData.applicationId)
+
+        String applicationId = vscope.variantData.applicationId
+        File mappingFile = vscope.mappingFile
+        String variantName = task.variantName.capitalize()
+
+//        Map props = task.getProperties()
+//        for (Object key : props.keySet() ) {
+//            project.logger.error("BugsnagGroovy:  TaskProperty " + key.toString() + " " + props.get(key).toString())
+//        }
+//        props = data.getProperties()
+//        for (Object key : props.keySet() ) {
+//            project.logger.error("BugsnagGroovy:  DataProperty " + key.toString() + " " + props.get(key).toString())
+//        }
+//        props = scope.getProperties()
+//        for (Object key : props.keySet() ) {
+//            project.logger.error("BugsnagGroovy:  ScopeProperty " + key.toString() + " " + props.get(key).toString())
+//        }
+//        props = vscope.getProperties()
+//        for (Object key : props.keySet() ) {
+//            project.logger.error("BugsnagGroovy:  VScopeProperty " + key.toString() + " " + props.get(key).toString())
+//        }
+//        Map props = project.properties
+//        for (Object key : props.keySet() ) {
+//            project.logger.error("BugsnagGroovy:  ProjectProperty " + key.toString() + " " + props.get(key).toString())
+//        }
+//
+//
+//        props = project.ext.properties
+//        for (Object key : props.keySet() ) {
+//            project.logger.error("BugsnagGroovy:  ProjectExtProperty " + key.toString() + " " + props.get(key).toString())
+//        }
+//
+//        DefaultTask debug = project.androidDebug
+//        props = debug.properties
+//        for (Object key : props.keySet() ) {
+//            project.logger.error("BugsnagGroovy:  ProjectAndroidDebugProperty " + key.toString() + " " + props.get(key).toString())
+//        }
+//
+//        props = debug.inputs.properties
+//        for (Object key : props.keySet() ) {
+//            project.logger.error("BugsnagGroovy:  ProjectAndroidDebugInput " + key.toString() + " " + props.get(key).toString())
+//        }
+
+        Task assembleTask = project.assemble //project["processDebugManifest"]
+        Task packageTask = project.processDebugResources
+
+        //configureProguardConfigTask(project, variantName, bt, vscope.packageApplicationTask)
+
+        configureManifestTask(project, variantName, manifestPath, task, data.processResourcesTask)
+
+        configureUploadTask(project, variantName, manifestPath, applicationId, mappingFile, packageTask, assembleTask)
+    }
+
+    private static void configureVariant(Project project, BaseVariant variant) {
+        project.logger.error("BugsnagGroovy: Configuring variant " + variant.name +  " for project " + project.name)
+
         def hasDisabledBugsnag = {
             it.ext.properties.containsKey("enableBugsnag") && !it.ext.enableBugsnag
         }
@@ -64,37 +149,29 @@ class BugsnagPlugin implements Plugin<Project> {
         //
         // Variant Outputs share most tasks so we only need to attach
         // Bugsnag tasks to the first output.
-        def variantOutput = variant.outputs.first()
-        def variantName = variant.name.capitalize()
+        BaseVariantOutput variantOutput = variant.outputs.first()
+        String variantName = variant.name.capitalize()
 
         // The location of the "intermediate" AndroidManifest.xml
-        def manifestPath = variantOutput.processManifest.manifestOutputFile
+        String manifestPath = variantOutput.processManifest.manifestOutputFile.absolutePath
 
+        PackageApplication packageTask = variantOutput.packageApplication
+
+        configureProguardConfigTask(project, variantName, variant.getBuildType(), packageTask)
+
+        configureManifestTask(project, variantName, manifestPath, variantOutput.processManifest, variantOutput.processResources)
+
+        configureUploadTask(project, variantName, manifestPath, variant.applicationId, variant.mappingFile, packageTask, variant.getAssemble())
+    }
+
+    private static void configureProguardConfigTask(Project project,
+                                                    String variantName,
+                                                    BuildType buildType,
+                                                    Task packageTask) {
         // Create a Bugsnag task to add a "Bugsnag recommended proguard settings" file
         BugsnagProguardConfigTask proguardConfigTask = project.tasks.create("processBugsnag${variantName}Proguard", BugsnagProguardConfigTask)
         proguardConfigTask.group = GROUP_NAME
-        proguardConfigTask.applicationVariant = variant
-
-        // Create a Bugsnag task to add a build UUID to AndroidManifest.xml
-        // This task must be called after "process${variantName}Manifest", since it
-        // requires that an AndroidManifest.xml exists in `build/intermediates`.
-        BugsnagManifestTask manifestTask = project.tasks.create("processBugsnag${variantName}Manifest", BugsnagManifestTask)
-        manifestTask.group = GROUP_NAME
-        manifestTask.manifestPath = manifestPath
-        manifestTask.mustRunAfter variantOutput.processManifest
-        manifestTask.onlyIf { it.shouldRun() }
-
-        // Create a Bugsnag task to upload proguard mapping file
-        BugsnagUploadTask uploadTask = project.tasks.create("uploadBugsnag${variantName}Mapping", BugsnagUploadTask)
-        uploadTask.group = GROUP_NAME
-        uploadTask.manifestPath = manifestPath
-        uploadTask.applicationId = variant.applicationId
-        uploadTask.mappingFile = variant.getMappingFile()
-        if (isApplication) {
-            uploadTask.mustRunAfter variantOutput.packageApplication
-        } else {
-            uploadTask.mustRunAfter variantOutput.packageLibrary
-        }
+        proguardConfigTask.buildType = buildType
 
         // Automatically add the "edit proguard settings" task to the
         // build process.
@@ -110,12 +187,24 @@ class BugsnagPlugin implements Plugin<Project> {
         // task is named `transformClassesAndResourcesWithProguardForRelease`
         // as it is now part of the "transforms" process.
         if(project.bugsnag.autoProguardConfig) {
-            if (isApplication) {
-                variantOutput.packageApplication.dependsOn proguardConfigTask
-            } else {
-                variantOutput.packageLibrary.dependsOn proguardConfigTask
-            }
+            packageTask.dependsOn proguardConfigTask
         }
+    }
+
+    private static void configureManifestTask(Project project,
+                                              String variantName,
+                                              String manifestPath,
+                                              ManifestProcessorTask manifestProcessor,
+                                              ProcessAndroidResources processResources) {
+        // Create a Bugsnag task to add a build UUID to AndroidManifest.xml
+        // This task must be called after "process${variantName}Manifest", since it
+        // requires that an AndroidManifest.xml exists in `build/intermediates`.
+        BugsnagManifestTask manifestTask = project.tasks.create("processBugsnag${variantName}Manifest", BugsnagManifestTask)
+        manifestTask.group = GROUP_NAME
+        manifestTask.manifestPath = manifestPath
+        manifestTask.mustRunAfter manifestProcessor
+        manifestTask.onlyIf { it.shouldRun() }
+
 
         // Automatically add the "add build uuid to manifest" task to
         // the build process.
@@ -124,7 +213,26 @@ class BugsnagPlugin implements Plugin<Project> {
         // but before any source code is compiled, and before
         // Bugsnag's upload task is run, since both require a UUID to
         // be present in AndroidManifest.xml.
-        variantOutput.processResources.dependsOn manifestTask
+        processResources.dependsOn manifestTask
+    }
+
+    private static void configureUploadTask(Project project,
+                                            String variantName,
+                                            String manifestPath,
+                                            String applicationId,
+                                            File mappingFile,
+                                            Task packageTask,
+                                            Task assembleTask) {
+
+        // Create a Bugsnag task to upload proguard mapping file
+        BugsnagUploadTask uploadTask = project.tasks.create("uploadBugsnag${variantName}Mapping", BugsnagUploadTask)
+        uploadTask.group = GROUP_NAME
+        uploadTask.manifestPath = manifestPath
+        uploadTask.applicationId = applicationId
+        uploadTask.mappingFile = mappingFile
+
+        uploadTask.mustRunAfter packageTask
+
 
         // Automatically add the "upload proguard mappings" task to
         // the build process.
@@ -133,8 +241,7 @@ class BugsnagPlugin implements Plugin<Project> {
         // above), but we also want this to run automatically as part
         // of a typical build, so we hook into the `assemble` task.
         if(project.bugsnag.autoUpload) {
-            variant.getAssemble().dependsOn uploadTask
+            assembleTask.dependsOn uploadTask
         }
     }
-
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -1,10 +1,8 @@
 package com.bugsnag.android.gradle
 
+import com.android.build.gradle.api.BaseVariant
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
-
-import com.android.build.gradle.api.ApplicationVariant
-
 /**
     Task to add an additional ProGuard configuration file (bugsnag.pro)
     which ensures that our required ProGuard settings are applied.
@@ -15,7 +13,7 @@ class BugsnagProguardConfigTask extends DefaultTask {
     static final String PROGUARD_CONFIG_PATH = "build/intermediates/bugsnag/bugsnag.pro"
     static final String PROGUARD_CONFIG_SETTINGS = "-keepattributes LineNumberTable,SourceFile"
 
-    ApplicationVariant applicationVariant
+    BaseVariant applicationVariant
 
     BugsnagProguardConfigTask() {
         super()

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -1,6 +1,6 @@
 package com.bugsnag.android.gradle
 
-import com.android.build.gradle.api.BaseVariant
+import com.android.builder.model.BuildType
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 /**
@@ -13,7 +13,7 @@ class BugsnagProguardConfigTask extends DefaultTask {
     static final String PROGUARD_CONFIG_PATH = "build/intermediates/bugsnag/bugsnag.pro"
     static final String PROGUARD_CONFIG_SETTINGS = "-keepattributes LineNumberTable,SourceFile"
 
-    BaseVariant applicationVariant
+    BuildType buildType
 
     BugsnagProguardConfigTask() {
         super()
@@ -35,6 +35,6 @@ class BugsnagProguardConfigTask extends DefaultTask {
         fr.close()
 
         // Add this proguard settings file to the list
-        applicationVariant.getBuildType().buildType.proguardFiles(file)
+        buildType.buildType.proguardFiles(file)
     }
 }


### PR DESCRIPTION
Changes to support the gradle-experimental (see http://tools.android.com/tech-docs/new-build-system/gradle-experimental) plugin that support building android NDK in Android Studio

The experimental build uses a different namespace and slightly different objects in the build.gradle file. It looks like this uses "libraryVariants" instead of "applicationVariants" in the groovy script (once updated to the latest version of the plugin).

This needs a bit of testing to check it will upload proguard files correctly when compiling with the experimental plugin
