### PR TITLE
Create tasks for debug variant which are not run by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.X.X (TBD)
+
+* Create tasks for debug variant which are not run by default
+[#139](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/139)
+
 ## 3.5.0 (2018-10-18)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Tasks were not created for the debug buildType when `bugsnag.uploadDebugBuildMappings` was set to false. This means it's not possible to manually invoke the mapping file upload task for the debug buildType.

For example, `./gradlew uploadBugsnagJavaExample-debugMapping` would be unsuccessful as the task does not exist in the project, whereas `./gradlew uploadBugsnagJavaExample-releaseMapping` would be successful.

Our aim is to alter the plugin so that these debug tasks are created, but not run automatically. This is because in most scenarios, debug mapping files are not required and can slow down the build process.

## Changeset

This changeset alters the plugin so that tasks are created regardless of build type. A dependency between tasks is only added if `bugsnag.uploadDebugBuildMappings` is true, meaning that only non-debug tasks are run automatically.

## Tests

The existing mazerunner scenarios were run, to verify that debug mappings are not uploaded automatically. Additionally a debug mapping upload task was invoked manually in an example project where the artefact was installed.
