### PR TITLE
Support upload of library mapping files

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = com.bugsnag
-version = 3.0.0-beta3
+version = 3.0.0-beta4

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -125,7 +125,7 @@ class BugsnagPlugin implements Plugin<Project> {
     private static void setupManifestUuidTask(Project project, BaseVariant variant, BaseVariantOutput output) {
         BugsnagManifestTask manifestTask = project.tasks.create("processBugsnag${taskNameForOutput(output)}Manifest", BugsnagManifestTask)
         manifestTask.variantOutput = output
-        manifestTask.variant = baseVariant
+        manifestTask.variant = variant
         manifestTask.group = GROUP_NAME
         manifestTask.mustRunAfter output.processManifest
         dependTaskOnPackageTask(variant, manifestTask)


### PR DESCRIPTION
Adds support for uploading mapping files from a library variant. Changes include using the `BaseVariant` superclass rather than APK/Library specific classes, and altering the tasks upon which the upload tasks depend.

There have been changes in #60 which will need to be rebased onto this and adapted, so it would be good if that could be reviewed before this.