### PR TITLE
Gradle 4.8-rc-1 compat fix - use def when finding the buildType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-* Gradle 4.8-rc-1 compat fix - use def when finding the buildType
+* Add compatibility with Gradle 4.8-rc1 - use def rather than TreeSet when finding the buildType
 [Jamie Lynch](https://github.com/fractalwrench) [#110](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/110)
 
 ## 3.2.6 (2018-04-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.2.7 (TBD)
+
+### Bug fixes
+
+* Gradle 4.8-rc-1 compat fix - use def when finding the buildType
+[Jamie Lynch](https://github.com/fractalwrench) [#110](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/110)
+
 ## 3.2.6 (2018-04-24)
 
 * Update Android Plugin for Gradle version to 3.1.0

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -259,7 +259,7 @@ class BugsnagPlugin implements Plugin<Project> {
     private static boolean isJackEnabled(Project project, BaseVariant variant) {
 
         // First check the selected build type to see if there are jack settings
-        TreeSet buildTypes = project.android.buildTypes.store
+        def buildTypes = project.android.buildTypes.store
         BuildType b = findNode(buildTypes, variant.baseName)
 
         if (b?.hasProperty('jackOptions')
@@ -287,7 +287,7 @@ class BugsnagPlugin implements Plugin<Project> {
         String toolchain = null
 
         // First check the selected build type to see if there are cmake arguments
-        TreeSet buildTypes = project.android.buildTypes.store
+        def buildTypes = project.android.buildTypes.store
         BuildType b = findNode(buildTypes, variant.baseName)
 
         if (b != null
@@ -340,7 +340,7 @@ class BugsnagPlugin implements Plugin<Project> {
      * @param name The name of the buildtype to search for
      * @return The buildtype, or null if not found
      */
-    private static BuildType findNode(TreeSet<BuildType> set, String name) {
+    private static BuildType findNode(def set, String name) {
         Iterator<BuildType> iterator = set.iterator()
 
         while (iterator.hasNext()) {


### PR DESCRIPTION
## Goal
Gradle 4.8-rc-1 changes `project.android.buildTypes.store` to return an `Iterable` rather than a `Set`, which can lead to a runtime error within the plugin. This changeset prevents the runtime error by using `def` instead.

## Changeset

### Changed
Altered affected types from specific `Set` implementation to `def`.

## Tests

Mazerunner was run locally after running `./gradlew wrapper --gradle-version 4.8-rc-1` in each of the fixture projects.

## Discussion

### Alternative Approaches

We could use `Iterable` instead of `def`.

### Linked issues

#109 

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [x] Consistency across platforms for structures or concepts added or modified
- [x] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language
