### PR TITLE
Add default app scenario

### DIFF
--- a/features/default_app.feature
+++ b/features/default_app.feature
@@ -1,5 +1,29 @@
 Feature: Plugin integrated in default app
 
-Scenario: Project builds successfully
+Scenario: Single-module default app builds successfully
     When I build "default_app" using the "standard" bugsnag config
-    Then I should receive a request
+    Then I should receive 2 requests
+
+    And the request 0 is valid for the Build API
+    And the payload field "appVersion" equals "1.0" for request 0
+    And the payload field "apiKey" equals "TEST_API_KEY" for request 0
+    And the payload field "builderName" is not null for request 0
+    And the payload field "buildTool" equals "gradle-android" for request 0
+    And the payload field "appVersionCode" equals "1" for request 0
+    And the payload field "sourceControl.provider" equals "github" for request 0
+    And the payload field "sourceControl.repository" equals "https://github.com/bugsnag/bugsnag-android-gradle-plugin.git" for request 0
+    And the payload field "sourceControl.revision" is not null for request 0
+
+    And the payload field "metadata.os_arch" is not null for request 0
+    And the payload field "metadata.os_name" is not null for request 0
+    And the payload field "metadata.os_version" is not null for request 0
+    And the payload field "metadata.java_version" is not null for request 0
+    And the payload field "metadata.gradle_version" is not null for request 0
+    And the payload field "metadata.git_version" is not null for request 0
+
+    And the request 1 is valid for the Android Mapping API
+    And the part "apiKey" for request 1 equals "TEST_API_KEY"
+    And the part "versionCode" for request 1 equals "1"
+    And the part "versionName" for request 1 equals "1.0"
+    And the part "appId" for request 1 equals "com.bugsnag.android.example"
+

--- a/features/fixtures/app/module/config/android/common.gradle
+++ b/features/fixtures/app/module/config/android/common.gradle
@@ -3,6 +3,7 @@ android {
     buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
 
     defaultConfig {
+        applicationId 'com.bugsnag.android.example'
         minSdkVersion Integer.parseInt(project.ANDROID_MIN_SDK_VERSION)
         targetSdkVersion Integer.parseInt(project.ANDROID_TARGET_SDK_VERSION)
         versionCode Integer.parseInt(project.SAMPLE_VERSION_CODE)

--- a/features/fixtures/app/module/src/main/AndroidManifest.xml
+++ b/features/fixtures/app/module/src/main/AndroidManifest.xml
@@ -4,6 +4,6 @@
 
     <meta-data
       android:name="com.bugsnag.android.API_KEY"
-      android:value="YOUR_API_KEY" />
+      android:value="TEST_API_KEY" />
   </application>
 </manifest>

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
@@ -150,12 +150,12 @@ class BugsnagReleasesTask extends BugsnagVariantOutputTask {
 
     private Map<String, String> collectDefaultMetaData() {
         Map<String, String> metadata = new HashMap<>()
-        metadata.put(MK_OS_ARCH.replaceAll(".", "_"), System.getProperty(MK_OS_ARCH))
-        metadata.put(MK_OS_NAME.replaceAll(".", "_"), System.getProperty(MK_OS_NAME))
-        metadata.put(MK_OS_VERSION.replaceAll(".", "_"), System.getProperty(MK_OS_VERSION))
-        metadata.put(MK_JAVA_VERSION.replaceAll(".", "_"), System.getProperty(MK_JAVA_VERSION))
-        metadata.put(MK_GRADLE_VERSION.replaceAll(".", "_"), project.gradle.gradleVersion)
-        metadata.put(MK_GIT_VERSION.replaceAll(".", "_"), runCmd("git", "--version"))
+        metadata.put("os_arch", System.getProperty(MK_OS_ARCH))
+        metadata.put("os_name", System.getProperty(MK_OS_NAME))
+        metadata.put("os_version", System.getProperty(MK_OS_VERSION))
+        metadata.put("java_version", System.getProperty(MK_JAVA_VERSION))
+        metadata.put("gradle_version", project.gradle.gradleVersion)
+        metadata.put("git_version", runCmd("git", "--version"))
         metadata
     }
 


### PR DESCRIPTION
Adds a scenario to validate the payload in a default Android application. Also fixes metadata serialisation keys in the build API.