### PR TITLE
Address lint warnings, add missing gradle properties, autoformat

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,2 @@
 group = com.bugsnag
 version = 2.4.2
-bintray_user=your_user
-bintray_api_key=your_api_key

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 group = com.bugsnag
 version = 2.4.2
+bintray_user=your_user
+bintray_api_key=your_api_key

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -3,16 +3,17 @@ package com.bugsnag.android.gradle
 import groovy.xml.Namespace
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
+
 /**
-    Task to add a unique build UUID to AndroidManifest.xml during the build
-    process. This is used by Bugsnag to identify which proguard mapping file
-    should be used to deobfuscate each crash report.
+ Task to add a unique build UUID to AndroidManifest.xml during the build
+ process. This is used by Bugsnag to identify which proguard mapping file
+ should be used to deobfuscate each crash report.
 
-    https://docs.gradle.org/current/userguide/custom_tasks.html
+ https://docs.gradle.org/current/userguide/custom_tasks.html
 
-    This task must be called after "process${variantName}Manifest", since it
-    requires that an AndroidManifest.xml exists in `build/intermediates`.
-*/
+ This task must be called after "process${variantName}Manifest", since it
+ requires that an AndroidManifest.xml exists in `build/intermediates`.
+ */
 class BugsnagManifestTask extends DefaultTask {
     String manifestPath
 
@@ -32,9 +33,9 @@ class BugsnagManifestTask extends DefaultTask {
             def metaDataTags = application['meta-data']
 
             // remove any old BUILD_UUID_TAG elements
-            def buildUuidTags = metaDataTags.findAll{
-                it.attributes()[ns.name].equals(BugsnagPlugin.BUILD_UUID_TAG)
-            }.each{
+            metaDataTags.findAll {
+                (it.attributes()[ns.name] == BugsnagPlugin.BUILD_UUID_TAG)
+            }.each {
                 it.parent().remove(it)
             }
 
@@ -49,8 +50,7 @@ class BugsnagManifestTask extends DefaultTask {
             def printer = new XmlNodePrinter(new PrintWriter(writer))
             printer.preserveWhitespace = true
             printer.print(xml)
-        }
-        else {
+        } else {
             project.logger.warn("Bugsnag detected invalid manifest with no application element so did not write Build UUID")
         }
     }
@@ -64,7 +64,7 @@ class BugsnagManifestTask extends DefaultTask {
         def app = new XmlParser().parse(manifestPath).application[0]
         if (app) {
             def tagCount = app['meta-data'].findAll {
-                it.attributes()[ns.name].equals(BugsnagPlugin.BUILD_UUID_TAG)
+                (it.attributes()[ns.name] == BugsnagPlugin.BUILD_UUID_TAG)
             }.size()
             tagCount == 0 || !isInstantRun()
         } else {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -6,6 +6,7 @@ import com.android.build.gradle.internal.core.Toolchain
 import com.android.build.gradle.internal.dsl.BuildType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+
 /**
  * Gradle plugin to automatically upload ProGuard mapping files to Bugsnag.
  *
@@ -119,7 +120,7 @@ class BugsnagPlugin implements Plugin<Project> {
                 // task was named `proguardRelease`, and in 1.5+ the ProGuard
                 // task is named `transformClassesAndResourcesWithProguardForRelease`
                 // as it is now part of the "transforms" process.
-                if(project.bugsnag.autoProguardConfig) {
+                if (project.bugsnag.autoProguardConfig) {
                     variantOutput.packageApplication.dependsOn proguardConfigTask
                 }
 
@@ -138,7 +139,7 @@ class BugsnagPlugin implements Plugin<Project> {
                 // This task must be called after `packageApplication` (see
                 // above), but we also want this to run automatically as part
                 // of a typical build, so we hook into the `assemble` task.
-                if(project.bugsnag.autoUpload) {
+                if (project.bugsnag.autoUpload) {
                     variant.getAssemble().dependsOn uploadTask
 
                     if (project.bugsnag.ndk) {
@@ -167,7 +168,7 @@ class BugsnagPlugin implements Plugin<Project> {
 
             return b.jackOptions.enabled
 
-        // Now check the default config to see if any Jack settings are defined
+            // Now check the default config to see if any Jack settings are defined
         } else if (project.android.defaultConfig?.hasProperty('jackOptions')
             && project.android.defaultConfig.jackOptions.enabled instanceof Boolean) {
 
@@ -207,7 +208,7 @@ class BugsnagPlugin implements Plugin<Project> {
                 && project.android.defaultConfig.externalNativeBuildOptions.cmake.arguments != null) {
 
                 ArrayList<String> args = project.android.defaultConfig.externalNativeBuildOptions.cmake.arguments
-                for (String arg : args ) {
+                for (String arg : args) {
                     toolchain = getToolchain(args)
                 }
             }
@@ -227,7 +228,7 @@ class BugsnagPlugin implements Plugin<Project> {
      * @return the value of the "ANDROID_TOOLCHAIN" argument, or null if not found
      */
     private static String getToolchain(ArrayList<String> args) {
-        for (String arg : args ) {
+        for (String arg : args) {
             if (arg.startsWith("-DANDROID_TOOLCHAIN")) {
                 return arg.substring(arg.indexOf("=") + 1).trim()
             }
@@ -245,10 +246,11 @@ class BugsnagPlugin implements Plugin<Project> {
     private static BuildType findNode(TreeSet<BuildType> set, String name) {
 
         Iterator<BuildType> iterator = set.iterator();
-        while(iterator.hasNext()) {
+        while (iterator.hasNext()) {
             BuildType node = iterator.next();
-            if(node.getName().equals(name))
+            if (node.getName() == name) {
                 return node;
+            }
         }
 
         return null;

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -6,11 +6,11 @@ import org.gradle.api.tasks.TaskAction
 import com.android.build.gradle.api.ApplicationVariant
 
 /**
-    Task to add an additional ProGuard configuration file (bugsnag.pro)
-    which ensures that our required ProGuard settings are applied.
+ Task to add an additional ProGuard configuration file (bugsnag.pro)
+ which ensures that our required ProGuard settings are applied.
 
-    This task must be called before ProGuard is run.
-*/
+ This task must be called before ProGuard is run.
+ */
 class BugsnagProguardConfigTask extends DefaultTask {
     static final String PROGUARD_CONFIG_PATH = "build/intermediates/bugsnag/bugsnag.pro"
     static final String PROGUARD_CONFIG_SETTINGS = """\

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
@@ -11,19 +11,20 @@ import org.apache.http.params.HttpConnectionParams
 import org.apache.http.params.HttpParams
 import org.apache.http.util.EntityUtils
 import org.gradle.api.DefaultTask
+
 /**
-    Task to upload ProGuard mapping files to Bugsnag.
+ Task to upload ProGuard mapping files to Bugsnag.
 
-    Reads meta-data tags from the project's AndroidManifest.xml to extract a
-    build UUID (injected by BugsnagManifestTask) and a Bugsnag API Key:
+ Reads meta-data tags from the project's AndroidManifest.xml to extract a
+ build UUID (injected by BugsnagManifestTask) and a Bugsnag API Key:
 
-    https://developer.android.com/guide/topics/manifest/manifest-intro.html
-    https://developer.android.com/guide/topics/manifest/meta-data-element.html
+ https://developer.android.com/guide/topics/manifest/manifest-intro.html
+ https://developer.android.com/guide/topics/manifest/meta-data-element.html
 
-    This task must be called after ProGuard mapping files are generated, so
-    it is usually safe to have this be the absolute last task executed during
-    a build.
-*/
+ This task must be called after ProGuard mapping files are generated, so
+ it is usually safe to have this be the absolute last task executed during
+ a build.
+ */
 abstract class BugsnagUploadAbstractTask extends DefaultTask {
     static final int MAX_RETRY_COUNT = 5
     static final int TIMEOUT_MILLIS = 60000 // 60 seconds
@@ -49,7 +50,7 @@ abstract class BugsnagUploadAbstractTask extends DefaultTask {
 
         // Get the Bugsnag API key
         apiKey = getApiKey(metaDataTags, ns)
-        if(!apiKey) {
+        if (!apiKey) {
             throw new RuntimeException("Could not find apiKey in '$BugsnagPlugin.API_KEY_TAG' <meta-data> tag in your AndroidManifest.xml or in your gradle config")
         }
 
@@ -76,7 +77,7 @@ abstract class BugsnagUploadAbstractTask extends DefaultTask {
         def retryCount = maxRetryCount
         while (!uploadSuccessful && retryCount > 0) {
             project.logger.warn(String.format("Retrying Bugsnag upload (%d/%d) ...",
-                                maxRetryCount - retryCount + 1, maxRetryCount))
+                maxRetryCount - retryCount + 1, maxRetryCount))
             uploadSuccessful = uploadToServer(mpEntity)
             retryCount--
         }
@@ -110,8 +111,8 @@ abstract class BugsnagUploadAbstractTask extends DefaultTask {
         HttpConnectionParams.setConnectionTimeout(params, TIMEOUT_MILLIS)
         HttpConnectionParams.setSoTimeout(params, TIMEOUT_MILLIS)
 
-        int statusCode = 0
-        def responseEntity = null
+        int statusCode
+        def responseEntity
         try {
             HttpResponse response = httpClient.execute(httpPost)
             statusCode = response.getStatusLine().getStatusCode()
@@ -127,17 +128,19 @@ abstract class BugsnagUploadAbstractTask extends DefaultTask {
         }
 
         project.logger.warn(String.format("Bugsnag upload failed with code %d: %s",
-                            statusCode, responseEntity))
+            statusCode, responseEntity))
         return false
     }
 
     def getApiKey(metaDataTags, ns) {
         def apiKey = null
 
-        if(project.bugsnag.apiKey != null) {
+        if (project.bugsnag.apiKey != null) {
             apiKey = project.bugsnag.apiKey
         } else {
-            def apiKeyTags = metaDataTags.findAll{ it.attributes()[ns.name].equals(BugsnagPlugin.API_KEY_TAG) }
+            def apiKeyTags = metaDataTags.findAll {
+                (it.attributes()[ns.name] == BugsnagPlugin.API_KEY_TAG)
+            }
             if (apiKeyTags.size() > 0) {
                 apiKey = apiKeyTags[0].attributes()[ns.value]
             }
@@ -149,7 +152,9 @@ abstract class BugsnagUploadAbstractTask extends DefaultTask {
     def getBuildUUID(metaDataTags, ns) {
         def buildUUID = null
 
-        def buildUUIDTags = metaDataTags.findAll{ it.attributes()[ns.name].equals(BugsnagPlugin.BUILD_UUID_TAG) }
+        def buildUUIDTags = metaDataTags.findAll {
+            (it.attributes()[ns.name] == BugsnagPlugin.BUILD_UUID_TAG)
+        }
         if (buildUUIDTags.size() == 0) {
             project.logger.warn("Could not find '$BugsnagPlugin.BUILD_UUID_TAG' <meta-data> tag in your AndroidManifest.xml")
         } else {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadJackTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadJackTask.groovy
@@ -3,22 +3,23 @@ package com.bugsnag.android.gradle
 import org.apache.http.entity.mime.MultipartEntity
 import org.apache.http.entity.mime.content.FileBody
 import org.gradle.api.tasks.TaskAction
+
 /**
 
-    Deprecated by google: http://tools.android.com/tech-docs/jackandjill
+ Deprecated by google: http://tools.android.com/tech-docs/jackandjill
 
-    Task to upload Jack mapping files to Bugsnag.
+ Task to upload Jack mapping files to Bugsnag.
 
-    Reads meta-data tags from the project's AndroidManifest.xml to extract a
-    build UUID (injected by BugsnagManifestTask) and a Bugsnag API Key:
+ Reads meta-data tags from the project's AndroidManifest.xml to extract a
+ build UUID (injected by BugsnagManifestTask) and a Bugsnag API Key:
 
-    https://developer.android.com/guide/topics/manifest/manifest-intro.html
-    https://developer.android.com/guide/topics/manifest/meta-data-element.html
+ https://developer.android.com/guide/topics/manifest/manifest-intro.html
+ https://developer.android.com/guide/topics/manifest/meta-data-element.html
 
-    This task must be called after ProGuard mapping files are generated, so
-    it is usually safe to have this be the absolute last task executed during
-    a build.
-*/
+ This task must be called after ProGuard mapping files are generated, so
+ it is usually safe to have this be the absolute last task executed during
+ a build.
+ */
 @Deprecated
 class BugsnagUploadJackTask extends BugsnagUploadAbstractTask {
     File mappingFile

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -13,18 +13,18 @@ import java.util.regex.Pattern
 import static groovy.io.FileType.*
 
 /**
-    Task to upload shared object mapping files to Bugsnag.
+ Task to upload shared object mapping files to Bugsnag.
 
-    Reads meta-data tags from the project's AndroidManifest.xml to extract a
-    build UUID (injected by BugsnagManifestTask) and a Bugsnag API Key:
+ Reads meta-data tags from the project's AndroidManifest.xml to extract a
+ build UUID (injected by BugsnagManifestTask) and a Bugsnag API Key:
 
-    https://developer.android.com/guide/topics/manifest/manifest-intro.html
-    https://developer.android.com/guide/topics/manifest/meta-data-element.html
+ https://developer.android.com/guide/topics/manifest/manifest-intro.html
+ https://developer.android.com/guide/topics/manifest/meta-data-element.html
 
-    This task must be called after shared object files are generated, so
-    it is usually safe to have this be the absolute last task executed during
-    a build.
-*/
+ This task must be called after shared object files are generated, so
+ it is usually safe to have this be the absolute last task executed during
+ a build.
+ */
 class BugsnagUploadNdkTask extends BugsnagUploadAbstractTask {
     File intermediatePath
     File symbolPath
@@ -33,7 +33,7 @@ class BugsnagUploadNdkTask extends BugsnagUploadAbstractTask {
     File rootDir
     String toolchain
     String sharedObjectPath
-    def joinPath = { String ...args -> args.join(File.separator) }
+    def joinPath = { String... args -> args.join(File.separator) }
 
     BugsnagUploadNdkTask() {
         super()
@@ -53,7 +53,7 @@ class BugsnagUploadNdkTask extends BugsnagUploadAbstractTask {
             }
         }
         if (!sharedObjectFound) {
-            project.logger.error("No shared objects found in ${sharedObjectPath?: intermediatePath}")
+            project.logger.error("No shared objects found in ${sharedObjectPath ?: intermediatePath}")
         }
     }
 
@@ -61,8 +61,7 @@ class BugsnagUploadNdkTask extends BugsnagUploadAbstractTask {
      * Traverse potential library paths, aggregating shared libraries
      *
      * Potential locations:
-     * - {project dir}/{defined shared object path}
-     * - {project dir}/obj/local
+     * - {project dir}/{defined shared object path}* - {project dir}/obj/local
      * - {intermediates}/cmake/{variant}/obj
      * - {intermediates}/binaries/{variant}/obj
      * - {intermediates}/exploded-aar/{*}/jni
@@ -107,12 +106,12 @@ class BugsnagUploadNdkTask extends BugsnagUploadAbstractTask {
     /**
      * Searches the subdirectories of a given path and executes a block on
      * any shared object files
-     * @param path      The parent path to search. Each subdirectory should
+     * @param path The parent path to search. Each subdirectory should
      *                  represent an architecture
      * @param processor a closure to execute on each parent directory and shared
      *                  object file
      */
-    def findSharedObjectFiles(String path, Closure processor) {
+    static def findSharedObjectFiles(String path, Closure processor) {
         File dir = new File(path)
         if (dir.exists()) {
             dir.eachDir { arch ->
@@ -120,7 +119,6 @@ class BugsnagUploadNdkTask extends BugsnagUploadAbstractTask {
             }
         }
     }
-
 
     /**
      * Uses objdump to create a symbols file for the given shared object file
@@ -143,7 +141,7 @@ class BugsnagUploadNdkTask extends BugsnagUploadAbstractTask {
                 Process process = builder.start()
 
                 InputStream stdout = process.getInputStream();
-                BufferedReader outReader = new BufferedReader (new InputStreamReader(stdout));
+                BufferedReader outReader = new BufferedReader(new InputStreamReader(stdout));
 
                 if (!outPutSymbolFile(outReader, outputFile, arch)) {
                     return null;
@@ -156,7 +154,7 @@ class BugsnagUploadNdkTask extends BugsnagUploadAbstractTask {
                     return null
                 }
             } catch (Exception e) {
-                project.logger.error("failed to generate symbols for " + arch + ": "+ e.getMessage());
+                project.logger.error("failed to generate symbols for " + arch + ": " + e.getMessage());
             }
         } else {
             project.logger.error("Unable to upload NDK symbols: Could not find objdump location for " + arch)
@@ -188,7 +186,7 @@ class BugsnagUploadNdkTask extends BugsnagUploadAbstractTask {
 
             // Loop to remove redundant address lines (just keep the first and last addresses of each block)
             String line = outReader.readLine()
-            Matcher addressMatcher = null;
+            Matcher addressMatcher
             while (line != null) {
 
                 // Check to see if the current line is an address

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
@@ -3,19 +3,20 @@ package com.bugsnag.android.gradle
 import org.apache.http.entity.mime.MultipartEntity
 import org.apache.http.entity.mime.content.FileBody
 import org.gradle.api.tasks.TaskAction
+
 /**
-    Task to upload ProGuard mapping files to Bugsnag.
+ Task to upload ProGuard mapping files to Bugsnag.
 
-    Reads meta-data tags from the project's AndroidManifest.xml to extract a
-    build UUID (injected by BugsnagManifestTask) and a Bugsnag API Key:
+ Reads meta-data tags from the project's AndroidManifest.xml to extract a
+ build UUID (injected by BugsnagManifestTask) and a Bugsnag API Key:
 
-    https://developer.android.com/guide/topics/manifest/manifest-intro.html
-    https://developer.android.com/guide/topics/manifest/meta-data-element.html
+ https://developer.android.com/guide/topics/manifest/manifest-intro.html
+ https://developer.android.com/guide/topics/manifest/meta-data-element.html
 
-    This task must be called after ProGuard mapping files are generated, so
-    it is usually safe to have this be the absolute last task executed during
-    a build.
-*/
+ This task must be called after ProGuard mapping files are generated, so
+ it is usually safe to have this be the absolute last task executed during
+ a build.
+ */
 class BugsnagUploadProguardTask extends BugsnagUploadAbstractTask {
     File mappingFile
 


### PR DESCRIPTION
Addresses Lint warnings for Groovy by applying auto-fix suggestions. Also adds missing gradle properties to fix failed sync on checkout, and formats code consistently.