### PR TITLE
Update multipart request scenarios to use new syntax

### DIFF
--- a/features/abi_apk_splits.feature
+++ b/features/abi_apk_splits.feature
@@ -31,31 +31,31 @@ Scenario: ABI Splits project builds successfully
     And the payload field "apiKey" equals "TEST_API_KEY" for request 7
 
     And the request 8 is valid for the Android Mapping API
-    And the part "versionCode" for request 8 equals "2"
+    And the field "versionCode" for multipart request 8 equals "2"
 
     And the request 9 is valid for the Android Mapping API
-    And the part "versionCode" for request 9 equals "3"
+    And the field "versionCode" for multipart request 9 equals "3"
 
     And the request 10 is valid for the Android Mapping API
-    And the part "versionCode" for request 10 equals "4"
+    And the field "versionCode" for multipart request 10 equals "4"
 
     And the request 11 is valid for the Android Mapping API
-    And the part "versionCode" for request 11 equals "5"
+    And the field "versionCode" for multipart request 11 equals "5"
 
     And the request 12 is valid for the Android Mapping API
-    And the part "versionCode" for request 12 equals "6"
+    And the field "versionCode" for multipart request 12 equals "6"
 
     And the request 13 is valid for the Android Mapping API
-    And the part "versionCode" for request 13 equals "1"
+    And the field "versionCode" for multipart request 13 equals "1"
 
     And the request 14 is valid for the Android Mapping API
-    And the part "versionCode" for request 14 equals "7"
+    And the field "versionCode" for multipart request 14 equals "7"
 
     And the request 15 is valid for the Android Mapping API
-    And the part "versionCode" for request 15 equals "8"
-    And the part "apiKey" for request 15 equals "TEST_API_KEY"
-    And the part "versionName" for request 15 equals "1.0"
-    And the part "appId" for request 15 equals "com.bugsnag.android.example"
+    And the field "versionCode" for multipart request 15 equals "8"
+    And the field "apiKey" for multipart request 15 equals "TEST_API_KEY"
+    And the field "versionName" for multipart request 15 equals "1.0"
+    And the field "appId" for multipart request 15 equals "com.bugsnag.android.example"
 
 Scenario: ABI Splits automatic upload disabled
     When I build "abi_splits" using the "all_disabled" bugsnag config
@@ -65,7 +65,7 @@ Scenario: ABI Splits manual upload of build API
     When I build the "Armeabi-release" variantOutput for "abi_splits" using the "all_disabled" bugsnag config
     Then I should receive 1 request
     And the request 0 is valid for the Android Mapping API
-    And the part "apiKey" for request 0 equals "TEST_API_KEY"
-    And the part "versionCode" for request 0 equals "3"
-    And the part "versionName" for request 0 equals "1.0"
-    And the part "appId" for request 0 equals "com.bugsnag.android.example"
+    And the field "apiKey" for multipart request 0 equals "TEST_API_KEY"
+    And the field "versionCode" for multipart request 0 equals "3"
+    And the field "versionName" for multipart request 0 equals "1.0"
+    And the field "appId" for multipart request 0 equals "com.bugsnag.android.example"

--- a/features/default_app.feature
+++ b/features/default_app.feature
@@ -22,7 +22,7 @@ Scenario: Single-module default app builds successfully
     And the payload field "metadata.git_version" is not null for request 0
 
     And the request 1 is valid for the Android Mapping API
-    And the part "apiKey" for request 1 equals "TEST_API_KEY"
-    And the part "versionCode" for request 1 equals "1"
-    And the part "versionName" for request 1 equals "1.0"
-    And the part "appId" for request 1 equals "com.bugsnag.android.example"
+    And the field "apiKey" for multipart request 1 equals "TEST_API_KEY"
+    And the field "versionCode" for multipart request 1 equals "1"
+    And the field "versionName" for multipart request 1 equals "1.0"
+    And the field "appId" for multipart request 1 equals "com.bugsnag.android.example"

--- a/features/default_lib.feature
+++ b/features/default_lib.feature
@@ -22,7 +22,7 @@ Scenario: Single-module default library builds successfully
     And the payload field "metadata.git_version" is not null for request 0
 
     And the request 1 is valid for the Android Mapping API
