### PR TITLE
Remove reference to removed splits task

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = com.bugsnag
-version = 3.2.3
-example_plugin_version = 3.2.3
+version = 3.2.4
+example_plugin_version = 3.2.2
 
 ANDROID_MIN_SDK_VERSION=14
 ANDROID_TARGET_SDK_VERSION=27

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -89,7 +89,6 @@ class BugsnagPlugin implements Plugin<Project> {
                 BugsnagTaskDeps deps = new BugsnagTaskDeps()
                 deps.variant = variant
                 deps.output = output
-                deps.splitsTask = splitsTask
 
                 setupManifestUuidTask(project, deps)
                 setupMappingFileUpload(project, deps)
@@ -150,7 +149,6 @@ class BugsnagPlugin implements Plugin<Project> {
         task.group = GROUP_NAME
         task.variantOutput = deps.output
         task.variant = deps.variant
-        task.dependsOn deps.splitsTask
     }
 
     private static void prepareUploadTask(BugsnagMultiPartUploadTask uploadTask, BugsnagTaskDeps deps, Project project) {
@@ -357,6 +355,5 @@ class BugsnagPlugin implements Plugin<Project> {
     private static class BugsnagTaskDeps {
         BaseVariant variant
         BaseVariantOutput output
-        def splitsTask
     }
 }


### PR DESCRIPTION
The Splits task was removed but erroneously referenced in the plugin, resulting in a build failure.

Fixes #83 