### PR TITLE
Add manual upload task step

### DIFF
--- a/features/scripts/upload_variant_mapping.sh
+++ b/features/scripts/upload_variant_mapping.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [ -z "$VARIANT_OUTPUT_NAME" ]; then
+    echo VARIANT_OUTPUT_NAME environment variable is not set
+    exit 1
+fi
+
+cd features/fixtures/app
+./gradlew :module:clean :module:build uploadBugsnag${VARIANT_OUTPUT_NAME}Mapping --stacktrace

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -6,3 +6,13 @@ steps %Q{
   And I wait for 1 second
 }
 end
+
+When("I build the {string} variantOutput for {string} using the {string} bugsnag config") do |variant, module_config, bugsnag_config|
+steps %Q{
+  When I set environment variable "VARIANT_OUTPUT_NAME" to "#{variant}"
+  When I set environment variable "MODULE_CONFIG" to "#{module_config}"
+  When I set environment variable "BUGSNAG_CONFIG" to "#{bugsnag_config}"
+  And I run the script "features/scripts/upload_variant_mapping.sh" synchronously
+  And I wait for 1 second
+}
+end


### PR DESCRIPTION
Adds a step for running a manual upload task, e.g.

`When I build the "Release" variantOutput for "default_app" using the "standard" bugsnag config`