-    And the part "apiKey" for request 1 equals "TEST_API_KEY"
-    And the part "versionCode" for request 1 equals "1"
-    And the part "versionName" for request 1 equals "1.0"
-    And the part "appId" for request 1 equals "com.bugsnag.libvanilla"
+    And the field "apiKey" for multipart request 1 equals "TEST_API_KEY"
+    And the field "versionCode" for multipart request 1 equals "1"
+    And the field "versionName" for multipart request 1 equals "1.0"
+    And the field "appId" for multipart request 1 equals "com.bugsnag.libvanilla"

--- a/features/density_abi_splits.feature
+++ b/features/density_abi_splits.feature
@@ -44,43 +44,43 @@ Scenario: Density ABI Splits project builds successfully
     And the payload field "appVersionCode" equals "53" for request 12
 
     And the request 13 is valid for the Android Mapping API
-    And the part "versionCode" for request 13 equals "21"
+    And the field "versionCode" for multipart request 13 equals "21"
 
     And the request 14 is valid for the Android Mapping API
-    And the part "versionCode" for request 14 equals "31"
+    And the field "versionCode" for multipart request 14 equals "31"
 
     And the request 15 is valid for the Android Mapping API
-    And the part "versionCode" for request 15 equals "11"
+    And the field "versionCode" for multipart request 15 equals "11"
 
     And the request 16 is valid for the Android Mapping API
-    And the part "versionCode" for request 16 equals "41"
+    And the field "versionCode" for multipart request 16 equals "41"
 
     And the request 17 is valid for the Android Mapping API
-    And the part "versionCode" for request 17 equals "51"
+    And the field "versionCode" for multipart request 17 equals "51"
 
     And the request 18 is valid for the Android Mapping API
-    And the part "versionCode" for request 18 equals "22"
+    And the field "versionCode" for multipart request 18 equals "22"
 
     And the request 19 is valid for the Android Mapping API
-    And the part "versionCode" for request 19 equals "32"
+    And the field "versionCode" for multipart request 19 equals "32"
 
     And the request 20 is valid for the Android Mapping API
-    And the part "versionCode" for request 20 equals "42"
+    And the field "versionCode" for multipart request 20 equals "42"
 
     And the request 21 is valid for the Android Mapping API
-    And the part "versionCode" for request 21 equals "52"
+    And the field "versionCode" for multipart request 21 equals "52"
 
     And the request 22 is valid for the Android Mapping API
-    And the part "versionCode" for request 22 equals "23"
+    And the field "versionCode" for multipart request 22 equals "23"
 
     And the request 23 is valid for the Android Mapping API
-    And the part "versionCode" for request 23 equals "33"
+    And the field "versionCode" for multipart request 23 equals "33"
 
     And the request 24 is valid for the Android Mapping API
-    And the part "versionCode" for request 24 equals "43"
+    And the field "versionCode" for multipart request 24 equals "43"
 
     And the request 25 is valid for the Android Mapping API
-    And the part "versionCode" for request 25 equals "53"
+    And the field "versionCode" for multipart request 25 equals "53"
 
 Scenario: Density ABI Splits automatic upload disabled
     When I build "density_abi_splits" using the "all_disabled" bugsnag config
@@ -90,4 +90,4 @@ Scenario: Density ABI Splits manual upload of build API
     When I build the "XxxhdpiArmeabi-release" variantOutput for "density_abi_splits" using the "all_disabled" bugsnag config
     Then I should receive 1 request
     And the request 0 is valid for the Android Mapping API
-    And the part "versionCode" for request 0 equals "33"
+    And the field "versionCode" for multipart request 0 equals "33"

--- a/features/density_splits.feature
+++ b/features/density_splits.feature
@@ -28,28 +28,28 @@ Scenario: Density Splits project builds successfully
     And the payload field "apiKey" equals "TEST_API_KEY" for request 6
 
     And the request 7 is valid for the Android Mapping API
-    And the part "versionCode" for request 7 equals "4"
+    And the field "versionCode" for multipart request 7 equals "4"
 
     And the request 8 is valid for the Android Mapping API
-    And the part "versionCode" for request 8 equals "2"
+    And the field "versionCode" for multipart request 8 equals "2"
 
     And the request 9 is valid for the Android Mapping API
-    And the part "versionCode" for request 9 equals "3"
+    And the field "versionCode" for multipart request 9 equals "3"
 
     And the request 10 is valid for the Android Mapping API
-    And the part "versionCode" for request 10 equals "1"
+    And the field "versionCode" for multipart request 10 equals "1"
 
     And the request 11 is valid for the Android Mapping API
