### PR TITLE
Create ndk task to automatically copy files

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = com.bugsnag
-version = 3.2.0
+version = 3.2.1

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
@@ -1,0 +1,35 @@
+package com.bugsnag.android.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+class BugsnagNdkSetupTask extends DefaultTask {
+
+    BugsnagNdkSetupTask() {
+        super()
+        this.description = "Assembles information about the build that will be sent to the releases API"
+    }
+
+    @TaskAction
+    void setupNdkProject() {
+        def configs = project.configurations.findAll {
+            it.toString().contains('CompileClasspath')
+        }.each { config ->
+            def artifactFile = config.resolvedConfiguration.getFiles().find {
+                it.toString().contains("bugsnag-android-ndk")
+            }
+            if (artifactFile) {
+                File buildDir = project.buildDir
+                File dst = new File(buildDir, "/intermediates/bugsnag-libs")
+
+                project.copy {
+                    from project.zipTree(artifactFile)
+                    into(project.file(dst))
+                }
+            }
+        }
+    }
+
+}
+
+

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
@@ -7,7 +7,7 @@ class BugsnagNdkSetupTask extends DefaultTask {
 
     BugsnagNdkSetupTask() {
         super()
-        this.description = "Assembles information about the build that will be sent to the releases API"
+        this.description = "Copies shared object files from the bugsnag-android AAR to the required build directory"
     }
 
     @TaskAction


### PR DESCRIPTION
Automatically copies shared object files into the relevant build directory for NDK projects, negating the need for users to add their own gradle task as part of setup