### PR TITLE
Auto-detect ndk project

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = com.bugsnag
-version = 3.1.1
+version = 3.1.2

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -90,7 +90,8 @@ class BugsnagPlugin implements Plugin<Project> {
     }
 
     private static void setupNdkMappingFileUpload(Project project, BaseVariant variant, BaseVariantOutput output) {
-        if (project.bugsnag.ndk) {
+        if (isNdkProject(project)) {
+            project.logger.lifecycle("is ndk project")
 
             // Create a Bugsnag task to upload NDK mapping file(s)
             BugsnagUploadNdkTask uploadNdkTask = project.tasks.create("uploadBugsnagNdk${taskNameForOutput(output)}Mapping", BugsnagUploadNdkTask)
@@ -101,6 +102,15 @@ class BugsnagPlugin implements Plugin<Project> {
             uploadNdkTask.rootDir = project.rootDir
             uploadNdkTask.toolchain = getCmakeToolchain(project, variant)
             uploadNdkTask.sharedObjectPath = project.bugsnag.sharedObjectPath
+        } else {
+            project.logger.lifecycle("is not ndk project")
+        }
+    }
+
+    private static boolean isNdkProject(Project project) {
+        def tasks = project.tasks.findAll()
+        return tasks.stream().anyMatch {
+            it.name.startsWith("externalNativeBuild")
         }
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -91,8 +91,6 @@ class BugsnagPlugin implements Plugin<Project> {
 
     private static void setupNdkMappingFileUpload(Project project, BaseVariant variant, BaseVariantOutput output) {
         if (isNdkProject(project)) {
-            project.logger.lifecycle("is ndk project")
-
             // Create a Bugsnag task to upload NDK mapping file(s)
             BugsnagUploadNdkTask uploadNdkTask = project.tasks.create("uploadBugsnagNdk${taskNameForOutput(output)}Mapping", BugsnagUploadNdkTask)
             prepareUploadTask(uploadNdkTask, output, variant, project)
@@ -102,8 +100,6 @@ class BugsnagPlugin implements Plugin<Project> {
             uploadNdkTask.rootDir = project.rootDir
             uploadNdkTask.toolchain = getCmakeToolchain(project, variant)
             uploadNdkTask.sharedObjectPath = project.bugsnag.sharedObjectPath
-        } else {
-            project.logger.lifecycle("is not ndk project")
         }
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -104,9 +104,13 @@ class BugsnagPlugin implements Plugin<Project> {
     }
 
     private static boolean isNdkProject(Project project) {
-        def tasks = project.tasks.findAll()
-        return tasks.stream().anyMatch {
-            it.name.startsWith("externalNativeBuild")
+        if (project.bugsnag.ndk != null) { // always respect user override
+            return project.bugsnag.ndk
+        } else { // infer whether native build or not
+            def tasks = project.tasks.findAll()
+            return tasks.stream().anyMatch {
+                it.name.startsWith("externalNativeBuild")
+            }
         }
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
@@ -11,6 +11,6 @@ class BugsnagPluginExtension {
     def boolean uploadDebugBuildMappings = false
     def boolean overwrite = false
     def int retryCount = 0
-    def boolean ndk = false
+    def Boolean ndk = null
     def String sharedObjectPath = null
 }

--- a/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
@@ -26,7 +26,7 @@ class PluginExtensionTest {
         assertFalse(proj.bugsnag.uploadDebugBuildMappings)
         assertFalse(proj.bugsnag.overwrite)
         assertEquals(0, proj.bugsnag.retryCount)
-        assertFalse(proj.bugsnag.ndk)
+        assertNull(proj.bugsnag.ndk)
         assertNull(proj.bugsnag.sharedObjectPath)
     }
 


### PR DESCRIPTION
Automatically detects the presence of an NDK project by checking for the presence of an [ExternalNativeBuild](https://google.github.io/android-gradle-dsl/current/com.android.build.gradle.internal.dsl.ExternalNativeBuild.html) task. This makes `project.bugsnag.ndk` obsolete.