### PR TITLE
fix: Update ProGuard keep rules for Breadcrumb class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.2.8 (2018-06-21)
+
+### Bug fixes
+
+* Update ProGuard keep rules for Breadcrumb class, fixing NDK compatibility
+[Jamie Lynch](https://github.com/fractalwrench) [#114](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/114)
+
 ## 3.2.7 (2018-06-05)
 
 ### Bug fixes

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.bugsnag
-version = 3.2.7
+version = 3.2.8
 
 ANDROID_MIN_SDK_VERSION=14
 ANDROID_TARGET_SDK_VERSION=27

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -17,6 +17,7 @@ class BugsnagProguardConfigTask extends DefaultTask {
     static final String PROGUARD_CONFIG_SETTINGS = """\
     -keepattributes LineNumberTable,SourceFile
     -keep class com.bugsnag.android.NativeInterface { *; }
+    -keep class com.bugsnag.android.Breadcrumb { *; }
     -keep class com.bugsnag.android.Breadcrumbs { *; }
     -keep class com.bugsnag.android.Breadcrumbs\$Breadcrumb { *; }
     -keep class com.bugsnag.android.BreadcrumbType { *; }


### PR DESCRIPTION
## Goal

The NDK requires access to the `Breadcrumb` class as of 1.2.0, which changed location in the bugsnag-android notifier from an inner to root class. This fix
ensures that our added ProGuard rules keep the class, making it accessible via the JNI.

## Changeset

Added proguard entry to keep new class location

## Tests

Tested against NDK example project with bugsnag-android-ndk 1.2.0, a local maven installation of the plugin, and ProGuard enabled. With the old plugin version, the notifier crashes on startup, with this fix it launches and is capable of notifying. Adding the keep rule to the ProGuard file manually also works.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
