### PR TITLE
Address provider api warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
   - echo y | sdkmanager "platform-tools" >/dev/null
   - echo y | sdkmanager "tools" >/dev/null
   - echo y | sdkmanager "build-tools;27.0.3" >/dev/null
+  - echo y | sdkmanager 'cmake;3.6.4111459'
   - gem install bundler
   - bundle install
   - ls $ANDROID_HOME

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -305,7 +305,15 @@ class BugsnagPlugin implements Plugin<Project> {
         if (variant instanceof LibraryVariant) {
             variant.getPackageLibrary().dependsOn task
         } else {
-            variant.getPackageApplication().dependsOn task
+            resolvePackageApplication(variant).dependsOn task
+        }
+    }
+
+    static def resolvePackageApplication(BaseVariant variant) {
+        try {
+            return variant.getPackageApplicationProvider().get()
+        } catch (Throwable ignored) {
+            return variant.getPackageApplication()
         }
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -250,8 +250,16 @@ class BugsnagPlugin implements Plugin<Project> {
     private static void setupManifestUuidTask(Project project, BugsnagTaskDeps deps) {
         BugsnagManifestTask manifestTask = project.tasks.create("processBugsnag${taskNameForOutput(deps.output)}Manifest", BugsnagManifestTask)
         setupBugsnagTask(manifestTask, deps)
-        def processManifest = deps.output.processManifest
+        def processManifest = resolveProcessManifest(deps.output)
         processManifest.finalizedBy(manifestTask)
+    }
+
+    static def resolveProcessManifest(BaseVariantOutput output) {
+        try {
+            return output.processManifestProvider.get()
+        } catch (Throwable ignored) {
+            return output.processManifest
+        }
     }
 
     /**

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -2,7 +2,6 @@ package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.BaseVariantOutput
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
-import com.android.build.gradle.tasks.ProcessAndroidResources
 import org.apache.http.entity.mime.MultipartEntity
 import org.apache.http.entity.mime.content.FileBody
 import org.apache.http.entity.mime.content.StringBody
@@ -85,14 +84,21 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
     }
 
     private static File findSymbolPath(BaseVariantOutput variantOutput) {
-        ProcessAndroidResources resources = variantOutput.processResources
-
+        def resources = resolveProcessAndroidResources(variantOutput)
         def symbolPath = resources.textSymbolOutputFile
 
         if (symbolPath == null) {
             throw new IllegalStateException("Could not find symbol path")
         }
         symbolPath
+    }
+
+    private static def resolveProcessAndroidResources(BaseVariantOutput variantOutput) {
+        try {
+            return variantOutput.processResourcesProvider.get()
+        } catch (Throwable ignored) {
+            return variantOutput.processResources
+        }
     }
     /**
      * Searches the subdirectories of a given path and executes a block on

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -57,8 +57,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
             }
         }
 
-        Collection<ExternalNativeBuildTask> tasks = variant.externalNativeBuildTasks
-        for (ExternalNativeBuildTask task : tasks) {
+        for (ExternalNativeBuildTask task : resolveExternalNativeBuildTasks()) {
             File objFolder = task.objFolder
             File soFolder = task.soFolder
             findSharedObjectFiles(objFolder, processor)
@@ -71,6 +70,17 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
         }
         if (!sharedObjectFound) {
             project.logger.error("No shared objects found")
+        }
+    }
+
+    private Collection<ExternalNativeBuildTask> resolveExternalNativeBuildTasks() {
+        try {
+            return variant.externalNativeBuildProviders
+                .stream()
+                .map({ it.get() })
+                .collect()
+        } catch (Throwable ignored) {
+            return variant.externalNativeBuildTasks
         }
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -4,8 +4,6 @@ import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
 import groovy.xml.Namespace
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.Directory
-import org.gradle.api.provider.Provider
 
 import java.nio.file.Paths
 
@@ -34,7 +32,8 @@ class BugsnagVariantOutputTask extends DefaultTask {
      */
     File getManifestPath() {
         File directory
-        def outputDir = variantOutput.processManifest.manifestOutputDirectory
+        def processManifest = BugsnagPlugin.resolveProcessManifest(variantOutput)
+        def outputDir = processManifest.manifestOutputDirectory
 
         if (outputDir instanceof File) {
             directory = outputDir


### PR DESCRIPTION
## Goal

3.4-alpha of the Android Gradle Plugin has introduced new Provider APIs, which are meant to [avoid unnecessary tasks](https://developer.android.com/studio/preview/features/?utm_source=android-studio#lazy_task_config). In a project with 3.4-alpha our plugin now logs warnings about using deprecated APIs, and suggests that we should use the Provider API instead. This changeset updates our plugin to follow these recommendations.

## Design

The following locations are affected by deprecated APIs:
```
variantOutput.getProcessManifest(): com.bugsnag.android.gradle.BugsnagPlugin.setupManifestUuidTask(BugsnagPlugin.groovy:245)
variantOutput.getAssemble(): com.bugsnag.android.gradle.BugsnagPlugin.findTaskNamesForPrefix(BugsnagPlugin.groovy:229)
variantOutput.getProcessResources(): com.bugsnag.android.gradle.BugsnagUploadNdkTask.upload(BugsnagUploadNdkTask.groovy:46)
variant.getExternalNativeBuildTasks(): com.bugsnag.android.gradle.BugsnagUploadNdkTask.upload(BugsnagUploadNdkTask.groovy:60)
```

The new APIs follow this general naming convention:

```
variant.assemble // (deprecated API) eagerly accesses the assemble task
variant.assembleProvider.get() // (new API) accesses the assemble task only when required
```

Invoking the Provider API will throw an exception if the Gradle wrapper is below 5.1-RC. This can be exploited with a try-catch blocks to use the Provider API on new gradle versions, and fall back to the eager API on older versions.

## Tests

I installed a local maven artefact into the current example project, then ran `./gradlew assembleRelease`, confirming that no warnings relating to 'sdkAppExample' were logged.

I then updated the example project to the latest Canary channel, then performed the same action. An example is available on [this branch](https://github.com/bugsnag/bugsnag-android/tree/3.4-example-app). Note that due to an unrelated bug with the shared object file copy task, the bugsnag-android-ndk integration was replaced with bugsnag-android. However, this should not affect the running of the NDK upload task.

Note: the CI is also failing due to apparently unrelated issues.
