### PR TITLE
Remove trailing quote from pro guard settings

### DIFF
--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -14,7 +14,7 @@ import com.android.build.gradle.api.ApplicationVariant
 class BugsnagProguardConfigTask extends DefaultTask {
     static final String PROGUARD_CONFIG_PATH = "build/intermediates/bugsnag/bugsnag.pro"
     static final String PROGUARD_CONFIG_SETTINGS = """\
-    -keepattributes LineNumberTable,SourceFile"
+    -keepattributes LineNumberTable,SourceFile
     -keep class com.bugsnag.android.NativeInterface { *; }
     -keep class com.bugsnag.android.Breadcrumbs { *; }
     -keep class com.bugsnag.android.Breadcrumbs\$Breadcrumb { *; }


### PR DESCRIPTION
When building an Android project using the bugsnag android gradle plugin v2.4.0 the following error is encountered:

```
Error:Execution failed for task ':app:transformClassesAndResourcesWithProguardForRelease'.
> java.io.IOException: proguard.ParseException: Expecting java type before 'SourceFile"' in line 1 of file '/bugsnag-android-ndk/example/app/build/intermediates/bugsnag/bugsnag.pro'
```

It looks like this is caused by a trailing quote accidentally added to the end of one of the new ProGuard settings lines
