### PR TITLE
fix: support provider api introduced in gradle 4.7

### DIFF
--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -4,6 +4,8 @@ import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
 import groovy.xml.Namespace
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 
 import java.nio.file.Paths
 
@@ -31,7 +33,18 @@ class BugsnagVariantOutputTask extends DefaultTask {
      * https://issuetracker.google.com/issues/37085185
      */
     File getManifestPath() {
-        File directory = variantOutput.processManifest.manifestOutputDirectory
+        File directory
+        def outputDir = variantOutput.processManifest.manifestOutputDirectory
+
+        if (outputDir instanceof File) {
+            directory = outputDir
+        } else {
+            // gradle 4.7 introduced a provider API for lazy evaluation of properties,
+            // AGP subsequently changed the API from File to Provider<File>
+            // see https://docs.gradle.org/4.7/userguide/lazy_configuration.html
+            directory = outputDir.get().asFile
+        }
+
         File manifestFile = Paths.get(directory.toString(), variantOutput.dirName, "AndroidManifest.xml").toFile()
 
         if (!manifestFile.exists()) {


### PR DESCRIPTION
## Goal

Gradle 4.7 introduced a [provider API](https://docs.gradle.org/4.7/userguide/lazy_configuration.html) for lazy evaluation of properties. The AGP subsequently changed the type of the `manifestOutputDir` property from `File` to Provider<File>. This changeset supports that API change while maintaining backward compatibility.

## Changeset

If `manifestOutputDir` is not a `File`, assume it is using the Provider API and coerce it to a file.

## Tests

Tested manually on an app using AGP 3.1.0 and another app running AGP 3.3.0.

Additionally the mazerunner scenarios were run on AGP 3.0.1, and then updated to also [run on AGP 3.3.0](https://github.com/bugsnag/bugsnag-android-gradle-plugin/tree/mazerunner-agp330). It's worth noting that the `default_lib` feature does not pass in the 3.3.0 project - this is thought to be due to a separate issue.

### Linked issues

#121 
