### PR TITLE
Setup ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: groovy
+script: ./gradlew clean build --stacktrace
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/

--- a/build.gradle
+++ b/build.gradle
@@ -96,8 +96,8 @@ publishing {
 }
 // Bintray upload
 bintray {
-    user = "$bintray_user"
-    key = "$bintray_api_key"
+    user = hasProperty("bintray_user") ? "$bintray_user" : System.getenv("bintray_user")
+    key = hasProperty("bintray_api_key") ? "$bintray_api_key" : System.getenv("bintray_api_key")
     publications = ['Publication']
     pkg {
         repo = 'maven'


### PR DESCRIPTION
Ensure that the project can build. Includes a minor adjustment to the build script - if the bintray credentials aren't present in a properties file, gradle will attempt to use a system environment variable with the same key.