### PR TITLE
Use AGP 3 dsl to locate cmake so files

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = com.bugsnag
-version = 3.1.0
+version = 3.1.1

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -91,15 +91,11 @@ class BugsnagPlugin implements Plugin<Project> {
 
     private static void setupNdkMappingFileUpload(Project project, BaseVariant variant, BaseVariantOutput output) {
         if (project.bugsnag.ndk) {
-            File symbolPath = getSymbolPath(output)
-            File intermediatePath = getIntermediatePath(symbolPath)
 
             // Create a Bugsnag task to upload NDK mapping file(s)
             BugsnagUploadNdkTask uploadNdkTask = project.tasks.create("uploadBugsnagNdk${taskNameForOutput(output)}Mapping", BugsnagUploadNdkTask)
             prepareUploadTask(uploadNdkTask, output, variant, project)
 
-            uploadNdkTask.intermediatePath = intermediatePath
-            uploadNdkTask.symbolPath = symbolPath
             uploadNdkTask.variantName = taskNameForVariant(variant)
             uploadNdkTask.projectDir = project.projectDir
             uploadNdkTask.rootDir = project.rootDir
@@ -204,24 +200,6 @@ class BugsnagPlugin implements Plugin<Project> {
 
         // Ignore any conflicting properties, bail if anything has a disable flag.
         return (variant.productFlavors + variant.buildType).any(hasDisabledBugsnag)
-    }
-
-    private static File getIntermediatePath(File symbolPath) {
-        def intermediatePath = null
-
-        if (symbolPath != null) {
-            intermediatePath = symbolPath.parentFile.parentFile
-        }
-        intermediatePath
-    }
-
-    private static File getSymbolPath(BaseVariantOutput variantOutput) {
-        def symbolPath = variantOutput.processResources.textSymbolOutputFile
-
-        if (symbolPath == null) {
-            throw new IllegalStateException("Could not find symbol path")
-        }
-        symbolPath
     }
 
     /**


### PR DESCRIPTION
Changes in the AGP 3 DSL mean that output files are no longer guaranteed to be present during the configuration phase. This alters the plugin so that it looks up the outputFiles after packaging.

The NDKHandler constructor also has an additional parameter, the default value has been supplied.

The plugin now relies on the `cmakeOptions` task, which contains the locations of object files, rather than guessing their location