### PR TITLE
Improve NDK object file generation performance

### DIFF
--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -179,7 +179,7 @@ class BugsnagUploadNdkTask extends BugsnagUploadAbstractTask {
             OutputStreamWriter osw = new OutputStreamWriter(is)
             Writer writer = new BufferedWriter(osw)
 
-            Pattern addressPattern = Pattern.compile("\\s+([0-9a-f]+):.*", Pattern.CASE_INSENSITIVE);
+            Pattern addressPattern = Pattern.compile("^\\s+([0-9a-f]+):", Pattern.CASE_INSENSITIVE);
             boolean justSeenAddress = false;
             String previousAddress = null;
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -185,10 +185,11 @@ class BugsnagUploadNdkTask extends BugsnagUploadAbstractTask {
 
             // Loop to remove redundant address lines (just keep the first and last addresses of each block)
             String line = outReader.readLine()
+            Matcher addressMatcher = null;
             while (line != null) {
 
                 // Check to see if the current line is an address
-                Matcher addressMatcher = addressPattern.matcher(line);
+                addressMatcher = addressPattern.matcher(line);
                 if (addressMatcher.matches()) {
 
                     // Only output the line if this is the start of a block of addresses

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -190,7 +190,7 @@ class BugsnagUploadNdkTask extends BugsnagUploadAbstractTask {
 
                 // Check to see if the current line is an address
                 addressMatcher = addressPattern.matcher(line);
-                if (addressMatcher.matches()) {
+                if (addressMatcher.find()) {
 
                     // Only output the line if this is the start of a block of addresses
                     if (!justSeenAddress) {


### PR DESCRIPTION
The performance of generating an object mapping file degrades for larger binary sizes, as scanning the binary can take a long time. This is a few small tweaks within the tight loop where the scan happens.