-    And the part "versionCode" for request 11 equals "5"
+    And the field "versionCode" for multipart request 11 equals "5"
 
     And the request 12 is valid for the Android Mapping API
-    And the part "versionCode" for request 12 equals "6"
+    And the field "versionCode" for multipart request 12 equals "6"
 
     And the request 13 is valid for the Android Mapping API
-    And the part "versionCode" for request 13 equals "7"
-    And the part "apiKey" for request 7 equals "TEST_API_KEY"
-    And the part "versionName" for request 7 equals "1.0"
-    And the part "appId" for request 7 equals "com.bugsnag.android.example"
+    And the field "versionCode" for multipart request 13 equals "7"
+    And the field "apiKey" for multipart request 7 equals "TEST_API_KEY"
+    And the field "versionName" for multipart request 7 equals "1.0"
+    And the field "appId" for multipart request 7 equals "com.bugsnag.android.example"
 
 Scenario: Density Splits automatic upload disabled
     When I build "density_splits" using the "all_disabled" bugsnag config
@@ -59,7 +59,7 @@ Scenario: Density Splits manual upload of build API
     When I build the "Hdpi-release" variantOutput for "density_splits" using the "all_disabled" bugsnag config
     Then I should receive 1 request
     And the request 0 is valid for the Android Mapping API
-    And the part "apiKey" for request 0 equals "TEST_API_KEY"
-    And the part "versionCode" for request 0 equals "4"
-    And the part "versionName" for request 0 equals "1.0"
-    And the part "appId" for request 0 equals "com.bugsnag.android.example"
+    And the field "apiKey" for multipart request 0 equals "TEST_API_KEY"
+    And the field "versionCode" for multipart request 0 equals "4"
+    And the field "versionName" for multipart request 0 equals "1.0"
+    And the field "appId" for multipart request 0 equals "com.bugsnag.android.example"

--- a/features/flavor_apk_splits.feature
+++ b/features/flavor_apk_splits.feature
@@ -23,28 +23,28 @@ Scenario: Flavor Density Split project builds successfully
     And the payload field "appVersionCode" equals "3" for request 5
 
     And the request 6 is valid for the Android Mapping API
-    And the part "versionCode" for request 6 equals "2"
-    And the part "appId" for request 6 equals "com.bugsnag.android.example.bar"
+    And the field "versionCode" for multipart request 6 equals "2"
+    And the field "appId" for multipart request 6 equals "com.bugsnag.android.example.bar"
 
     And the request 7 is valid for the Android Mapping API
-    And the part "versionCode" for request 7 equals "1"
-    And the part "appId" for request 7 equals "com.bugsnag.android.example.bar"
+    And the field "versionCode" for multipart request 7 equals "1"
+    And the field "appId" for multipart request 7 equals "com.bugsnag.android.example.bar"
 
     And the request 8 is valid for the Android Mapping API
-    And the part "versionCode" for request 8 equals "3"
-    And the part "appId" for request 8 equals "com.bugsnag.android.example.bar"
+    And the field "versionCode" for multipart request 8 equals "3"
+    And the field "appId" for multipart request 8 equals "com.bugsnag.android.example.bar"
 
     And the request 9 is valid for the Android Mapping API
-    And the part "versionCode" for request 9 equals "2"
-    And the part "appId" for request 9 equals "com.bugsnag.android.example.foo"
+    And the field "versionCode" for multipart request 9 equals "2"
+    And the field "appId" for multipart request 9 equals "com.bugsnag.android.example.foo"
 
     And the request 10 is valid for the Android Mapping API
-    And the part "versionCode" for request 10 equals "1"
-    And the part "appId" for request 10 equals "com.bugsnag.android.example.foo"
+    And the field "versionCode" for multipart request 10 equals "1"
+    And the field "appId" for multipart request 10 equals "com.bugsnag.android.example.foo"
 
     And the request 11 is valid for the Android Mapping API
-    And the part "versionCode" for request 11 equals "3"
-    And the part "appId" for request 11 equals "com.bugsnag.android.example.foo"
+    And the field "versionCode" for multipart request 11 equals "3"
+    And the field "appId" for multipart request 11 equals "com.bugsnag.android.example.foo"
 
 Scenario: Flavor Density Split automatic upload disabled
     When I build "flavor_apk_splits" using the "all_disabled" bugsnag config
