### PR TITLE
Fix CI by updating NDK mazerunner scenario

### DIFF
--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -36,7 +36,7 @@ android {
         }
         arm {
             ndk {
-                abiFilters "armeabi-v7a", "armeabi"
+                abiFilters "armeabi-v7a"
             }
         }
     }

--- a/features/ndk_app.feature
+++ b/features/ndk_app.feature
@@ -2,7 +2,7 @@ Feature: Plugin integrated in NDK app
 
 Scenario: NDK apps send requests
     When I build the NDK app
-    Then I should receive 7 requests
+    Then I should receive 6 requests
 
     And the request 0 is valid for the Build API
     And the payload field "appVersion" equals "1.0" for request 0
@@ -27,8 +27,5 @@ Scenario: NDK apps send requests
     And the request 4 is valid for the Android NDK Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 4
 
-    And the request 5 is valid for the Android NDK Mapping API
+    And the request 5 is valid for the Android Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 5
-
-    And the request 6 is valid for the Android Mapping API
-    And the payload field "apiKey" equals "your-api-key-here" for request 6


### PR DESCRIPTION
Armeabi no longer seems to be a supported architecture on the Travis CI image. This changeset alters the product flavors to only target armeabi-v7a and updates the scenario, so that the CI build no longer breaks.

## Changeset

### Changed
Removed armeabi variant, updated scenario expectations

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
