### PR TITLE
Resolve api key from string resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.X.X (TBD)
+
+* Resolve apiKey from string resource
+[#143](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/143)
+
 ## 3.6.0 (2018-12-12)
 
 * Support automatic upload when building App Bundles

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -53,7 +53,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
         manifestFile
     }
 
-    private String getStringResourcesPath(String key){
+    private String getValueFromStringResources(String key){
         String keyName = key.substring("@string/".length())
         String mainFlavorValue = getStringValueFromFlavor("main", keyName)
         return getStringValueFromFlavor(variant.flavorName, mainFlavorValue)
@@ -103,7 +103,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
 
         if (apiKey != null && apiKey.startsWith("@string/")){
             project.logger.info("apiKey starts with @string '$apiKey' and it will be searched in resources")
-            apiKey = getStringResourcesPath(apiKey)
+            apiKey = getValueFromStringResources(apiKey)
             project.logger.info("apiKey '$apiKey' after search in resources")
         }
 


### PR DESCRIPTION
## Goal

When using metada like on below example upload process is broken so api returns '@string/bugsnag_api_key' not valid key.

  <meta-data
      android:name="com.bugsnag.android.API_KEY"
      android:value="@string/bugsnag_api_key" />


## Changeset

It will fix string reference from string resources.  

## Tests

It tested for flavor and flavorless projects for both type project string resource reference resolve apiKey.