### PR TITLE
Finalise uuid generation on process manifest task

### DIFF
--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -194,8 +194,8 @@ class BugsnagPlugin implements Plugin<Project> {
     private static void setupManifestUuidTask(Project project, BugsnagTaskDeps deps) {
         BugsnagManifestTask manifestTask = project.tasks.create("processBugsnag${taskNameForOutput(deps.output)}Manifest", BugsnagManifestTask)
         setupBugsnagTask(manifestTask, deps)
-        manifestTask.mustRunAfter deps.output.processManifest
-        dependTaskOnPackageTask(deps.variant, manifestTask)
+        def processManifest = deps.output.processManifest
+        processManifest.finalizedBy(manifestTask)
     }
 
     /**


### PR DESCRIPTION
Finalises UUID generation on process manifest, rather than executing task after.