### PR TITLE
Be aware of errors during mapping uploads

### DIFF
--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
@@ -9,6 +9,9 @@ import org.apache.http.impl.client.DefaultHttpClient
 import org.apache.http.params.HttpConnectionParams
 import org.apache.http.params.HttpParams
 import org.apache.http.util.EntityUtils
+import org.gradle.api.GradleException
+import org.gradle.api.GradleScriptException
+
 /**
  Task to upload ProGuard mapping files to Bugsnag.
 
@@ -36,7 +39,11 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
     def uploadMultipartEntity(MultipartEntity mpEntity) {
         if (apiKey == null) {
             project.logger.warn("Skipping upload due to invalid parameters")
-            return
+            if (project.bugsnag.failOnUploadError) {
+                throw new GradleException("Skipping upload due to invalid parameters")
+            } else {
+                return
+            }
         }
 
         addPropertiesToMultipartEntity(mpEntity)
@@ -50,6 +57,10 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
                 maxRetryCount - retryCount + 1, maxRetryCount))
             uploadSuccessful = uploadToServer(mpEntity)
             retryCount--
+        }
+
+        if (!uploadSuccessful && project.bugsnag.failOnUploadError) {
+            throw new GradleException("Upload did not succeed")
         }
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
@@ -17,6 +17,7 @@ class BugsnagPluginExtension {
     boolean ndk = false
     String sharedObjectPath = null
     String projectRoot = null
+    boolean failOnUploadError = false
 
     // release API values
     String builderName = null

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
@@ -4,6 +4,7 @@ import org.apache.http.entity.mime.HttpMultipartMode
 import org.apache.http.entity.mime.MultipartEntity
 import org.apache.http.entity.mime.content.FileBody
 import org.apache.http.util.TextUtils
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 
@@ -42,7 +43,11 @@ class BugsnagUploadProguardTask extends BugsnagMultiPartUploadTask {
         // will not exist (but we also won't need it).
         if (!mappingFile || !mappingFile.exists()) {
             project.logger.warn("Mapping file not found: ${mappingFile}")
-            return
+            if (project.bugsnag.failOnUploadError) {
+                throw new GradleException("Mapping file not found: ${mappingFile}")
+            } else {
+                return
+            }
         }
 
         // Read the API key and Build ID etc..

--- a/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
@@ -31,6 +31,7 @@ class PluginExtensionTest {
         assertFalse(proj.bugsnag.ndk)
         assertNull(proj.bugsnag.sharedObjectPath)
         assertFalse(BugsnagPlugin.hasDexguardPlugin(proj))
+        assertFalse(proj.bugsnag.failOnUploadError)
 
         assertFalse(BugsnagPlugin.hasMultipleOutputs(proj))
 


### PR DESCRIPTION
## Goal
Allow users to be aware of errors during mapping uploads and react accordingly if needed.

For us it would be helpful as we could be generating release apks where the upload of the mapping fails, leaving us with obfuscated crashes in Bugsnag's dashboard until someone manually fixes that.

This change lets users decide if they want to fail their release build if the upload of the mapping fails if they feel so.

A new `failOnUploadError` property, that defaults to **false**, has been added. 

## Tests

Manual testing of a build with no connectivity.