### PR TITLE
Manually calculate location of objdump in gradle plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.X.X (TBD)
+
+### Bug fixes
+
+* Manually calculate location of objdump in gradle plugin
+[#136](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/136)
+
 ## 3.5.0 (2018-10-18)
 
 ### Bug fixes

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -13,6 +13,9 @@ android {
                 cppFlags ""
             }
         }
+        ndk {
+            abiFilters "x86", "x86_64", "armeabi", "armeabi-v7a", "arm64-v8a"
+        }
     }
     buildTypes {
         release {
@@ -25,25 +28,10 @@ android {
             path "CMakeLists.txt"
         }
     }
-
-    flavorDimensions "regular"
-
-    productFlavors {
-        x86 {
-            ndk {
-                abiFilter "x86"
-            }
-        }
-        arm {
-            ndk {
-                abiFilters "armeabi-v7a"
-            }
-        }
-    }
 }
 
 dependencies {
-    compile 'com.bugsnag:bugsnag-android-ndk:1.+'
+    compile 'com.bugsnag:bugsnag-android-ndk:4.+'
 }
 
 apply plugin: 'com.bugsnag.android.gradle'

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -42,8 +42,16 @@ bugsnag {
     releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
 
     def customPath = System.env.PROJECT_ROOT
+    def objdumpLocation = System.env.OBJDUMP_LOCATION
 
     if (customPath != null) {
         projectRoot = customPath
+    }
+
+    if (objdumpLocation != null) {
+        objdumpPaths = [
+                "x86": objdumpLocation,
+                "arm64-v8a": objdumpLocation
+        ]
     }
 }

--- a/features/ndk_app.feature
+++ b/features/ndk_app.feature
@@ -14,27 +14,27 @@ Scenario: NDK apps send requests
     And the request 1 is valid for the Android NDK Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 1
     And the payload field "projectRoot" ends with "features/fixtures/ndkapp/app" for request 1
-    And the payload field "arch" equals "armeabi-v7a" for request 1
+    And the payload field "arch" equals "armeabi" for request 1
 
     And the request 2 is valid for the Android NDK Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 2
     And the payload field "projectRoot" ends with "features/fixtures/ndkapp/app" for request 2
-    And the payload field "arch" equals "x86" for request 2
+    And the payload field "arch" equals "armeabi-v7a" for request 2
 
     And the request 3 is valid for the Android NDK Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 3
     And the payload field "projectRoot" ends with "features/fixtures/ndkapp/app" for request 3
-    And the payload field "arch" equals "arm64-v8a" for request 3
+    And the payload field "arch" equals "x86_64" for request 3
 
     And the request 4 is valid for the Android NDK Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 4
     And the payload field "projectRoot" ends with "features/fixtures/ndkapp/app" for request 4
-    And the payload field "arch" equals "armeabi" for request 4
+    And the payload field "arch" equals "arm64-v8a" for request 4
 
     And the request 5 is valid for the Android NDK Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 5
     And the payload field "projectRoot" ends with "features/fixtures/ndkapp/app" for request 5
-    And the payload field "arch" equals "x86_64" for request 5
+    And the payload field "arch" equals "x86" for request 5
 
     And the request 6 is valid for the Android Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 6
@@ -58,3 +58,18 @@ Scenario: Custom projectRoot is added to payload
 
     And the request 5 is valid for the Android NDK Mapping API
     And the payload field "projectRoot" equals "/repos/custom/my-app" for request 5
+
+# Sets a non-existent objdump location for x86 and arm64-v8a, delivery should proceed as normal for other files
+Scenario: Custom objdump location
+    When I set environment variable "OBJDUMP_LOCATION" to "/fake/objdump"
+    When I build the NDK app
+    Then I should receive 5 requests
+
+    And the request 1 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "armeabi" for request 1
+
+    And the request 2 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "armeabi-v7a" for request 2
+
+    And the request 3 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "x86_64" for request 3

--- a/features/ndk_app.feature
+++ b/features/ndk_app.feature
@@ -2,7 +2,7 @@ Feature: Plugin integrated in NDK app
 
 Scenario: NDK apps send requests
     When I build the NDK app
-    Then I should receive 6 requests
+    Then I should receive 7 requests
 
     And the request 0 is valid for the Build API
     And the payload field "appVersion" equals "1.0" for request 0
@@ -11,34 +11,50 @@ Scenario: NDK apps send requests
     And the payload field "buildTool" equals "gradle-android" for request 0
     And the payload field "appVersionCode" equals "1" for request 0
 
-    And the request 1 is valid for the Build API
-    And the payload field "appVersion" equals "1.0" for request 1
+    And the request 1 is valid for the Android NDK Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 1
-    And the payload field "builderName" is not null for request 1
-    And the payload field "buildTool" equals "gradle-android" for request 1
-    And the payload field "appVersionCode" equals "1" for request 1
+    And the payload field "projectRoot" ends with "features/fixtures/ndkapp/app" for request 1
+    And the payload field "arch" equals "armeabi-v7a" for request 1
 
