### PR TITLE
Fixed an issue with the apply code snippet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ buildscript {
 You'll then need to "apply" the plugin by adding the following line to the top of your *Module Gradle Settings*, at `<project_dir>/<module_name>/build.gradle` (usually `<project_dir>/app/build.gradle`).
 
 ```groovy
-apply plugin: com.bugsnag.android.gradle.BugsnagPlugin
+apply plugin: 'com.bugsnag.android.gradle'
 ```
 
 


### PR DESCRIPTION
The original one was missing the quotes and once the quotes were added, it was resulting with:
`Error:Plugin with id 'com.bugsnag.android.gradle.BugsnagPlugin' not found.`