### PR TITLE
[ENG-620] Add jack compiler support

### DIFF
--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -80,30 +80,14 @@ class BugsnagPlugin implements Plugin<Project> {
                 manifestTask.mustRunAfter variantOutput.processManifest
                 manifestTask.onlyIf { it.shouldRun() }
 
-
-                BugsnagUploadAbstractTask uploadTask
-                if (isJackEnabled(project, variant)) {
-                    // Create a Bugsnag task to upload jack mapping file
-                    BugsnagUploadJackTask uploadJackTask = project.tasks.create("uploadBugsnag${variantName}Mapping", BugsnagUploadJackTask)
-                    uploadJackTask.group = GROUP_NAME
-                    uploadJackTask.manifestPath = manifestPath
-                    uploadJackTask.applicationId = variant.applicationId
-                    uploadJackTask.mappingFile = variant.getMappingFile()
-                    uploadJackTask.mustRunAfter variantOutput.packageApplication
-
-                    uploadTask = uploadJackTask
-                } else {
-                    // Create a Bugsnag task to upload proguard mapping file
-                    BugsnagUploadProguardTask uploadProguardTask = project.tasks.create("uploadBugsnag${variantName}Mapping", BugsnagUploadProguardTask)
-                    uploadProguardTask.group = GROUP_NAME
-                    uploadProguardTask.manifestPath = manifestPath
-                    uploadProguardTask.applicationId = variant.applicationId
-                    uploadProguardTask.mappingFile = variant.getMappingFile()
-                    uploadProguardTask.mustRunAfter variantOutput.packageApplication
-
-                    uploadTask = uploadProguardTask
-                }
-
+                // Create a Bugsnag task to upload proguard mapping file
+                def uploadTaskClass = isJackEnabled(project, variant) ? BugsnagUploadJackTask : BugsnagUploadProguardTask
+                def uploadTask = project.tasks.create("uploadBugsnag${variantName}Mapping", uploadTaskClass)
+                uploadTask.group = GROUP_NAME
+                uploadTask.manifestPath = manifestPath
+                uploadTask.applicationId = variant.applicationId
+                uploadTask.mappingFile = variant.getMappingFile()
+                uploadTask.mustRunAfter variantOutput.packageApplication
 
                 BugsnagUploadNdkTask uploadNdkTask
                 if (project.bugsnag.ndk) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -178,15 +178,13 @@ class BugsnagPlugin implements Plugin<Project> {
         TreeSet buildTypes = project.android.buildTypes.store
         BuildType b = findNode(buildTypes, variant.baseName)
 
-        if (b != null
-            && b.jackOptions != null
+        if (b?.hasProperty('jackOptions')
             && b.jackOptions.enabled instanceof Boolean) {
 
             return b.jackOptions.enabled
 
         // Now check the default config to see if any Jack settings are defined
-        } else if (project.android.defaultConfig != null
-            && project.android.defaultConfig.jackOptions != null
+        } else if (project.android.defaultConfig?.hasProperty('jackOptions')
             && project.android.defaultConfig.jackOptions.enabled instanceof Boolean) {
 
             return project.android.defaultConfig.jackOptions.enabled;

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadJackTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadJackTask.groovy
@@ -1,0 +1,46 @@
+package com.bugsnag.android.gradle
+
+import org.apache.http.entity.mime.MultipartEntity
+import org.apache.http.entity.mime.content.FileBody
+import org.gradle.api.tasks.TaskAction
+/**
+    Task to upload Jack mapping files to Bugsnag.
+
+    Reads meta-data tags from the project's AndroidManifest.xml to extract a
+    build UUID (injected by BugsnagManifestTask) and a Bugsnag API Key:
+
+    https://developer.android.com/guide/topics/manifest/manifest-intro.html
+    https://developer.android.com/guide/topics/manifest/meta-data-element.html
+
+    This task must be called after ProGuard mapping files are generated, so
+    it is usually safe to have this be the absolute last task executed during
+    a build.
+*/
+class BugsnagUploadJackTask extends BugsnagUploadAbstractTask {
+    File mappingFile
+
+    BugsnagUploadJackTask() {
+        super()
+        this.description = "Uploads the jack mapping file to Bugsnag"
+    }
+
+    @TaskAction
+    def upload() {
+        // If we haven't enabled jack for this variant, or the proguard
+        // configuration includes -dontobfuscate, the mapping file
+        // will not exist (but we also won't need it).
+        if (!mappingFile || !mappingFile.exists()) {
+            return
+        }
+
+        // Read the API key and Build ID etc..
+        super.readManifestFile();
+
+        // Construct a basic request
+        MultipartEntity mpEntity = new MultipartEntity()
+        mpEntity.addPart("jack", new FileBody(mappingFile))
+
+        // Send the request
+        super.uploadMultipartEntity(mpEntity)
+    }
+}


### PR DESCRIPTION
When using the Jack compiler the output mapping file is slightly different and should be uploaded to a different endpoint.

This change detects whether the project is being build using Jack and uses a different task to perform the upload to a different endpoint