-    And the request 2 is valid for the Android Mapping API
+    And the request 2 is valid for the Android NDK Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 2
+    And the payload field "projectRoot" ends with "features/fixtures/ndkapp/app" for request 2
+    And the payload field "arch" equals "x86" for request 2
 
     And the request 3 is valid for the Android NDK Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 3
     And the payload field "projectRoot" ends with "features/fixtures/ndkapp/app" for request 3
+    And the payload field "arch" equals "arm64-v8a" for request 3
 
     And the request 4 is valid for the Android NDK Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 4
     And the payload field "projectRoot" ends with "features/fixtures/ndkapp/app" for request 4
+    And the payload field "arch" equals "armeabi" for request 4
 
-    And the request 5 is valid for the Android Mapping API
+    And the request 5 is valid for the Android NDK Mapping API
     And the payload field "apiKey" equals "your-api-key-here" for request 5
+    And the payload field "projectRoot" ends with "features/fixtures/ndkapp/app" for request 5
+    And the payload field "arch" equals "x86_64" for request 5
+
+    And the request 6 is valid for the Android Mapping API
+    And the payload field "apiKey" equals "your-api-key-here" for request 6
 
 Scenario: Custom projectRoot is added to payload
     When I set environment variable "PROJECT_ROOT" to "/repos/custom/my-app"
     When I build the NDK app
-    Then I should receive 6 requests
+    Then I should receive 7 requests
+
+    And the request 1 is valid for the Android NDK Mapping API
+    And the payload field "projectRoot" equals "/repos/custom/my-app" for request 1
+
+    And the request 2 is valid for the Android NDK Mapping API
+    And the payload field "projectRoot" equals "/repos/custom/my-app" for request 2
 
     And the request 3 is valid for the Android NDK Mapping API
     And the payload field "projectRoot" equals "/repos/custom/my-app" for request 3
 
     And the request 4 is valid for the Android NDK Mapping API
     And the payload field "projectRoot" equals "/repos/custom/my-app" for request 4
+
+    And the request 5 is valid for the Android NDK Mapping API
+    And the payload field "projectRoot" equals "/repos/custom/my-app" for request 5

--- a/src/main/groovy/com/bugsnag/android/gradle/Abi.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/Abi.groovy
@@ -1,0 +1,49 @@
+package com.bugsnag.android.gradle
+
+enum Abi {
+
+    ARMEABI(
+        "armeabi",
+        "arm-linux-androideabi",
+        "arm-linux-androideabi"
+    ),
+    ARMEABI_V7A(
+        "armeabi-v7a",
+        "arm-linux-androideabi",
+        "arm-linux-androideabi"
+    ),
+    ARM64_V8A(
+        "arm64-v8a",
+        "aarch64-linux-android",
+        "aarch64-linux-android"
+    ),
+    X86(
+        "x86",
+        "x86",
+        "i686-linux-android"
+    ),
+    X86_64(
+        "x86_64",
+        "x86_64",
+        "x86_64-linux-android"
+    );
+
+    final String abiName
+    final String toolchainPrefix
+    final String objdumpPrefix
+
+    Abi(String abiName, String toolchainPrefix, String objdumpPrefix) {
+        this.abiName = abiName
+        this.toolchainPrefix = toolchainPrefix
+        this.objdumpPrefix = objdumpPrefix
+    }
+
+    static Abi findByName(String abiName) {
+        for (Abi value : values()) {
+            if (value.abiName == abiName) {
+                return value
+            }
+        }
+        return null
+    }
+}

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
@@ -21,6 +21,7 @@ class BugsnagPluginExtension {
     // release API values
     String builderName = null
     Map<String, String> metadata = null
+    Map<String, String> objdumpPaths = null
 
 }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -207,7 +207,14 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
      */
     File getObjDumpExecutable(String arch) {
         try {
-            File objDumpFile = findObjDump(project, arch)
+            String override = getObjDumpOverride(arch)
+            File objDumpFile
+
+            if (override != null) {
+                objDumpFile = new File(override)
+            } else {
+                objDumpFile = findObjDump(project, arch)
+            }
 
             if (!objDumpFile.exists() || !objDumpFile.canExecute()) {
                 throw new RuntimeException("Failed to find executable objdump at $objDumpFile")
@@ -217,6 +224,11 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
             project.logger.error("Error attempting to calculate objdump location: " + ex.message)
         }
         return null
+    }
+
+    private Object getObjDumpOverride(String arch) {
+        Map<String, String> paths = project.bugsnag.objdumpPaths
+        return paths != null ? paths[arch] : null
     }
 
     static File findObjDump(Project project, String arch) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -235,6 +235,13 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
         Abi abi = Abi.findByName(arch)
         String ndkDir = project.android.ndkDirectory
         String osName = calculateOsName()
+
+        if (abi == null) {
+            throw new IllegalStateException("Failed to find ABI for $arch")
+        }
+        if (osName == null) {
+            throw new IllegalStateException("Failed to calculate OS name")
+        }
         return calculateObjDumpLocation(ndkDir, abi, osName)
     }
 
