### PR TITLE
Add scenario for density apk splits

### DIFF
--- a/features/density_splits.feature
+++ b/features/density_splits.feature
@@ -1,0 +1,43 @@
+Feature: Plugin integrated in project with Density APK splits
+
+Scenario: Density Splits project builds successfully
+    When I build "density_splits" using the "standard" bugsnag config
+    Then I should receive 14 request
+
+    And the request 0 is valid for the Build API
+    And the request 1 is valid for the Build API
+    And the request 2 is valid for the Build API
+    And the request 3 is valid for the Build API
+    And the request 4 is valid for the Build API
+    And the request 5 is valid for the Build API
+    And the request 6 is valid for the Build API
+
+    And the payload field "appVersion" equals "1.0" for request 0
+    And the payload field "apiKey" equals "TEST_API_KEY" for request 0
+    And the payload field "appVersionCode" equals "1" for request 0
+
+    And the request 7 is valid for the Android Mapping API
+    And the request 8 is valid for the Android Mapping API
+    And the request 9 is valid for the Android Mapping API
+    And the request 10 is valid for the Android Mapping API
+    And the request 11 is valid for the Android Mapping API
+    And the request 12 is valid for the Android Mapping API
+    And the request 13 is valid for the Android Mapping API
+
+    And the part "apiKey" for request 7 equals "TEST_API_KEY"
+    And the part "versionCode" for request 7 equals "1"
+    And the part "versionName" for request 7 equals "1.0"
+    And the part "appId" for request 7 equals "com.bugsnag.android.example"
+
+Scenario: Density Splits automatic upload disabled
+    When I build "density_splits" using the "all_disabled" bugsnag config
+    Then I should receive no requests
+
+Scenario: Density Splits manual upload of build API
+    When I build the "Hdpi-release" variantOutput for "density_splits" using the "all_disabled" bugsnag config
+    Then I should receive 1 request
+    And the request 0 is valid for the Android Mapping API
+    And the part "apiKey" for request 0 equals "TEST_API_KEY"
+    And the part "versionCode" for request 0 equals "1"
+    And the part "versionName" for request 0 equals "1.0"
+    And the part "appId" for request 0 equals "com.bugsnag.android.example"

--- a/features/density_splits.feature
+++ b/features/density_splits.feature
@@ -2,30 +2,52 @@ Feature: Plugin integrated in project with Density APK splits
 
 Scenario: Density Splits project builds successfully
     When I build "density_splits" using the "standard" bugsnag config
-    Then I should receive 14 request
+    Then I should receive 14 requests
 
     And the request 0 is valid for the Build API
-    And the request 1 is valid for the Build API
-    And the request 2 is valid for the Build API
-    And the request 3 is valid for the Build API
-    And the request 4 is valid for the Build API
-    And the request 5 is valid for the Build API
-    And the request 6 is valid for the Build API
+    And the payload field "appVersionCode" equals "4" for request 0
 
-    And the payload field "appVersion" equals "1.0" for request 0
-    And the payload field "apiKey" equals "TEST_API_KEY" for request 0
-    And the payload field "appVersionCode" equals "1" for request 0
+    And the request 1 is valid for the Build API
+    And the payload field "appVersionCode" equals "2" for request 1
+
+    And the request 2 is valid for the Build API
+    And the payload field "appVersionCode" equals "3" for request 2
+
+    And the request 3 is valid for the Build API
+    And the payload field "appVersionCode" equals "1" for request 3
+
+    And the request 4 is valid for the Build API
+    And the payload field "appVersionCode" equals "5" for request 4
+
+    And the request 5 is valid for the Build API
+    And the payload field "appVersionCode" equals "6" for request 5
+
+    And the request 6 is valid for the Build API
+    And the payload field "appVersionCode" equals "7" for request 6
+    And the payload field "appVersion" equals "1.0" for request 6
+    And the payload field "apiKey" equals "TEST_API_KEY" for request 6
 
     And the request 7 is valid for the Android Mapping API
-    And the request 8 is valid for the Android Mapping API
-    And the request 9 is valid for the Android Mapping API
-    And the request 10 is valid for the Android Mapping API
-    And the request 11 is valid for the Android Mapping API
-    And the request 12 is valid for the Android Mapping API
-    And the request 13 is valid for the Android Mapping API
+    And the part "versionCode" for request 7 equals "4"
 
+    And the request 8 is valid for the Android Mapping API
+    And the part "versionCode" for request 8 equals "2"
+
+    And the request 9 is valid for the Android Mapping API
+    And the part "versionCode" for request 9 equals "3"
+
+    And the request 10 is valid for the Android Mapping API
+    And the part "versionCode" for request 10 equals "1"
+
+    And the request 11 is valid for the Android Mapping API
+    And the part "versionCode" for request 11 equals "5"
+
+    And the request 12 is valid for the Android Mapping API
+    And the part "versionCode" for request 12 equals "6"
+
+    And the request 13 is valid for the Android Mapping API
+    And the part "versionCode" for request 13 equals "7"
     And the part "apiKey" for request 7 equals "TEST_API_KEY"
-    And the part "versionCode" for request 7 equals "1"
     And the part "versionName" for request 7 equals "1.0"
     And the part "appId" for request 7 equals "com.bugsnag.android.example"
 
@@ -38,6 +60,6 @@ Scenario: Density Splits manual upload of build API
     Then I should receive 1 request
     And the request 0 is valid for the Android Mapping API
     And the part "apiKey" for request 0 equals "TEST_API_KEY"
-    And the part "versionCode" for request 0 equals "1"
+    And the part "versionCode" for request 0 equals "4"
     And the part "versionName" for request 0 equals "1.0"
     And the part "appId" for request 0 equals "com.bugsnag.android.example"

--- a/features/fixtures/app/module/config/android/density_splits.gradle
+++ b/features/fixtures/app/module/config/android/density_splits.gradle
@@ -1,0 +1,10 @@
+apply plugin: 'com.android.application'
+apply from: 'config/android/common.gradle'
+
+android {
+    splits {
+        density {
+            enable true
+        }
+    }
+}

--- a/features/fixtures/app/module/config/android/density_splits.gradle
+++ b/features/fixtures/app/module/config/android/density_splits.gradle
@@ -1,10 +1,22 @@
 apply plugin: 'com.android.application'
 apply from: 'config/android/common.gradle'
 
+ext.densityCodes = [ldpi:2, mdpi:3, hdpi:4, xhdpi:5, xxhdpi:6, xxxhdpi:7]
+
 android {
     splits {
         density {
             enable true
+        }
+    }
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            def densityVersionCode =
+                project.ext.densityCodes.get(output.getFilter("DENSITY"))
+
+            if (densityVersionCode != null) {
+                output.versionCodeOverride = densityVersionCode
+            }
         }
     }
 }


### PR DESCRIPTION
Adds a scenario for APK splits by resource density (e.g. xxhdpi).

The version code is overriden for each variantOutput, allowing validation that the correct request has been received by checking this value.