### PR TITLE
Extend upload timeout

### DIFF
--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
@@ -26,7 +26,7 @@ import org.gradle.api.DefaultTask
 */
 abstract class BugsnagUploadAbstractTask extends DefaultTask {
     static final int MAX_RETRY_COUNT = 5
-    static final int TIMEOUT_MILLIS = 10000 // 10 seconds
+    static final int TIMEOUT_MILLIS = 60000 // 60 seconds
     String manifestPath
     String applicationId
 


### PR DESCRIPTION
It can sometimes take significantly longer than 10 seconds for large mappings files to be uploaded and processed.