### PR TITLE
APK split upload support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 3.0.0-beta3 (2017-10-10)
+
+* Support upload of APK splits
+
+#### Breaking changes
+If you run the upload task manually, the task name has now changed to use the VariantOutput name, rather than the Variant name.
+
+```shell
+./gradlew clean build uploadBugsnag${variantOutputName}Mapping
+```
+
+For example, the following would upload the release mapping file for the `x86` split of the `javaExample` productFlavor in the `example` module: 
+```shell
+./gradlew clean build :example:uploadBugsnagJavaExample-x86-releaseMapping
+```
+
 ## 3.0.0-beta2 (2017-09-22)
 
 * Expose manual upload gradle task 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Settings, at `<project dir>/<module name>/build.gradle` (usually
 
 ```groovy
 plugins {
-    id "com.bugsnag.android.gradle" version "3.0.0-beta2"
+    id "com.bugsnag.android.gradle" version "3.0.0-beta3"
 }
 ```
 
@@ -50,7 +50,7 @@ Add this plugin as a dependency in your main *Project Gradle Settings*, at `<pro
 buildscript {
     dependencies {
         // Add this line to your `dependencies` section
-        classpath 'com.bugsnag:bugsnag-android-gradle-plugin:3.0.0-beta2'
+        classpath 'com.bugsnag:bugsnag-android-gradle-plugin:3.0.0-beta3'
     }
 }
 ```
@@ -101,7 +101,9 @@ If you disable automatic uploading, you can still run the upload task manually, 
 ```
 
 For example, the following would upload the release mapping file for the `x86` split of the `javaExample` productFlavor in the `example` module: 
-:example:uploadBugsnagJavaExample-x86-releaseMapping
+```shell
+./gradlew clean build :example:uploadBugsnagJavaExample-x86-releaseMapping
+```
 
 ## Automatic Proguard Config
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ If you disable automatic uploading, you can still run the upload task manually, 
 ./gradlew clean build uploadBugsnag${variantOutputName}Mapping
 ```
 
-In this example, $moduleName is the module being built (e.g. 'app'), and $variantName is the build variant name (e.g. 'appProRelease')
+For example, the following would upload the release mapping file for the `x86` split of the `javaExample` productFlavor in the `example` module: 
+:example:uploadBugsnagJavaExample-x86-releaseMapping
 
 ## Automatic Proguard Config
 

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ bugsnag {
 }
 ```
 
-If you disable automatic uploading, you can still run the upload task manually, with the uploadBugsnag*Variant*Mapping task:
+If you disable automatic uploading, you can still run the upload task manually, with the uploadBugsnag*VariantOutput*Mapping task:
 
 ```shell
-./gradlew clean assembleRelease packageRelease ${moduleName}:uploadBugsnag${variantName}Mapping
+./gradlew clean build uploadBugsnag${variantOutputName}Mapping
 ```
 
 In this example, $moduleName is the module being built (e.g. 'app'), and $variantName is the build variant name (e.g. 'appProRelease')

--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,10 @@ compileGroovy {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'com.android.tools.build:gradle:3.0.0-beta6'
+    compile 'com.android.tools.build:gradle:3.0.0-beta7'
     compile 'org.apache.httpcomponents:httpclient:4.5.2'
     compile 'org.apache.httpcomponents:httpmime:4.5.2'
+    testCompile 'junit:junit:4.12'
 }
 
 // Maven publishing settings (nexus-maven-plugins)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = com.bugsnag
-version = 3.0.0-beta2
+version = 3.0.0-beta3

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -80,11 +80,7 @@ class BugsnagManifestTask extends DefaultTask {
     }
 
     def getManifestPath() {
-        File directory = output.processManifest.manifestOutputDirectory
-        def name = output.name
-        println("Output name: " + name)
-
-        File manifestPath = new File(directory, "AndroidManifest.xml")
+        File manifestPath = ManifestOutputDir.getManifestPath(output)
 
         if (!manifestPath.exists()) {
             project.logger.warn("Failed to find manifest for output " + output.name)

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -18,7 +18,6 @@ import org.gradle.api.tasks.TaskAction
 class BugsnagManifestTask extends DefaultTask {
 
     BaseVariantOutput output // cache output to find manifestPath when it is created
-    BugsnagPlugin.SplitsInfo splitsInfo
 
     BugsnagManifestTask() {
         super()
@@ -27,7 +26,7 @@ class BugsnagManifestTask extends DefaultTask {
 
     @TaskAction
     def updateManifest() {
-        def manifestPath = ManifestOutputDir.getManifestPath(output, splitsInfo)
+        def manifestPath = ManifestOutputDir.getManifestPath(output)
 
         if (!manifestPath.exists()) {
             project.logger.warn("Failed to find manifest for output " + output.name)
@@ -72,7 +71,7 @@ class BugsnagManifestTask extends DefaultTask {
     }
 
     def shouldRun() {
-        def manifestPath = ManifestOutputDir.getManifestPath(output, splitsInfo)
+        def manifestPath = ManifestOutputDir.getManifestPath(output)
 
         if (!manifestPath.exists()) {
             project.logger.warn("Failed to find manifest for output " + output.name)

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -18,6 +18,7 @@ import org.gradle.api.tasks.TaskAction
 class BugsnagManifestTask extends DefaultTask {
 
     BaseVariantOutput output // cache output to find manifestPath when it is created
+    BugsnagPlugin.SplitsInfo splitsInfo
 
     BugsnagManifestTask() {
         super()
@@ -26,7 +27,7 @@ class BugsnagManifestTask extends DefaultTask {
 
     @TaskAction
     def updateManifest() {
-        def manifestPath = ManifestOutputDir.getManifestPath(output)
+        def manifestPath = ManifestOutputDir.getManifestPath(output, splitsInfo)
 
         if (!manifestPath.exists()) {
             project.logger.warn("Failed to find manifest for output " + output.name)
@@ -71,7 +72,7 @@ class BugsnagManifestTask extends DefaultTask {
     }
 
     def shouldRun() {
-        def manifestPath = ManifestOutputDir.getManifestPath(output)
+        def manifestPath = ManifestOutputDir.getManifestPath(output, splitsInfo)
 
         if (!manifestPath.exists()) {
             project.logger.warn("Failed to find manifest for output " + output.name)

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -80,7 +80,11 @@ class BugsnagManifestTask extends DefaultTask {
     }
 
     def getManifestPath() {
-        File manifestPath = new File(output.processManifest.manifestOutputDirectory, "AndroidManifest.xml")
+        File directory = output.processManifest.manifestOutputDirectory
+        def name = output.name
+        println("Output name: " + name)
+
+        File manifestPath = new File(directory, "AndroidManifest.xml")
 
         if (!manifestPath.exists()) {
             project.logger.warn("Failed to find manifest for output " + output.name)

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -1,10 +1,7 @@
 package com.bugsnag.android.gradle
 
-import com.android.build.gradle.api.BaseVariantOutput
 import groovy.xml.Namespace
-import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
-
 /**
  Task to add a unique build UUID to AndroidManifest.xml during the build
  process. This is used by Bugsnag to identify which proguard mapping file
@@ -15,9 +12,7 @@ import org.gradle.api.tasks.TaskAction
  This task must be called after "process${variantName}Manifest", since it
  requires that an AndroidManifest.xml exists in `build/intermediates`.
  */
-class BugsnagManifestTask extends DefaultTask {
-
-    BaseVariantOutput output // cache output to find manifestPath when it is created
+class BugsnagManifestTask extends BugsnagVariantOutputTask {
 
     BugsnagManifestTask() {
         super()
@@ -26,10 +21,10 @@ class BugsnagManifestTask extends DefaultTask {
 
     @TaskAction
     def updateManifest() {
-        def manifestPath = ManifestOutputDir.getManifestPath(output)
+        def manifestPath = ManifestOutputDir.getManifestPath()
 
         if (!manifestPath.exists()) {
-            project.logger.warn("Failed to find manifest for output " + output.name)
+            project.logger.warn("Failed to find manifest for output " + variantOutput.name)
             return
         }
 
@@ -71,10 +66,10 @@ class BugsnagManifestTask extends DefaultTask {
     }
 
     def shouldRun() {
-        def manifestPath = ManifestOutputDir.getManifestPath(output)
+        def manifestPath = ManifestOutputDir.getManifestPath()
 
         if (!manifestPath.exists()) {
-            project.logger.warn("Failed to find manifest for output " + output.name)
+            project.logger.warn("Failed to find manifest for output " + variantOutput.name)
             return false
         }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -24,7 +24,6 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
         def manifestPath = getManifestPath()
 
         if (!manifestPath.exists()) {
-            project.logger.warn("Failed to find manifest for output " + variantOutput.name)
             return
         }
 
@@ -69,7 +68,6 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
         def manifestPath = getManifestPath()
 
         if (!manifestPath.exists()) {
-            project.logger.warn("Failed to find manifest for output " + variantOutput.name)
             return false
         }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -21,7 +21,7 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
 
     @TaskAction
     def updateManifest() {
-        def manifestPath = ManifestOutputDir.getManifestPath()
+        def manifestPath = getManifestPath()
 
         if (!manifestPath.exists()) {
             project.logger.warn("Failed to find manifest for output " + variantOutput.name)
@@ -66,7 +66,7 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
     }
 
     def shouldRun() {
-        def manifestPath = ManifestOutputDir.getManifestPath()
+        def manifestPath = getManifestPath()
 
         if (!manifestPath.exists()) {
             project.logger.warn("Failed to find manifest for output " + variantOutput.name)

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -26,7 +26,13 @@ class BugsnagManifestTask extends DefaultTask {
 
     @TaskAction
     def updateManifest() {
-        def manifestPath = getManifestPath()
+        def manifestPath = ManifestOutputDir.getManifestPath(output)
+
+        if (!manifestPath.exists()) {
+            project.logger.warn("Failed to find manifest for output " + output.name)
+            return
+        }
+
         project.logger.debug("Updating manifest with build UUID: " + manifestPath)
 
         // Parse the AndroidManifest.xml
@@ -65,7 +71,12 @@ class BugsnagManifestTask extends DefaultTask {
     }
 
     def shouldRun() {
-        def manifestPath = getManifestPath()
+        def manifestPath = ManifestOutputDir.getManifestPath(output)
+
+        if (!manifestPath.exists()) {
+            project.logger.warn("Failed to find manifest for output " + output.name)
+            return false
+        }
 
         def ns = new Namespace("http://schemas.android.com/apk/res/android", "android")
         def app = new XmlParser().parse(manifestPath).application[0]
@@ -77,15 +88,6 @@ class BugsnagManifestTask extends DefaultTask {
         } else {
             false
         }
-    }
-
-    def getManifestPath() {
-        File manifestPath = ManifestOutputDir.getManifestPath(output)
-
-        if (!manifestPath.exists()) {
-            project.logger.warn("Failed to find manifest for output " + output.name)
-        }
-        manifestPath
     }
 
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -26,6 +26,7 @@ class BugsnagPlugin implements Plugin<Project> {
     static final String API_KEY_TAG = 'com.bugsnag.android.API_KEY'
     static final String BUILD_UUID_TAG = 'com.bugsnag.android.BUILD_UUID'
     static final String GROUP_NAME = 'Bugsnag'
+    static final String BUGSNAG_SPLIT_INFO = "bugsnagSplitInfo"
 
     private SplitsInfo splitsInfo
     private BugsnagManifestTask manifestUuidTask
@@ -64,19 +65,13 @@ class BugsnagPlugin implements Plugin<Project> {
     }
 
     private void setupSplitsDiscovery(Project project, ApplicationVariant variant) {
+        // TODO need to expose this as a task to support uploading properly
         def task = project.tasks.findByName("splitsDiscoveryTask${taskNameForVariant(variant)}")
         task.doLast {
-            this.splitsInfo = new SplitsInfo()
-            this.splitsInfo.densityFilters = task.densityFilters
-            this.splitsInfo.languageFilters = task.languageFilters
-            this.splitsInfo.abiFilters = task.abiFilters
-
-            this.manifestUuidTask.splitsInfo = splitsInfo
-            this.uploadProguardTask.splitsInfo = splitsInfo
-
-            if (this.uploadNdkTask != null) {
-                this.uploadNdkTask.splitsInfo = splitsInfo
-            }
+            splitsInfo = new SplitsInfo()
+            splitsInfo.densityFilters = task.densityFilters
+            splitsInfo.languageFilters = task.languageFilters
+            splitsInfo.abiFilters = task.abiFilters
         }
     }
 
@@ -139,7 +134,7 @@ class BugsnagPlugin implements Plugin<Project> {
         manifestTask.output = output
         manifestTask.group = GROUP_NAME
         manifestTask.mustRunAfter output.processManifest
-        manifestTask.onlyIf { it.shouldRun() }
+//        manifestTask.onlyIf { it.shouldRun() }
 
         output.packageApplication.dependsOn manifestTask
         return manifestTask

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -65,7 +65,7 @@ class BugsnagPlugin implements Plugin<Project> {
 
         // Create a Bugsnag task to upload proguard mapping file
         def uploadTaskClass = BugsnagUploadProguardTask
-        def uploadTask = project.tasks.create("uploadBugsnag${taskNameForVariant(variant)}Mapping", uploadTaskClass)
+        def uploadTask = project.tasks.create("uploadBugsnag${taskNameForOutput(output)}Mapping", uploadTaskClass)
         uploadTask.partName = isJackEnabled(project, variant) ? "jack" : "proguard"
 
         uploadTask.group = GROUP_NAME
@@ -86,7 +86,7 @@ class BugsnagPlugin implements Plugin<Project> {
 
         if (project.bugsnag.ndk) {
             // Create a Bugsnag task to upload NDK mapping file(s)
-            uploadNdkTask = project.tasks.create("uploadBugsnagNdk${taskNameForVariant(variant)}Mapping", BugsnagUploadNdkTask)
+            uploadNdkTask = project.tasks.create("uploadBugsnagNdk${taskNameForOutput(output)}Mapping", BugsnagUploadNdkTask)
             uploadNdkTask.group = GROUP_NAME
             uploadNdkTask.output = output
             uploadNdkTask.variant = variant
@@ -110,7 +110,7 @@ class BugsnagPlugin implements Plugin<Project> {
     private static void setupManifestUuidTask(Project project, ApplicationVariant variant,  BaseVariantOutput output) {
         project.logger.debug("Adding Build UUID to manifest")
 
-        BugsnagManifestTask manifestTask = project.tasks.create("processBugsnag${taskNameForVariant(variant)}Manifest", BugsnagManifestTask)
+        BugsnagManifestTask manifestTask = project.tasks.create("processBugsnag${taskNameForOutput(output)}Manifest", BugsnagManifestTask)
         manifestTask.output = output
         manifestTask.group = GROUP_NAME
         manifestTask.mustRunAfter output.processManifest
@@ -145,6 +145,10 @@ class BugsnagPlugin implements Plugin<Project> {
 
     private static String taskNameForVariant(ApplicationVariant variant) {
         variant.name.capitalize()
+    }
+
+    private static String taskNameForOutput(BaseVariantOutput output) {
+        output.name.capitalize()
     }
 
     /**

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -64,7 +64,7 @@ class BugsnagPlugin implements Plugin<Project> {
 
         // need to be run for each output
         variant.outputs.all { output ->
-            if (!output.name.toLowerCase().endsWith("debug")) {
+            if (!output.name.toLowerCase().endsWith("debug") || project.bugsnag.uploadDebugBuildMappings) {
                 setupManifestUuidTask(project, output)
                 setupMappingFileUpload(project, variant, output)
                 setupNdkMappingFileUpload(project, variant, output)

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -55,7 +55,7 @@ class BugsnagPlugin implements Plugin<Project> {
         }
     }
 
-    private static void setupMappingFileUpload(Project project, ApplicationVariant variant,  BaseVariantOutput output) {
+    private static void setupMappingFileUpload(Project project, ApplicationVariant variant, BaseVariantOutput output) {
         // The Android build system supports creating multiple APKs
         // per Build Variant (Variant Outputs):
         // https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/user-guide/apk-splits

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -115,7 +115,7 @@ class BugsnagPlugin implements Plugin<Project> {
 
     private static void prepareUploadTask(uploadTask, BaseVariantOutput output, BaseVariant variant, Project project) {
         uploadTask.group = GROUP_NAME
-        uploadTask.output = output
+        uploadTask.variantOutput = output
         uploadTask.variant = variant
         uploadTask.applicationId = variant.applicationId
         uploadTask.mustRunAfter output.assemble
@@ -131,7 +131,7 @@ class BugsnagPlugin implements Plugin<Project> {
         project.logger.debug("Adding Build UUID to manifest")
 
         BugsnagManifestTask manifestTask = project.tasks.create("processBugsnag${taskNameForOutput(output)}Manifest", BugsnagManifestTask)
-        manifestTask.output = output
+        manifestTask.variantOutput = output
         manifestTask.group = GROUP_NAME
         manifestTask.mustRunAfter output.processManifest
 //        manifestTask.onlyIf { it.shouldRun() }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -8,7 +8,6 @@ import com.android.build.gradle.internal.core.Toolchain
 import com.android.build.gradle.internal.dsl.BuildType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-
 /**
  * Gradle plugin to automatically upload ProGuard mapping files to Bugsnag.
  *
@@ -28,12 +27,16 @@ class BugsnagPlugin implements Plugin<Project> {
     static final String API_KEY_TAG = 'com.bugsnag.android.API_KEY'
     static final String BUILD_UUID_TAG = 'com.bugsnag.android.BUILD_UUID'
     static final String GROUP_NAME = 'Bugsnag'
-    static final String BUGSNAG_SPLIT_INFO = "bugsnagSplitInfo"
 
-    private SplitsInfo splitsInfo
     private BugsnagManifestTask manifestUuidTask
     private BugsnagUploadProguardTask uploadProguardTask
     private BugsnagUploadNdkTask uploadNdkTask
+
+    class SplitsInfo {
+        def densityFilters
+        def languageFilters
+        def abiFilters
+    }
 
     void apply(Project project) {
         project.extensions.create("bugsnag", BugsnagPluginExtension)
@@ -72,13 +75,12 @@ class BugsnagPlugin implements Plugin<Project> {
     }
 
     private void setupSplitsDiscovery(Project project, BaseVariant variant) {
-        // TODO need to expose this as a task to support uploading properly
         def task = project.tasks.findByName("splitsDiscoveryTask${taskNameForVariant(variant)}")
         task.doLast {
-            splitsInfo = new SplitsInfo()
-            splitsInfo.densityFilters = task.densityFilters
-            splitsInfo.languageFilters = task.languageFilters
-            splitsInfo.abiFilters = task.abiFilters
+            project.ext.splitsInfo = new SplitsInfo()
+            project.ext.splitsInfo.densityFilters = task.densityFilters
+            project.ext.splitsInfo.languageFilters = task.languageFilters
+            project.ext.splitsInfo.abiFilters = task.abiFilters
         }
     }
 
@@ -305,11 +307,5 @@ class BugsnagPlugin implements Plugin<Project> {
             }
         }
         return null
-    }
-
-    static class SplitsInfo {
-        def densityFilters
-        def languageFilters
-        def abiFilters
     }
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -95,7 +95,7 @@ class BugsnagPlugin implements Plugin<Project> {
     private BugsnagUploadNdkTask setupNdkMappingFileUpload(Project project, BaseVariant variant, BaseVariantOutput output) {
         File symbolPath = getSymbolPath(output)
         File intermediatePath = getIntermediatePath(symbolPath)
-        BugsnagUploadNdkTask uploadNdkTask
+        BugsnagUploadNdkTask uploadNdkTask = null
 
         if (project.bugsnag.ndk) {
             // Create a Bugsnag task to upload NDK mapping file(s)

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -36,6 +36,8 @@ class BugsnagPlugin implements Plugin<Project> {
                 throw new IllegalStateException('Must apply \'com.android.application\' first!')
             }
 
+
+
             // Create tasks for each Build Variant
             // https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/user-guide#TOC-Build-Variants
             project.android.applicationVariants.all { ApplicationVariant variant ->
@@ -45,6 +47,17 @@ class BugsnagPlugin implements Plugin<Project> {
 
                 // proguard rules only need to be setup once
                 setupProguardAutoConfig(project, variant)
+
+
+                def task = project.tasks.findByName("splitsDiscoveryTask${taskNameForVariant(variant)}")
+                task.doLast {
+                    println("Density filters: " + task.densityFilters)
+                    println("Language filters: " + task.languageFilters)
+                    println("ABI filters: " + task.abiFilters)
+
+                    // language filters appear to be broken?
+                    // see: https://issuetracker.google.com/issues/37085185
+                }
 
                 variant.outputs.all { output ->
                     setupManifestUuidTask(project, variant, output)

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
@@ -8,6 +8,7 @@ class BugsnagPluginExtension {
     def String apiKey = null
     def boolean autoUpload = true
     def boolean autoProguardConfig = true
+    def boolean uploadDebugBuildMappings = false
     def boolean overwrite = false
     def int retryCount = 0
     def boolean ndk = false

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
@@ -6,8 +6,8 @@ package com.bugsnag.android.gradle
 class BugsnagPluginExtension {
     def String endpoint = 'https://upload.bugsnag.com'
     def String apiKey = null
-    def boolean autoUpload = true;
-    def boolean autoProguardConfig = true;
+    def boolean autoUpload = true
+    def boolean autoProguardConfig = true
     def boolean overwrite = false
     def int retryCount = 0
     def boolean ndk = false

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -1,9 +1,9 @@
 package com.bugsnag.android.gradle
 
+import com.android.build.gradle.api.BaseVariant
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
-import com.android.build.gradle.api.ApplicationVariant
 
 /**
  Task to add an additional ProGuard configuration file (bugsnag.pro)
@@ -12,6 +12,7 @@ import com.android.build.gradle.api.ApplicationVariant
  This task must be called before ProGuard is run.
  */
 class BugsnagProguardConfigTask extends DefaultTask {
+
     static final String PROGUARD_CONFIG_PATH = "build/intermediates/bugsnag/bugsnag.pro"
     static final String PROGUARD_CONFIG_SETTINGS = """\
     -keepattributes LineNumberTable,SourceFile
@@ -23,7 +24,7 @@ class BugsnagProguardConfigTask extends DefaultTask {
     -keep class com.bugsnag.android.ndk.BugsnagObserver { *; }
     """.toString()
 
-    ApplicationVariant applicationVariant
+    BaseVariant variant
 
     BugsnagProguardConfigTask() {
         super()
@@ -45,6 +46,6 @@ class BugsnagProguardConfigTask extends DefaultTask {
         fr.close()
 
         // Add this proguard settings file to the list
-        applicationVariant.getBuildType().buildType.proguardFiles(file)
+        variant.getBuildType().buildType.proguardFiles(file)
     }
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
@@ -1,6 +1,6 @@
 package com.bugsnag.android.gradle
 
-import com.android.build.gradle.api.ApplicationVariant
+import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
 import groovy.xml.Namespace
 import org.apache.http.HttpResponse
@@ -32,7 +32,7 @@ abstract class BugsnagUploadAbstractTask extends DefaultTask {
     static final int MAX_RETRY_COUNT = 5
     static final int TIMEOUT_MILLIS = 60000 // 60 seconds
 
-    ApplicationVariant variant
+    BaseVariant variant
     BaseVariantOutput output
     String applicationId
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
@@ -182,7 +182,7 @@ abstract class BugsnagUploadAbstractTask extends DefaultTask {
     }
 
     def getManifestPath() {
-        File manifestPath = new File(output.processManifest.manifestOutputDirectory, "AndroidManifest.xml")
+        File manifestPath = ManifestOutputDir.getManifestPath(output)
 
         if (!manifestPath.exists()) {
             project.logger.warn("Failed to find manifest for output " + output.name)

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
@@ -51,7 +51,7 @@ abstract class BugsnagUploadAbstractTask extends BugsnagVariantOutputTask {
         if (!manifestPath.exists()) {
             return
         }
-        project.logger.info("Reading manifest at: ${manifestPath}")
+        project.logger.debug("Reading manifest at: ${manifestPath}")
 
         def xml = new XmlParser().parse(manifestPath)
         def metaDataTags = xml.application['meta-data']
@@ -113,12 +113,12 @@ abstract class BugsnagUploadAbstractTask extends BugsnagVariantOutputTask {
             mpEntity.addPart("overwrite", new StringBody("true"))
         }
 
-        project.logger.info("apiKey: ${apiKey}")
-        project.logger.info("appId: ${applicationId}")
-        project.logger.info("versionCode: ${versionCode}")
-        project.logger.info("buildUUID: ${buildUUID}")
-        project.logger.info("versionName: ${versionName}")
-        project.logger.info("overwrite: ${project.bugsnag.overwrite}")
+        project.logger.debug("apiKey: ${apiKey}")
+        project.logger.debug("appId: ${applicationId}")
+        project.logger.debug("versionCode: ${versionCode}")
+        project.logger.debug("buildUUID: ${buildUUID}")
+        project.logger.debug("versionName: ${versionName}")
+        project.logger.debug("overwrite: ${project.bugsnag.overwrite}")
     }
 
     def boolean uploadToServer(mpEntity) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
@@ -1,7 +1,6 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.BaseVariant
-import com.android.build.gradle.api.BaseVariantOutput
 import groovy.xml.Namespace
 import org.apache.http.HttpResponse
 import org.apache.http.client.HttpClient
@@ -12,8 +11,6 @@ import org.apache.http.impl.client.DefaultHttpClient
 import org.apache.http.params.HttpConnectionParams
 import org.apache.http.params.HttpParams
 import org.apache.http.util.EntityUtils
-import org.gradle.api.DefaultTask
-
 /**
  Task to upload ProGuard mapping files to Bugsnag.
 
@@ -27,13 +24,12 @@ import org.gradle.api.DefaultTask
  it is usually safe to have this be the absolute last task executed during
  a build.
  */
-abstract class BugsnagUploadAbstractTask extends DefaultTask {
+abstract class BugsnagUploadAbstractTask extends BugsnagVariantOutputTask {
 
     static final int MAX_RETRY_COUNT = 5
     static final int TIMEOUT_MILLIS = 60000 // 60 seconds
 
     BaseVariant variant
-    BaseVariantOutput output
     String applicationId
 
     // Read from the manifest file
@@ -50,10 +46,10 @@ abstract class BugsnagUploadAbstractTask extends DefaultTask {
     def readManifestFile() {
         // Parse the AndroidManifest.xml
         def ns = new Namespace("http://schemas.android.com/apk/res/android", "android")
-        def manifestPath = ManifestOutputDir.getManifestPath(output)
+        def manifestPath = ManifestOutputDir.getManifestPath()
 
         if (!manifestPath.exists()) {
-            project.logger.warn("Failed to find manifest for output " + output.name)
+            project.logger.warn("Failed to find manifest for output " + variantOutput.name)
             return
         }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
@@ -46,7 +46,7 @@ abstract class BugsnagUploadAbstractTask extends BugsnagVariantOutputTask {
     def readManifestFile() {
         // Parse the AndroidManifest.xml
         def ns = new Namespace("http://schemas.android.com/apk/res/android", "android")
-        def manifestPath = ManifestOutputDir.getManifestPath()
+        def manifestPath = getManifestPath()
 
         if (!manifestPath.exists()) {
             project.logger.warn("Failed to find manifest for output " + variantOutput.name)

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
@@ -101,7 +101,7 @@ abstract class BugsnagUploadAbstractTask extends BugsnagVariantOutputTask {
         mpEntity.addPart("versionCode", new StringBody(versionCode))
 
         if (buildUUID != null) {
-            mpEntity.addPart("buildUUID", new StringBody(buildUUID));
+            mpEntity.addPart("buildUUID", new StringBody(buildUUID))
         }
 
         if (versionName != null) {
@@ -118,7 +118,7 @@ abstract class BugsnagUploadAbstractTask extends BugsnagVariantOutputTask {
 
         // Make the request
         HttpPost httpPost = new HttpPost(project.bugsnag.endpoint)
-        httpPost.setEntity(mpEntity);
+        httpPost.setEntity(mpEntity)
 
         HttpClient httpClient = new DefaultHttpClient()
         HttpParams params = httpClient.getParams()

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
@@ -51,6 +51,7 @@ abstract class BugsnagUploadAbstractTask extends BugsnagVariantOutputTask {
         if (!manifestPath.exists()) {
             return
         }
+        project.logger.info("Reading manifest at: ${manifestPath}")
 
         def xml = new XmlParser().parse(manifestPath)
         def metaDataTags = xml.application['meta-data']
@@ -111,6 +112,13 @@ abstract class BugsnagUploadAbstractTask extends BugsnagVariantOutputTask {
         if (project.bugsnag.overwrite || System.properties['bugsnag.overwrite']) {
             mpEntity.addPart("overwrite", new StringBody("true"))
         }
+
+        project.logger.info("apiKey: ${apiKey}")
+        project.logger.info("appId: ${applicationId}")
+        project.logger.info("versionCode: ${versionCode}")
+        project.logger.info("buildUUID: ${buildUUID}")
+        project.logger.info("versionName: ${versionName}")
+        project.logger.info("overwrite: ${project.bugsnag.overwrite}")
     }
 
     def boolean uploadToServer(mpEntity) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
@@ -35,6 +35,7 @@ abstract class BugsnagUploadAbstractTask extends DefaultTask {
     ApplicationVariant variant
     BaseVariantOutput output
     String applicationId
+    BugsnagPlugin.SplitsInfo splitsInfo
 
     // Read from the manifest file
     String apiKey
@@ -50,7 +51,7 @@ abstract class BugsnagUploadAbstractTask extends DefaultTask {
     def readManifestFile() {
         // Parse the AndroidManifest.xml
         def ns = new Namespace("http://schemas.android.com/apk/res/android", "android")
-        def manifestPath = ManifestOutputDir.getManifestPath(output)
+        def manifestPath = ManifestOutputDir.getManifestPath(output, splitsInfo)
 
         if (!manifestPath.exists()) {
             project.logger.warn("Failed to find manifest for output " + output.name)

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
@@ -35,7 +35,6 @@ abstract class BugsnagUploadAbstractTask extends DefaultTask {
     ApplicationVariant variant
     BaseVariantOutput output
     String applicationId
-    BugsnagPlugin.SplitsInfo splitsInfo
 
     // Read from the manifest file
     String apiKey
@@ -51,7 +50,7 @@ abstract class BugsnagUploadAbstractTask extends DefaultTask {
     def readManifestFile() {
         // Parse the AndroidManifest.xml
         def ns = new Namespace("http://schemas.android.com/apk/res/android", "android")
-        def manifestPath = ManifestOutputDir.getManifestPath(output, splitsInfo)
+        def manifestPath = ManifestOutputDir.getManifestPath(output)
 
         if (!manifestPath.exists()) {
             project.logger.warn("Failed to find manifest for output " + output.name)

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
@@ -49,7 +49,6 @@ abstract class BugsnagUploadAbstractTask extends BugsnagVariantOutputTask {
         def manifestPath = getManifestPath()
 
         if (!manifestPath.exists()) {
-            project.logger.warn("Failed to find manifest for output " + variantOutput.name)
             return
         }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -43,7 +43,7 @@ class BugsnagUploadNdkTask extends BugsnagUploadAbstractTask {
 
     @TaskAction
     def upload() {
-        super.readManifestFile();
+        super.readManifestFile()
         boolean sharedObjectFound = false
         searchLibraryPaths { String arch, File sharedObject ->
             sharedObjectFound = true

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -26,6 +26,7 @@ import static groovy.io.FileType.*
  a build.
  */
 class BugsnagUploadNdkTask extends BugsnagUploadAbstractTask {
+
     File intermediatePath
     File symbolPath
     String variantName

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
@@ -17,7 +17,7 @@ import org.gradle.api.tasks.TaskAction
  it is usually safe to have this be the absolute last task executed during
  a build.
  */
-class BugsnagUploadProguardTask extends BugsnagUploadAbstractTask { // FIXME duplication with Jack task
+class BugsnagUploadProguardTask extends BugsnagUploadAbstractTask {
 
     String partName
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
@@ -40,7 +40,7 @@ class BugsnagUploadProguardTask extends BugsnagUploadAbstractTask {
 
         // Read the API key and Build ID etc..
         super.readManifestFile()
-        project.logger.info("Attempting to upload mapping file: " + mappingFile)
+        project.logger.info("Attempting to upload mapping file: ${mappingFile}")
 
         // Construct a basic request
         MultipartEntity mpEntity = new MultipartEntity()

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
@@ -34,7 +34,7 @@ class BugsnagUploadProguardTask extends BugsnagUploadAbstractTask {
         // configuration includes -dontobfuscate, the mapping file
         // will not exist (but we also won't need it).
         if (!mappingFile || !mappingFile.exists()) {
-            project.logger.error("Mapping file not found")
+            project.logger.error("Mapping file not found: ${mappingFile}")
             return
         }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -19,7 +19,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
      * See: https://developer.android.com/studio/build/configure-apk-splits.html#build-apks-filename
      * https://issuetracker.google.com/issues/37085185
      */
-    def File getManifestPath() {
+    File getManifestPath() {
         File directory = variantOutput.processManifest.manifestOutputDirectory
         String[] tokens = variantOutput.name.split("-")
 
@@ -28,13 +28,16 @@ class BugsnagVariantOutputTask extends DefaultTask {
 
         if (tokens.length == 3) {
             def split = tokens[1]
-            BugsnagPlugin.SplitsInfo splitsInfo = null // TODO populate!
+            def splitsInfo = project.ext.splitsInfo
+            println("Manifest path ${splitsInfo}")
 
-            if (splitsInfo != null) {
-                def density = findValueForSplit(split, splitsInfo.densityFilters)
-                def abi = findValueForSplit(split, splitsInfo.densityFilters)
-                directory = findManifestDirForSplit(density, abi, directory)
-            }
+
+            def density = findValueForSplit(split, splitsInfo.densityFilters)
+            def abi = findValueForSplit(split, splitsInfo.abiFilters)
+            directory = findManifestDirForSplit(density, abi, directory)
+            println("Density ${density}")
+            println("ABI ${abi}")
+            println("Directory ${directory}")
         }
         new File(directory, "AndroidManifest.xml")
     }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -19,7 +19,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
      * See: https://developer.android.com/studio/build/configure-apk-splits.html#build-apks-filename
      * https://issuetracker.google.com/issues/37085185
      */
-    private File getManifestPath() {
+    def File getManifestPath() {
         File directory = variantOutput.processManifest.manifestOutputDirectory
         String[] tokens = variantOutput.name.split("-")
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -1,8 +1,11 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.BaseVariantOutput
+import org.gradle.api.DefaultTask
 
-class ManifestOutputDir {
+class BugsnagVariantOutputTask extends DefaultTask {
+
+    BaseVariantOutput variantOutput
 
     /**
      * Gets the manifest for a given Variant Output, accounting for any APK splits.
@@ -16,9 +19,9 @@ class ManifestOutputDir {
      * See: https://developer.android.com/studio/build/configure-apk-splits.html#build-apks-filename
      * https://issuetracker.google.com/issues/37085185
      */
-    static File getManifestPath(BaseVariantOutput output) {
-        File directory = output.processManifest.manifestOutputDirectory
-        String[] tokens = output.name.split("-")
+    private File getManifestPath() {
+        File directory = variantOutput.processManifest.manifestOutputDirectory
+        String[] tokens = variantOutput.name.split("-")
 
         // when splits are enabled, the output has a name with the following structure:
         // e.g. "javaExample-hdpiMips-debug"
@@ -57,4 +60,5 @@ class ManifestOutputDir {
             manifestDir
         }
     }
+
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -5,6 +5,8 @@ import org.gradle.api.DefaultTask
 
 class BugsnagVariantOutputTask extends DefaultTask {
 
+    private static final String SPLIT_UNIVERSAL = "universal"
+
     BaseVariantOutput variantOutput
 
     /**
@@ -28,16 +30,20 @@ class BugsnagVariantOutputTask extends DefaultTask {
 
         if (tokens.length == 3) {
             def split = tokens[1]
-            def density = findValueForSplit(split, project.ext.splitsInfo.densityFilters)
-            def abi = findValueForSplit(split, project.ext.splitsInfo.abiFilters)
-            directory = findManifestDirForSplit(density, abi, directory)
+
+            if (SPLIT_UNIVERSAL == split) {
+                directory = new File(directory, SPLIT_UNIVERSAL)
+            } else {
+                def density = findValueForSplit(split, project.ext.splitsInfo.densityFilters)
+                def abi = findValueForSplit(split, project.ext.splitsInfo.abiFilters)
+                directory = findManifestDirForSplit(density, abi, directory)
+            }
         }
         def file = new File(directory, "AndroidManifest.xml")
 
         if (!file.exists()) {
             project.logger.error("Failed to find manifest at ${file}")
         }
-
         file
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -34,8 +34,8 @@ class BugsnagVariantOutputTask extends DefaultTask {
             if (SPLIT_UNIVERSAL == split) {
                 directory = new File(directory, SPLIT_UNIVERSAL)
             } else {
-                def density = findValueForSplit(split, project.ext.splitsInfo.densityFilters)
-                def abi = findValueForSplit(split, project.ext.splitsInfo.abiFilters)
+                def density = findValueForDensityFilter(split, project.ext.splitsInfo.densityFilters)
+                def abi = findValueForAbiFilter(split, project.ext.splitsInfo.abiFilters)
                 directory = findManifestDirForSplit(density, abi, directory)
             }
         }
@@ -47,9 +47,18 @@ class BugsnagVariantOutputTask extends DefaultTask {
         file
     }
 
-    private static String findValueForSplit(String split, Collection<String> values) {
+    private static String findValueForAbiFilter(String split, Collection<String> values) {
         for (String val : values) {
-            if (split.toLowerCase().contains(val.toLowerCase())) {
+            if (split.toLowerCase().endsWith(val.toLowerCase())) {
+                return val
+            }
+        }
+        null
+    }
+
+    private static String findValueForDensityFilter(String split, Collection<String> values) {
+        for (String val : values) {
+            if (split.toLowerCase().startsWith(val.toLowerCase())) {
                 return val
             }
         }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -28,24 +28,23 @@ class BugsnagVariantOutputTask extends DefaultTask {
 
         if (tokens.length == 3) {
             def split = tokens[1]
-            def splitsInfo = project.ext.splitsInfo
-            println("Manifest path ${splitsInfo}")
-
-
-            def density = findValueForSplit(split, splitsInfo.densityFilters)
-            def abi = findValueForSplit(split, splitsInfo.abiFilters)
+            def density = findValueForSplit(split, project.ext.splitsInfo.densityFilters)
+            def abi = findValueForSplit(split, project.ext.splitsInfo.abiFilters)
             directory = findManifestDirForSplit(density, abi, directory)
-            println("Density ${density}")
-            println("ABI ${abi}")
-            println("Directory ${directory}")
         }
-        new File(directory, "AndroidManifest.xml")
+        def file = new File(directory, "AndroidManifest.xml")
+
+        if (!file.exists()) {
+            project.logger.error("Failed to find manifest at ${file}")
+        }
+
+        file
     }
 
     private static String findValueForSplit(String split, Collection<String> values) {
         for (String val : values) {
-            if (split.contains(val)) {
-                return split
+            if (split.toLowerCase().contains(val.toLowerCase())) {
+                return val
             }
         }
         null

--- a/src/main/groovy/com/bugsnag/android/gradle/ManifestOutputDir.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/ManifestOutputDir.groovy
@@ -1,22 +1,24 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.BaseVariantOutput
+import com.bugsnag.android.gradle.BugsnagPlugin.SplitsInfo
 
 class ManifestOutputDir {
 
     /**
      * Gets the manifest for a given Variant Output, accounting for any APK splits.
      *
-     * Currently supported split types include Density, ABI, and Language.
+     * Currently supported split types include Density, and ABI. There is also a Language split,
+     * but it appears to be broken (see issuetracker)
      *
      * @param output the variant output
      * @return the manifest path
      *
      * See: https://developer.android.com/studio/build/configure-apk-splits.html#build-apks-filename
+     * https://issuetracker.google.com/issues/37085185
      */
-    static File getManifestPath(BaseVariantOutput output) {
+    static File getManifestPath(BaseVariantOutput output, SplitsInfo splitsInfo) {
         File directory = output.processManifest.manifestOutputDirectory
-        String[] split = output.name.split("-")
 
 //        if (split.length == 2) { // only 1 split enabled
 //            directory = new File(directory, split[1])

--- a/src/main/groovy/com/bugsnag/android/gradle/ManifestOutputDir.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/ManifestOutputDir.groovy
@@ -1,0 +1,21 @@
+package com.bugsnag.android.gradle
+
+import com.android.build.gradle.api.BaseVariantOutput
+
+class ManifestOutputDir {
+
+    static File getManifestPath(BaseVariantOutput output) {
+        File directory = output.getProcessManifest().getManifestOutputDirectory();
+        String name = output.getName();
+        String[] split = name.split("-");
+
+        // need to account for APK splits, see:
+        // https://developer.android.com/studio/build/configure-apk-splits.html#build-apks-filename
+
+        if (split.length > 1) {
+            directory = new File(output.getProcessManifest().getManifestOutputDirectory(), split[1]);
+        }
+        return new File(directory, "AndroidManifest.xml");
+    }
+
+}

--- a/src/main/groovy/com/bugsnag/android/gradle/ManifestOutputDir.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/ManifestOutputDir.groovy
@@ -18,12 +18,12 @@ class ManifestOutputDir {
         File directory = output.processManifest.manifestOutputDirectory
         String[] split = output.name.split("-")
 
-        if (split.length == 2) { // only 1 split enabled
-            directory = new File(directory, split[1])
-        } else if (split.length > 2) { // more than 1 split, need to determine order
-            def subdir = split[3] + File.separator + split[2] // N.B. order is reversed!
-            directory = new File(directory, subdir)
-        }
+//        if (split.length == 2) { // only 1 split enabled
+//            directory = new File(directory, split[1])
+//        } else if (split.length > 2) { // more than 1 split, need to determine order
+//            def subdir = split[2] + File.separator + split[1] // N.B. order is reversed!
+//            directory = new File(directory, subdir)
+//        }
         return new File(directory, "AndroidManifest.xml");
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/ManifestOutputDir.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/ManifestOutputDir.groovy
@@ -4,16 +4,25 @@ import com.android.build.gradle.api.BaseVariantOutput
 
 class ManifestOutputDir {
 
+    /**
+     * Gets the manifest for a given Variant Output, accounting for any APK splits.
+     *
+     * Currently supported split types include Density, ABI, and Language.
+     *
+     * @param output the variant output
+     * @return the manifest path
+     *
+     * See: https://developer.android.com/studio/build/configure-apk-splits.html#build-apks-filename
+     */
     static File getManifestPath(BaseVariantOutput output) {
-        File directory = output.getProcessManifest().getManifestOutputDirectory();
-        String name = output.getName();
-        String[] split = name.split("-");
+        File directory = output.processManifest.manifestOutputDirectory
+        String[] split = output.name.split("-")
 
-        // need to account for APK splits, see:
-        // https://developer.android.com/studio/build/configure-apk-splits.html#build-apks-filename
-
-        if (split.length > 1) {
-            directory = new File(output.getProcessManifest().getManifestOutputDirectory(), split[1]);
+        if (split.length == 2) { // only 1 split enabled
+            directory = new File(directory, split[1])
+        } else if (split.length > 2) { // more than 1 split, need to determine order
+            def subdir = split[3] + File.separator + split[2] // N.B. order is reversed!
+            directory = new File(directory, subdir)
         }
         return new File(directory, "AndroidManifest.xml");
     }

--- a/src/test/groovy/com/bugsnag/android/gradle/SmokeTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/SmokeTest.groovy
@@ -1,14 +1,18 @@
 package com.bugsnag.android.gradle
 
-import org.junit.Assert
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Test
 
+import static org.junit.Assert.assertEquals
 
 class SmokeTest {
 
     @Test
-    public void greeterPluginAddsGreetingTaskToProject() {
-        Assert.assertTrue(2 + 2 == 4)
+    void ensurePluginBuilds() {
+        Project project = ProjectBuilder.builder().build()
+        project.pluginManager.apply 'com.bugsnag.android.gradle'
+        assertEquals("https://upload.bugsnag.com", project.bugsnag.endpoint)
     }
 
 }

--- a/src/test/groovy/com/bugsnag/android/gradle/SmokeTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/SmokeTest.groovy
@@ -1,0 +1,14 @@
+package com.bugsnag.android.gradle
+
+import org.junit.Assert
+import org.junit.Test
+
+
+class SmokeTest {
+
+    @Test
+    public void greeterPluginAddsGreetingTaskToProject() {
+        Assert.assertTrue(2 + 2 == 4)
+    }
+
+}


### PR DESCRIPTION
Initial implementation of APK split support. This is achieved by finding the supported splits in the `SplitsDiscovery` task, and calculating the manifest path.

Other changes include:
- Finalising the uploadTask on `build`, so that it only runs once
- Creation of `BugsnagVariantOutputTask` to contain common functionality between tasks
- Disabling creation of upload/process tasks for debug builds

There is one breaking change to our exposed tasks, the manual upload would now look like this:
`./gradlew clean build uploadBugsnagJavaExample-releaseMapping`

Not ready to merge as we need to discuss whether there will be any API changes internally.
