### PR TITLE
feat(ndk): Add alternative method for locating bugsnag NDK package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## TBD
+
+### Bug fixes
+
+* Fix native artifact resolution for NDK projects manually installing
+  bugsnag-android-ndk
+  [#130](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/130)
+
 ## 3.4.1 (2018-09-11)
 
 ### Bug fixes

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
@@ -15,10 +15,12 @@ class BugsnagNdkSetupTask extends DefaultTask {
         def configs = project.configurations.findAll {
             it.toString().contains('CompileClasspath')
         }.each { config ->
-            def artifactFile = config.resolvedConfiguration.getFiles().find {
-                it.toString().contains("bugsnag-android-ndk")
+            def artifact = config.resolvedConfiguration.getResolvedArtifacts().find {
+                def identifier = it.getId().getComponentIdentifier().toString()
+                identifier.contains("bugsnag-android-ndk") && it.getFile() != null
             }
-            if (artifactFile) {
+            if (artifact) {
+                def artifactFile = artifact.getFile()
                 File buildDir = project.buildDir
                 File dst = new File(buildDir, "/intermediates/bugsnag-libs")
 


### PR DESCRIPTION
## Goal

Fix CMake build resolution when using the bugsnag-android-ndk Native API
but without installing via a Maven repo.

If installing via one of the alternatives to gradle repository 
resolution, the SetupNdk task will not be able to locate the
bugsnag-android-ndk artifact and unpack the shared library files. This
will result in somewhat opaque broken builds for users attempting to use
the bugsnag-android-ndk Native API.

## Design

This change resolves the bugsnag-android-ndk artifact by ID rather than by file name. The file may not (yet) be in its final installed destination for other installation methods, but the ID will always point to the correct thing, and indicate where the existing file is.

## Tests

To reproduce the original problem:

1. Install bugsnag-android-ndk in a project using the [manual installation method](https://docs.bugsnag.com/platforms/android/ndk/#manual-aar-installation).
2. Set up CMake according to the Native API configuration section of the documentation
3. Watch the build fail due to being unable to locate `bugsnag-libs`

Tested in the following configurations in a fresh project as well as some existing ones:

* Installing bugsnag-android-ndk from a maven repo (The existing supported way)
* Installing bugsnag-android-ndk from an aar file
* Installing bugsnag-android-ndk from a local path

### Linked issues

Related to the example project build discussion in bugsnag/bugsnag-android#369

## Review

Please review to confirm:

- [ ] There is no simpler or more robust solution to this problem
- [ ] This is idiomatic gradle usage