### PR TITLE
Allow setting projectRoot via bugsnag plugin extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 env:
   global:
   - ANDROID_HOME=/usr/local/android-sdk
-  - ANDROID_NDK_HOME=/usr/local/android-sdk/ndk-bundle
+  - NDK_VERSION=r16b
 
 android:
   components:
@@ -14,9 +14,6 @@ android:
     - sys-img-armeabi-v7a-android-21
     - extra-google-m2repository
     - extra-android-m2repository
-    - cmake
-    - ndk-bundle
-    - lldb
 
 before_install:
   - echo y | sdkmanager "platform-tools" >/dev/null
@@ -25,6 +22,7 @@ before_install:
   - gem install bundler
   - bundle install
   - ls $ANDROID_HOME
+  - ./install_ndk.sh
 
 install:
   - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.5.0 (TBD)
+
+### Bug fixes
+
+* Add option for setting projectRoot on bugsnag plugin extension
+[#133](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/133)
+
 ## 3.4.2 (2018-09-27)
 
 ### Bug fixes

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -52,4 +52,10 @@ bugsnag {
     ndk true
     endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
     releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+
+    def customPath = System.env.PROJECT_ROOT
+
+    if (customPath != null) {
+        projectRoot = customPath
+    }
 }

--- a/features/ndk_app.feature
+++ b/features/ndk_app.feature
@@ -23,9 +23,22 @@ Scenario: NDK apps send requests
 
     And the request 3 is valid for the Android NDK Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 3
+    And the payload field "projectRoot" ends with "features/fixtures/ndkapp/app" for request 3
 
     And the request 4 is valid for the Android NDK Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 4
+    And the payload field "projectRoot" ends with "features/fixtures/ndkapp/app" for request 4
 
     And the request 5 is valid for the Android Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 5
+
+Scenario: Custom projectRoot is added to payload
+    When I set environment variable "PROJECT_ROOT" to "/repos/custom/my-app"
+    When I build the NDK app
+    Then I should receive 6 requests
+
+    And the request 3 is valid for the Android NDK Mapping API
+    And the payload field "projectRoot" equals "/repos/custom/my-app" for request 3
+
+    And the request 4 is valid for the Android NDK Mapping API
+    And the payload field "projectRoot" equals "/repos/custom/my-app" for request 4

--- a/install_ndk.sh
+++ b/install_ndk.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [ -z "$NDK_VERSION" ]; then
+    echo "No NDK version set. Using default (r16b)."
+    export NDK_VERSION=r16b
+fi
+
+curl --silent -L https://dl.google.com/android/repository/android-ndk-$NDK_VERSION-linux-x86_64.zip -O
+
+unzip -qq android-ndk-$NDK_VERSION-linux-x86_64.zip > /dev/null
+
+mv android-ndk-$NDK_VERSION $ANDROID_HOME/ndk-bundle
+rm android-ndk-$NDK_VERSION-linux-x86_64.zip
+
+export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
+export LOCAL_ANDROID_NDK_HOST_PLATFORM="linux-x86_64"
+export PATH=${PATH}:${ANDROID_NDK_HOME}

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
@@ -16,7 +16,7 @@ class BugsnagPluginExtension {
     int retryCount = 0
     boolean ndk = false
     String sharedObjectPath = null
-
+    String projectRoot = null
 
     // release API values
     String builderName = null

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -194,7 +194,9 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
         mpEntity.addPart("soSymbolFile", new FileBody(mappingFile))
         mpEntity.addPart("arch", new StringBody(arch))
         mpEntity.addPart("sharedObjectName", new StringBody(sharedObjectName))
-        mpEntity.addPart("projectRoot", new StringBody(projectDir.toString()))
+
+        String projectRoot = project.bugsnag.projectRoot ?: projectDir.toString()
+        mpEntity.addPart("projectRoot", new StringBody(projectRoot))
 
         super.uploadMultipartEntity(mpEntity)
     }


### PR DESCRIPTION
## Goal

When the current project directory is not the correct candidate for the project root, allow customers to override the value using a new configuration option, `projectRoot`.

## Changeset

Adds `projectRoot` to plugin extension, whose value defaults to the project root directory.

## Tests

Added mazerunner scenario for default + custom value of projectRoot. Manually tested that setting the value of `projectRoot` altered the dashboard grouping of an NDK crash.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
