### PR TITLE
Add step to release process to trigger buildkite manually

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,8 @@ Releasing a New Version
 ## Release Checklist
 Please follow the testing instructions in [the platforms release checklist](https://github.com/bugsnag/platforms-release-checklist/blob/master/README.md), and any additional steps directly below.
 
+- Trigger a New Build in Buildkite on the target branch, and verify that the private scenarios pass.
+
 - Use `gradlew clean install` to install a release build to a local maven repo, and `gradlew clean build` to refresh the example project.
 
 ### Instructions


### PR DESCRIPTION
After discussion earlier today, it was suggested that manually triggering the BuildKite build for private mazerunner scenarios would be preferable. This changeset adds a step to the release process that details how to achieve this step.