### PR TITLE
Close IO streams after the plugin has finished reading and writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.X.X (TBD)
+
+### Bug fixes
+
+* Close IO streams after the plugin has finished reading and writing
+[Jamie Lynch](https://github.com/fractalwrench) [#126](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/126)
+
 ## 3.3.1 (2018-08-10)
 
 ### Bug fixes

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -58,6 +58,8 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
                 def printer = new XmlNodePrinter(new PrintWriter(writer))
                 printer.preserveWhitespace = true
                 printer.print(xml)
+            } catch (Exception e) {
+                project.logger.warn("Failed to update manifest with Bugsnag metadata", e)
             } finally {
                 if (writer != null) {
                     writer.close()

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -51,10 +51,18 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
             application.appendNode('meta-data', [(ns.name): BugsnagPlugin.BUILD_UUID_TAG, (ns.value): buildUUID])
 
             // Write the manifest file
-            def writer = new FileWriter(manifestPath)
-            def printer = new XmlNodePrinter(new PrintWriter(writer))
-            printer.preserveWhitespace = true
-            printer.print(xml)
+            FileWriter writer = null
+
+            try {
+                writer = new FileWriter(manifestPath)
+                def printer = new XmlNodePrinter(new PrintWriter(writer))
+                printer.preserveWhitespace = true
+                printer.print(xml)
+            } finally {
+                if (writer != null) {
+                    writer.close()
+                }
+            }
         } else {
             project.logger.error("Bugsnag detected invalid manifest with no application element so did not write Build UUID")
         }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -47,6 +47,8 @@ class BugsnagProguardConfigTask extends DefaultTask {
             fr = new FileWriter(file.path)
             fr.write(PROGUARD_CONFIG_SETTINGS)
             fr.write("\n")
+        } catch (Exception e) {
+            project.logger.warn("Failed to write Bugsnag ProGuard settings", e)
         } finally {
             fr.close()
         }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -41,10 +41,15 @@ class BugsnagProguardConfigTask extends DefaultTask {
         file.getParentFile().mkdirs()
 
         // Write our recommended proguard settings to this file
-        FileWriter fr = new FileWriter(file.path)
-        fr.write(PROGUARD_CONFIG_SETTINGS)
-        fr.write("\n")
-        fr.close()
+        FileWriter fr = null
+
+        try {
+            fr = new FileWriter(file.path)
+            fr.write(PROGUARD_CONFIG_SETTINGS)
+            fr.write("\n")
+        } finally {
+            fr.close()
+        }
 
         // Add this proguard settings file to the list
         variant.getBuildType().buildType.proguardFiles(file)

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
@@ -48,6 +48,8 @@ class BugsnagReleasesTask extends BugsnagVariantOutputTask {
     }
 
     private boolean deliverPayload(JSONObject payload) {
+        OutputStream os = null
+
         try {
             URL url = new URL(project.bugsnag.releasesEndpoint)
             HttpURLConnection conn = url.openConnection()
@@ -58,9 +60,8 @@ class BugsnagReleasesTask extends BugsnagVariantOutputTask {
             conn.setConnectTimeout(Call.TIMEOUT_MILLIS)
             conn.setDoOutput(true)
 
-            OutputStream os = conn.outputStream
+            os = conn.outputStream
             os.write(payload.toString().getBytes("UTF-8"))
-            os.close()
 
             int statusCode = conn.getResponseCode()
 
@@ -83,6 +84,10 @@ class BugsnagReleasesTask extends BugsnagVariantOutputTask {
             project.logger.error(project.bugsnag.releasesEndpoint)
             project.logger.error("Failed to POST request", e)
             return false
+        } finally {
+            if (os != null) {
+                os.close()
+            }
         }
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
@@ -69,14 +69,20 @@ class BugsnagReleasesTask extends BugsnagVariantOutputTask {
                 project.logger.info("Uploaded release info to Bugsnag")
                 return true
             } else {
-                BufferedReader reader = new BufferedReader(new InputStreamReader(conn.errorStream))
+                BufferedReader reader
                 String line
 
-                while ((line = reader.readLine()) != null) {
-                    project.logger.error(line)
+                try {
+                    reader = new BufferedReader(new InputStreamReader(conn.errorStream))
+                    while ((line = reader.readLine()) != null) {
+                        project.logger.error(line)
+                    }
+                    project.logger.warn("Release Request failed with statusCode " + statusCode)
+                } finally {
+                    if (reader != null) {
+                        reader.close()
+                    }
                 }
-
-                project.logger.warn("Release Request failed with statusCode " + statusCode)
                 return false
             }
 


### PR DESCRIPTION
## Goal

Closes IO streams after the plugin has finished reading and writing, in a `finally` block, which is guaranteed to be executed last.

## Changeset

- Altered existing use of `Closeable` values so that `close` is called in a try-finally block. 
- Added catch block where this was previously missing, that logs a warning

## Tests

Ran mazerunner scenarios.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
