### PR TITLE
Add splitsinfo task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,8 +97,9 @@ publishing {
 }
 // Bintray upload
 bintray {
-    user = hasProperty("bintray_user") ? "$bintray_user" : System.getenv("bintray_user")
-    key = hasProperty("bintray_api_key") ? "$bintray_api_key" : System.getenv("bintray_api_key")
+    user = hasProperty("bintray_user") && "$bintray_user" != null ? "$bintray_user" : System.getenv("bintray_user")
+    key = hasProperty("bintray_api_key") && "$bintray_api_key" != null ? "$bintray_api_key" : System.getenv("bintray_api_key")
+
     publications = ['Publication']
     pkg {
         repo = 'maven'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = com.bugsnag
-version = 3.0.0-beta4
+version = 3.0.0-beta5

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -53,7 +53,7 @@ class BugsnagPlugin implements Plugin<Project> {
      * Create tasks for each Build Variant
      * See https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/user-guide#TOC-Build-Variants
      */
-    private void applyBugsnagToVariant(BaseVariant variant, Project project) {
+    private static void applyBugsnagToVariant(BaseVariant variant, Project project) {
         if (hasDisabledBugsnag(variant)) {
             return
         }
@@ -65,7 +65,7 @@ class BugsnagPlugin implements Plugin<Project> {
         // need to be run for each output
         variant.outputs.all { output ->
             if (!output.name.toLowerCase().endsWith("debug") || project.bugsnag.uploadDebugBuildMappings) {
-                setupManifestUuidTask(project, output)
+                setupManifestUuidTask(project, output, variant)
                 setupMappingFileUpload(project, variant, output)
                 setupNdkMappingFileUpload(project, variant, output)
             }
@@ -75,14 +75,12 @@ class BugsnagPlugin implements Plugin<Project> {
     /**
      * Latch on to the splits discovery task and store the split types as Set<String> in project.ext
      */
-    private void setupSplitsDiscovery(Project project, BaseVariant variant) {
-        def task = project.tasks.findByName("splitsDiscoveryTask${taskNameForVariant(variant)}")
-        task.doLast {
-            project.ext.splitsInfo = new SplitsInfo()
-            project.ext.splitsInfo.densityFilters = task.densityFilters
-            project.ext.splitsInfo.languageFilters = task.languageFilters
-            project.ext.splitsInfo.abiFilters = task.abiFilters
-        }
+    private static void setupSplitsDiscovery(Project project, BaseVariant variant) {
+        BugsnagSplitsInfoTask splitsInfoTask = project.tasks.create("bugsnagSplitsInfo${taskNameForVariant(variant)}", BugsnagSplitsInfoTask)
+        splitsInfoTask.group = GROUP_NAME
+        splitsInfoTask.variant = variant
+        variant.packageApplication.dependsOn splitsInfoTask
+        splitsInfoTask.mustRunAfter variant.outputs.first().processManifest
     }
 
     /**
@@ -127,9 +125,10 @@ class BugsnagPlugin implements Plugin<Project> {
         }
     }
 
-    private static void setupManifestUuidTask(Project project, BaseVariantOutput output) {
+    private static void setupManifestUuidTask(Project project, BaseVariantOutput output, BaseVariant baseVariant) {
         BugsnagManifestTask manifestTask = project.tasks.create("processBugsnag${taskNameForOutput(output)}Manifest", BugsnagManifestTask)
         manifestTask.variantOutput = output
+        manifestTask.variant = baseVariant
         manifestTask.group = GROUP_NAME
         manifestTask.mustRunAfter output.processManifest
         output.packageApplication.dependsOn manifestTask
@@ -161,11 +160,11 @@ class BugsnagPlugin implements Plugin<Project> {
         }
     }
 
-    private static String taskNameForVariant(BaseVariant variant) {
+    static String taskNameForVariant(BaseVariant variant) {
         variant.name.capitalize()
     }
 
-    private static String taskNameForOutput(BaseVariantOutput output) {
+    static String taskNameForOutput(BaseVariantOutput output) {
         output.name.capitalize()
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -28,12 +28,6 @@ class BugsnagPlugin implements Plugin<Project> {
     static final String BUILD_UUID_TAG = 'com.bugsnag.android.BUILD_UUID'
     static final String GROUP_NAME = 'Bugsnag'
 
-    class SplitsInfo {
-        def densityFilters
-        def languageFilters
-        def abiFilters
-    }
-
     void apply(Project project) {
         project.extensions.create("bugsnag", BugsnagPluginExtension)
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagSplitsInfoTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagSplitsInfoTask.groovy
@@ -8,7 +8,9 @@ import org.gradle.api.tasks.TaskAction
 class BugsnagSplitsInfoTask extends DefaultTask {
 
     BaseVariant variant
-    BugsnagPlugin.SplitsInfo splitsInfo
+    def densityFilters
+    def languageFilters
+    def abiFilters
 
     BugsnagSplitsInfoTask() {
         super()
@@ -23,12 +25,9 @@ class BugsnagSplitsInfoTask extends DefaultTask {
         if (task == null) {
             throw new IllegalStateException("Could not find task: ${taskName}")
         }
-
-        this.splitsInfo = new BugsnagPlugin.SplitsInfo()
-        this.splitsInfo.densityFilters = task.densityFilters
-        this.splitsInfo.languageFilters = task.languageFilters
-        this.splitsInfo.abiFilters = task.abiFilters
-        println("Density: ${this.splitsInfo.densityFilters}")
+        this.densityFilters = task.densityFilters
+        this.languageFilters = task.languageFilters
+        this.abiFilters = task.abiFilters
     }
 
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagSplitsInfoTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagSplitsInfoTask.groovy
@@ -1,0 +1,34 @@
+package com.bugsnag.android.gradle
+
+import com.android.build.gradle.api.BaseVariant
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+
+class BugsnagSplitsInfoTask extends DefaultTask {
+
+    BaseVariant variant
+    BugsnagPlugin.SplitsInfo splitsInfo
+
+    BugsnagSplitsInfoTask() {
+        super()
+        this.description = "Discovers information about APK splits"
+    }
+
+    @TaskAction
+    def discoverSplitsInfo() {
+        def taskName = "splitsDiscoveryTask${BugsnagPlugin.taskNameForVariant(variant)}"
+        def task = project.tasks.findByName(taskName)
+
+        if (task == null) {
+            throw new IllegalStateException("Could not find task: ${taskName}")
+        }
+
+        this.splitsInfo = new BugsnagPlugin.SplitsInfo()
+        this.splitsInfo.densityFilters = task.densityFilters
+        this.splitsInfo.languageFilters = task.languageFilters
+        this.splitsInfo.abiFilters = task.abiFilters
+        println("Density: ${this.splitsInfo.densityFilters}")
+    }
+
+}

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagSplitsInfoTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagSplitsInfoTask.groovy
@@ -22,12 +22,14 @@ class BugsnagSplitsInfoTask extends DefaultTask {
         def taskName = "splitsDiscoveryTask${BugsnagPlugin.taskNameForVariant(variant)}"
         def task = project.tasks.findByName(taskName)
 
-        if (task == null) {
-            throw new IllegalStateException("Could not find task: ${taskName}")
+        if (task != null) {
+            this.densityFilters = task.densityFilters
+            this.languageFilters = task.languageFilters
+            this.abiFilters = task.abiFilters
+        } else {
+            project.logger.error("Failed to find splits task ${taskName}")
         }
-        this.densityFilters = task.densityFilters
-        this.languageFilters = task.languageFilters
-        this.abiFilters = task.abiFilters
+
     }
 
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadAbstractTask.groovy
@@ -1,6 +1,5 @@
 package com.bugsnag.android.gradle
 
-import com.android.build.gradle.api.BaseVariant
 import groovy.xml.Namespace
 import org.apache.http.HttpResponse
 import org.apache.http.client.HttpClient
@@ -29,7 +28,6 @@ abstract class BugsnagUploadAbstractTask extends BugsnagVariantOutputTask {
     static final int MAX_RETRY_COUNT = 5
     static final int TIMEOUT_MILLIS = 60000 // 60 seconds
 
-    BaseVariant variant
     String applicationId
 
     // Read from the manifest file

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -57,8 +57,8 @@ class BugsnagVariantOutputTask extends DefaultTask {
         if (SPLIT_UNIVERSAL == split) {
             directory = new File(directory, SPLIT_UNIVERSAL)
         } else {
-            def density = findValueForDensityFilter(split, task.splitsInfo.densityFilters)
-            def abi = findValueForAbiFilter(split, task.splitsInfo.abiFilters)
+            def density = findValueForDensityFilter(split, task.densityFilters)
+            def abi = findValueForAbiFilter(split, task.abiFilters)
             directory = findManifestDirForSplit(density, abi, directory)
         }
         directory

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -1,5 +1,6 @@
 package com.bugsnag.android.gradle
 
+import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
 import org.gradle.api.DefaultTask
 
@@ -8,6 +9,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
     private static final String SPLIT_UNIVERSAL = "universal"
 
     BaseVariantOutput variantOutput
+    BaseVariant variant
 
     /**
      * Gets the manifest for a given Variant Output, accounting for any APK splits.
@@ -45,11 +47,18 @@ class BugsnagVariantOutputTask extends DefaultTask {
     }
 
     private File guessManifestDir(File directory, String split) {
+        String taskName = "bugsnagSplitsInfo${BugsnagPlugin.taskNameForVariant(variant)}"
+        def task = project.tasks.findByName(taskName)
+
+        if (task == null) {
+            throw new IllegalStateException("No task found matching ${taskName}")
+        }
+
         if (SPLIT_UNIVERSAL == split) {
             directory = new File(directory, SPLIT_UNIVERSAL)
         } else {
-            def density = findValueForDensityFilter(split, project.ext.splitsInfo.densityFilters)
-            def abi = findValueForAbiFilter(split, project.ext.splitsInfo.abiFilters)
+            def density = findValueForDensityFilter(split, task.splitsInfo.densityFilters)
+            def abi = findValueForAbiFilter(split, task.splitsInfo.abiFilters)
             directory = findManifestDirForSplit(density, abi, directory)
         }
         directory

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -50,16 +50,16 @@ class BugsnagVariantOutputTask extends DefaultTask {
         String taskName = "bugsnagSplitsInfo${BugsnagPlugin.taskNameForVariant(variant)}"
         def task = project.tasks.findByName(taskName)
 
-        if (task == null) {
-            throw new IllegalStateException("No task found matching ${taskName}")
-        }
-
-        if (SPLIT_UNIVERSAL == split) {
-            directory = new File(directory, SPLIT_UNIVERSAL)
+        if (task != null) {
+            if (SPLIT_UNIVERSAL == split) {
+                directory = new File(directory, SPLIT_UNIVERSAL)
+            } else {
+                def density = findValueForDensityFilter(split, task.densityFilters)
+                def abi = findValueForAbiFilter(split, task.abiFilters)
+                directory = findManifestDirForSplit(density, abi, directory)
+            }
         } else {
-            def density = findValueForDensityFilter(split, task.densityFilters)
-            def abi = findValueForAbiFilter(split, task.abiFilters)
-            directory = findManifestDirForSplit(density, abi, directory)
+            project.logger.error("Failed to find task ${taskName}")
         }
         directory
     }


### PR DESCRIPTION
Adds a separate task which retains information on which APK splits are available. This is more extensible than storing the values in project properties, which isn't recommended for plugins.

Tested in the following scenarios:

`./gradlew clean build && ./gradlew build`
`./gradlew build :example:uploadBugsnagKotlinExample-mdpiX86-releaseMapping`

Fixes #59 