@@ -54,7 +54,7 @@ Scenario: Flavor Density Split manual upload of build API
     When I build the "Bar-xxhdpi-release" variantOutput for "flavor_apk_splits" using the "all_disabled" bugsnag config
     Then I should receive 1 request
     And the request 0 is valid for the Android Mapping API
-    And the part "apiKey" for request 0 equals "TEST_API_KEY"
-    And the part "versionCode" for request 0 equals "3"
-    And the part "versionName" for request 0 equals "1.0"
-    And the part "appId" for request 0 equals "com.bugsnag.android.example.bar"
+    And the field "apiKey" for multipart request 0 equals "TEST_API_KEY"
+    And the field "versionCode" for multipart request 0 equals "3"
+    And the field "versionName" for multipart request 0 equals "1.0"
+    And the field "appId" for multipart request 0 equals "com.bugsnag.android.example.bar"

--- a/features/flavors.feature
+++ b/features/flavors.feature
@@ -15,16 +15,16 @@ Scenario: Flavors automatic upload on build
     And the payload field "appVersionCode" equals "1" for request 1
 
     And the request 2 is valid for the Android Mapping API
-    And the part "apiKey" for request 2 equals "TEST_API_KEY"
-    And the part "versionCode" for request 2 equals "1"
-    And the part "versionName" for request 2 equals "1.0"
-    And the part "appId" for request 2 equals "com.bugsnag.android.example.bar"
+    And the field "apiKey" for multipart request 2 equals "TEST_API_KEY"
+    And the field "versionCode" for multipart request 2 equals "1"
+    And the field "versionName" for multipart request 2 equals "1.0"
+    And the field "appId" for multipart request 2 equals "com.bugsnag.android.example.bar"
 
     And the request 3 is valid for the Android Mapping API
-    And the part "apiKey" for request 3 equals "TEST_API_KEY"
-    And the part "versionCode" for request 3 equals "1"
-    And the part "versionName" for request 3 equals "1.0"
-    And the part "appId" for request 3 equals "com.bugsnag.android.example.foo"
+    And the field "apiKey" for multipart request 3 equals "TEST_API_KEY"
+    And the field "versionCode" for multipart request 3 equals "1"
+    And the field "versionName" for multipart request 3 equals "1.0"
+    And the field "appId" for multipart request 3 equals "com.bugsnag.android.example.foo"
 
 Scenario: Flavors automatic upload disabled
     When I build "flavors" using the "all_disabled" bugsnag config
@@ -34,7 +34,7 @@ Scenario: Flavors manual upload of build API
     When I build the "Foo-release" variantOutput for "flavors" using the "all_disabled" bugsnag config
     Then I should receive 1 request
     And the request 0 is valid for the Android Mapping API
-    And the part "apiKey" for request 0 equals "TEST_API_KEY"
-    And the part "versionCode" for request 0 equals "1"
-    And the part "versionName" for request 0 equals "1.0"
-    And the part "appId" for request 0 equals "com.bugsnag.android.example.foo"
+    And the field "apiKey" for multipart request 0 equals "TEST_API_KEY"
+    And the field "versionCode" for multipart request 0 equals "1"
+    And the field "versionName" for multipart request 0 equals "1.0"
+    And the field "appId" for multipart request 0 equals "com.bugsnag.android.example.foo"

--- a/features/react_native.feature
+++ b/features/react_native.feature
@@ -12,7 +12,7 @@ Scenario: React Native sends requests
     And the payload field "appVersionCode" equals "1" for request 0
 
     And the request 1 is valid for the Android Mapping API
-    And the part "apiKey" for request 1 equals "YOUR-API-KEY-HERE"
-    And the part "versionCode" for request 1 equals "1"
-    And the part "versionName" for request 1 equals "1.0"
-    And the part "appId" for request 1 equals "com.bugsnag.android.rnapp"
+    And the field "apiKey" for multipart request 1 equals "YOUR-API-KEY-HERE"
+    And the field "versionCode" for multipart request 1 equals "1"
+    And the field "versionName" for multipart request 1 equals "1.0"
+    And the field "appId" for multipart request 1 equals "com.bugsnag.android.rnapp"


### PR DESCRIPTION
As part of [#16](https://github.com/bugsnag/maze-runner/pull/16) the multipart request syntax was updated. This PR updates the scenarios to match.