### PR TITLE
Fix upload script null check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,8 +98,8 @@ publishing {
 
 // Bintray upload
 bintray {
-    user = "$bintray_user" != null ? "$bintray_user" : System.getenv("bintray_user")
-    key = "$bintray_api_key" != null ? "$bintray_api_key" : System.getenv("bintray_api_key")
+    user = hasProperty("bintray_user") && "$bintray_user" != null ? "$bintray_user" : System.getenv("bintray_user")
+    key = hasProperty("bintray_api_key") && "$bintray_api_key" != null ? "$bintray_api_key" : System.getenv("bintray_api_key")
 
     publications = ['Publication']
     pkg {

--- a/build.gradle
+++ b/build.gradle
@@ -95,10 +95,12 @@ publishing {
         }
     }
 }
+
 // Bintray upload
 bintray {
-    user = hasProperty("bintray_user") ? "$bintray_user" : System.getenv("bintray_user")
-    key = hasProperty("bintray_api_key") ? "$bintray_api_key" : System.getenv("bintray_api_key")
+    user = "$bintray_user" != null ? "$bintray_user" : System.getenv("bintray_user")
+    key = "$bintray_api_key" != null ? "$bintray_api_key" : System.getenv("bintray_api_key")
+
     publications = ['Publication']
     pkg {
         repo = 'maven'


### PR DESCRIPTION
Adds a null check for `bintrayUpload` task, as the `hasProperty` check fails when uploading an archive.