### PR TITLE
[PLAT-1678] Change to use new objdump command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ### Bug fixes
 
+* Reduce processing requirements to improve upload speed for NDK mapping files
+  [Dave Perryman](https://github.com/Pezzah)
+  [#129](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/129)
+
 * Close IO streams after the plugin has finished reading and writing
-[Jamie Lynch](https://github.com/fractalwrench) [#126](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/126)
+  [Jamie Lynch](https://github.com/fractalwrench)
+  [#126](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/126)
 
 ## 3.4.0 (2018-08-30)
 

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -33,7 +33,7 @@ end
 
 Then(/^the request (\d+) is valid for the Android NDK Mapping API$/) do |request_index|
   parts = find_request(request_index)[:body]
-  assert_not_nil(parts["soMappingFile"], "'soMappingFile' should not be nil")
+  assert_not_nil(parts["soSymbolFile"], "'soSymbolFile' should not be nil")
   assert_not_nil(parts["apiKey"], "'apiKey' should not be nil")
   assert_not_nil(parts["sharedObjectName"], "'sharedObjectName' should not be nil")
   assert_not_nil(parts["appId"], "'appId' should not be nil")

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -128,7 +128,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
                 project.logger.lifecycle("Creating symbol file at ${outputFile}")
 
                 // Call objdump, redirecting output to the output file
-                ProcessBuilder builder = new ProcessBuilder(objDumpPath.toString(), "--disassemble", "--demangle", "--line-numbers", "--section=.text", sharedObject.toString())
+                ProcessBuilder builder = new ProcessBuilder(objDumpPath.toString(), "-W", "-x", "--section=.debug_line", sharedObject.toString())
                 builder.redirectError(errorOutputFile)
                 Process process = builder.start()
 
@@ -191,7 +191,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
      */
     void uploadSymbols(File mappingFile, String arch, String sharedObjectName) {
         MultipartEntity mpEntity = new MultipartEntity()
-        mpEntity.addPart("soMappingFile", new FileBody(mappingFile))
+        mpEntity.addPart("soSymbolFile", new FileBody(mappingFile))
         mpEntity.addPart("arch", new StringBody(arch))
         mpEntity.addPart("sharedObjectName", new StringBody(sharedObjectName))
         mpEntity.addPart("projectRoot", new StringBody(projectDir.toString()))

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -128,7 +128,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
                 project.logger.lifecycle("Creating symbol file at ${outputFile}")
 
                 // Call objdump, redirecting output to the output file
-                ProcessBuilder builder = new ProcessBuilder(objDumpPath.toString(), "-W", "-x", "--section=.debug_line", sharedObject.toString())
+                ProcessBuilder builder = new ProcessBuilder(objDumpPath.toString(), "--dwarf=info", "--dwarf=rawline", sharedObject.toString())
                 builder.redirectError(errorOutputFile)
                 Process process = builder.start()
 


### PR DESCRIPTION
## Goal

Use faster version of objdump command

Requires https://github.com/bugsnag/bugsnag-event-worker/pull/1061 to parse the new file upload

## Review

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
