### PR TITLE
Pin specific version of cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
   - echo y | sdkmanager "platform-tools" >/dev/null
   - echo y | sdkmanager "tools" >/dev/null
   - echo y | sdkmanager "build-tools;27.0.3" >/dev/null
+  - echo y | sdkmanager 'cmake;3.6.4111459'
   - gem install bundler
   - bundle install
   - ls $ANDROID_HOME


### PR DESCRIPTION
The cmake version installed on Travis CI was bumped sometime in the last month, causing the NDK fixture to fail at compile-time. This alters the environment to install the previous version of cmake.