### PR TITLE
[PIPE-1131] Zip shared object mapping files v2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.5.0 (2018-08-29)
+## TBD
 
 * Compress Android NDK mapping files to decrease upload times
 [Dave Perryman](https://github.com/Pezzah) [#128](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/128)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.5.0 (2018-08-29)
+
+* Compress Android NDK mapping files to decrease upload times
+[Dave Perryman](https://github.com/Pezzah) [#128](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/128)
+
 ## 2.4.3 (2018-08-16)
 
 * Improve logging for NDK symbol upload

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = com.bugsnag
-version = 2.4.3
+version = 2.5.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = com.bugsnag
-version = 2.5.0
+version = 2.4.3


### PR DESCRIPTION
## Goal

Zip shared object mapping files before sending, to reduce transfer time. Also don't process the file as zipping is very effective

This coresponding PR is required to process the zipped files
bugsnag/bugsnag-event-worker#1043

See https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/127 for implementation on the most recent release

## Design

See ROAD-570 design for reasons for the approach
