### PR TITLE
Readme adblocker note

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,3 +208,8 @@ this plugin, see our [contributing guide](CONTRIBUTING.md).
 
 This plugin is free software released under the MIT License. See
 [LICENSE.txt](LICENSE.txt) for details.
+
+
+# Can't comment on Issues?
+Some users have been unable to comment on Github issues when an [adblocker extension is enabled](https://docs.bugsnag.com/platforms/browsers/faq/#is-bugsnag-blocked-by-ad-blockers).
+We recommend temporarily disabling the extension, or if that fails, contacting support@bugsnag.com.

--- a/README.md
+++ b/README.md
@@ -208,8 +208,3 @@ this plugin, see our [contributing guide](CONTRIBUTING.md).
 
 This plugin is free software released under the MIT License. See
 [LICENSE.txt](LICENSE.txt) for details.
-
-
-# Can't comment on Issues?
-Some users have been unable to comment on Github issues when an [adblocker extension is enabled](https://docs.bugsnag.com/platforms/browsers/faq/#is-bugsnag-blocked-by-ad-blockers).
-We recommend temporarily disabling the extension, or if that fails, contacting support@bugsnag.com.

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,0 +1,18 @@
+### Expected behavior
+*[Insert details on expected behaviour]*
+
+### Observed behavior
+*[Insert details on observed behaviour]*
+
+### Steps to reproduce
+*[Insert reproduction steps (if known)]*
+
+### Version
+*[Insert version information]*
+
+### Additional information
+*[Insert any additional information]*
+
+#### Can't comment on Issues?
+Some users have been unable to comment on Github issues when an [adblocker extension is enabled](https://docs.bugsnag.com/platforms/browsers/faq/#is-bugsnag-blocked-by-ad-blockers).
+We recommend temporarily disabling the extension, or if that fails, contacting support@bugsnag.com.


### PR DESCRIPTION
Adds a note to the Readme about adblockers preventing comments. Also adds an issue template asking for expected/observed behaviour, steps to reproduce, and any additional info.

If the content is ok, I can create similar PRs for the other public repos.