@@ -254,7 +261,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
                 return "windows-x86_64"
             }
         } else {
-            return "unknown"
+            return null
         }
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -1,8 +1,6 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.BaseVariantOutput
-import com.android.build.gradle.internal.core.Abi
-import com.android.build.gradle.internal.ndk.NdkHandler
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.android.build.gradle.tasks.ProcessAndroidResources
 import org.apache.http.entity.mime.MultipartEntity
@@ -33,7 +31,6 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
     String variantName
     File projectDir
     File rootDir
-    String toolchain
     String sharedObjectPath
 
     BugsnagUploadNdkTask() {
@@ -209,9 +206,6 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
     File getObjDumpExecutable(String arch) {
 
         try {
-            Abi abi = Abi.getByName(arch)
-            NdkHandler handler = new NdkHandler(rootDir, null, toolchain, "", true)
-            File objDumpPath = new File(handler.getDefaultGccToolchainPath(abi), "bin/" + abi.getGccExecutablePrefix() + "-objdump")
             return objDumpPath
         } catch (Throwable ex) {
             project.logger.error("Error attempting to calculate objdump location: " + ex.message)

--- a/src/test/groovy/com/bugsnag/android/gradle/ObjDumpLocationTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/ObjDumpLocationTest.groovy
@@ -32,7 +32,7 @@ class ObjDumpLocationTest {
         return inputs
     }
 
-    @Parameterized.Parameters(name = "1")
+    @Parameterized.Parameters
     static Collection<String> os() {
         return Arrays.asList("windows", "linux")
     }

--- a/src/test/groovy/com/bugsnag/android/gradle/ObjDumpLocationTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/ObjDumpLocationTest.groovy
@@ -1,0 +1,47 @@
+package com.bugsnag.android.gradle
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import static org.junit.Assert.*
+
+@RunWith(Parameterized.class)
+class ObjDumpLocationTest {
+
+    @Parameterized.Parameter(0)
+    public Abi abi
+
+    @Parameterized.Parameter(1)
+    public String osName
+
+    @Parameterized.Parameter(2)
+    public String ndkDir
+
+    @Parameterized.Parameters
+    static Collection<Object[]> inputs() {
+        Collection<Object> inputs = new ArrayList<>();
+
+        for (Abi abi: Abi.values()) {
+            for (String os: ["darwin-x86_64", "linux-x86_64", "windows", "windows-x86_64"]) {
+                for (String ndkDir: ["/Users/bob/Library/Android/sdk/ndk-bundle", "/etc/ndk-bundle"]) {
+                    inputs.add([abi, os, ndkDir].toArray())
+                }
+            }
+        }
+        return inputs
+    }
+
+    @Parameterized.Parameters(name = "1")
+    static Collection<String> os() {
+        return Arrays.asList("windows", "linux")
+    }
+
+    @Test
+    void defaultObjDumpLocation() {
+        File file = BugsnagUploadNdkTask.calculateObjDumpLocation(ndkDir, abi, osName)
+        String expected = "$ndkDir/toolchains/$abi.toolchainPrefix-4.9/prebuilt/$osName/bin/$abi.objdumpPrefix-objdump"
+        assertEquals(expected, file.path)
+    }
+
+}


### PR DESCRIPTION
## Goal

The bugsnag gradle plugin relies on objdump to upload shared object mapping files, which deobfuscate stacktraces in NDK projects. The plugin relies on the `NdkHandler` and `Toolchain` classes to calculate the location of objdump on disk. These classes are internal APIs within the Android Gradle Plugin (AGP), and have been removed in v3.4.0-alpha.

The bugsnag gradle plugin will throw an Error when attempting to load these classes, which will break the build for any NDK project depending on our plugin and AGP 3.4.0. This changeset alters the plugin to perform the calculation manually, and removes the dependency on these classes.

N.B. a design doc is available which covers the goal in more detail

## Changeset

- Removed dependency on `Toolchain`, `NdkHandler`, and `Abi` classes which were internal to the AGP.
- Add `Abi` classes which contains pre-calculated information on the names of ABIs, and the expected location of objdump.
- Remove dead code which parses the CMake toolchain options
- Calculate the location of objdump manually, using the OS name, ABI, and NDK installation directory.
- Add an `objdumpPaths` property to the bugsnag plugin extension which allows users to override the calculation location on a per-ABI basis

## Tests

- Updated the mazerunner NDK fixture to build all supported ABIs, rather than just x86 and armeabi-v7a. The scenarios have been updated to verify that for each ABI a mapping file is uploaded.
- Added a mazerunner scenario to verify that setting a value in the `objdumpPaths` property overrides the calculated objdump location.
- Added a parameterized unit test that covers all the potential objdump locations we 
support.

## Discussion

### Linked issues

Fixes #134 
