### PR TITLE
Fail on upload error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.X.X (TBD)
+
+Note: this version of the plugin will fail the build if a mapping file is not uploaded successfully.
+Previously if this occurred the failure would have been logged as an error and the build would have continued.
+
+* Fail on upload error
+[#151](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/151)
+
 ## 4.0.0 (TBD)
 
 * Remove support for Jack compiler

--- a/features/fail_on_upload_error.feature
+++ b/features/fail_on_upload_error.feature
@@ -1,0 +1,29 @@
+Feature: Build stops when mapping file upload fails
+
+Scenario: Upload successfully with API key, mapping file, and correct endpoint
+    When I build "default_app" using the "standard" bugsnag config
+    Then I should receive 2 requests
+    And the exit code equals 0
+
+Scenario: No uploads or build failures when obfuscation is disabled
+    When I build the failing "disabled_obfuscation" using the "standard" bugsnag config
+    Then I should receive 1 request
+    And the request 0 is valid for the Build API
+    And the exit code equals 0
+
+Scenario: Upload failure due to empty API key
+    When I build the failing "default_app" using the "empty_api_key" bugsnag config
+    Then I should receive 1 request
+    And the request 0 is valid for the Build API
+    And the exit code equals 1
+
+Scenario: Upload failure due to connectivity failure
+    When I build the failing "default_app" using the "wrong_endpoint" bugsnag config
+    Then I should receive 0 requests
+    And the exit code equals 1
+
+Scenario: Upload failure due to missing mapping file
+    When I build the failing "missing_mapping_file" using the "standard" bugsnag config
+    Then I should receive 1 request
+    And the request 0 is valid for the Build API
+    And the exit code equals 1

--- a/features/fail_on_upload_error.feature
+++ b/features/fail_on_upload_error.feature
@@ -6,10 +6,8 @@ Scenario: Upload successfully with API key, mapping file, and correct endpoint
     And the exit code equals 0
 
 Scenario: No uploads or build failures when obfuscation is disabled
-    When I build the failing "disabled_obfuscation" using the "standard" bugsnag config
-    Then I should receive 1 request
-    And the request 0 is valid for the Build API
-    And the exit code equals 0
+    When I build "disabled_obfuscation" using the "standard" bugsnag config
+    Then I should receive 0 requests
 
 Scenario: Upload failure due to empty API key
     When I build the failing "default_app" using the "empty_api_key" bugsnag config

--- a/features/fail_on_upload_error.feature
+++ b/features/fail_on_upload_error.feature
@@ -8,6 +8,7 @@ Scenario: Upload successfully with API key, mapping file, and correct endpoint
 Scenario: No uploads or build failures when obfuscation is disabled
     When I build "disabled_obfuscation" using the "standard" bugsnag config
     Then I should receive 0 requests
+    And the exit code equals 0
 
 Scenario: Upload failure due to empty API key
     When I build the failing "default_app" using the "empty_api_key" bugsnag config

--- a/features/fixtures/app/module/config/android/disabled_obfuscation.gradle
+++ b/features/fixtures/app/module/config/android/disabled_obfuscation.gradle
@@ -1,0 +1,20 @@
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion Integer.parseInt(project.ANDROID_COMPILE_SDK_VERSION)
+    buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
+
+    defaultConfig {
+        applicationId 'com.bugsnag.android.example'
+        minSdkVersion Integer.parseInt(project.ANDROID_MIN_SDK_VERSION)
+        targetSdkVersion Integer.parseInt(project.ANDROID_TARGET_SDK_VERSION)
+        versionCode Integer.parseInt(project.SAMPLE_VERSION_CODE)
+        versionName project.SAMPLE_VERSION_NAME
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}

--- a/features/fixtures/app/module/config/android/missing_mapping_file.gradle
+++ b/features/fixtures/app/module/config/android/missing_mapping_file.gradle
@@ -1,0 +1,19 @@
+apply plugin: 'com.android.application'
+apply from: 'config/android/common.gradle'
+
+task deleteMappingFile {
+    doLast {
+        File mappingFile = new File("module/build/outputs/mapping/release/mapping.txt")
+        mappingFile.delete()
+        project.logger.lifecycle("Delete mapping file!")
+    }
+}
+
+// delete the mapping file after generation, but before bugsnag can upload it
+project.afterEvaluate {
+    project.android.applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            output.assemble.finalizedBy(deleteMappingFile)
+        }
+    }
+}

--- a/features/fixtures/app/module/config/bugsnag/empty_api_key.gradle
+++ b/features/fixtures/app/module/config/bugsnag/empty_api_key.gradle
@@ -1,0 +1,5 @@
+project.afterEvaluate {
+    project.bugsnag.apiKey = ""
+    project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+}

--- a/features/fixtures/app/module/config/bugsnag/wrong_endpoint.gradle
+++ b/features/fixtures/app/module/config/bugsnag/wrong_endpoint.gradle
@@ -1,0 +1,4 @@
+project.afterEvaluate {
+    project.bugsnag.endpoint = "http://localhost:12345"
+    project.bugsnag.releasesEndpoint = "http://localhost:12345"
+}

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -58,3 +58,17 @@ Then(/^the request (\d+) is valid for the Android NDK Mapping API$/) do |request
   assert_not_nil(parts["appId"], "'appId' should not be nil")
   assert_not_nil(parts["arch"], "'arch' should not be nil")
 end
+
+When("I build the failing {string} using the {string} bugsnag config") do |module_config, bugsnag_config|
+  begin
+    steps %Q{
+      When I build "#{module_config}" using the "#{bugsnag_config}" bugsnag config
+    }
+    assert(false, "Expected script to fail with non-zero exit code")
+  rescue SystemExit
+  end
+end
+
+Then(/^the exit code equals (\d+)$/) do |exit_code|
+  assert_equal(exit_code, $?.exitstatus.to_i)
+end

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
@@ -37,7 +37,7 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
     }
 
     def uploadMultipartEntity(MultipartEntity mpEntity) {
-        if (apiKey == null) {
+        if (apiKey == null || "" == apiKey) {
             project.logger.warn("Skipping upload due to invalid parameters")
             if (project.bugsnag.failOnUploadError) {
                 throw new GradleException("Skipping upload due to invalid parameters")

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
@@ -37,7 +37,7 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
     }
 
     def uploadMultipartEntity(MultipartEntity mpEntity) {
-        if (apiKey == null || "" == apiKey) {
+        if (apiKey == null || apiKey == "") {
             project.logger.warn("Skipping upload due to invalid parameters")
             if (project.bugsnag.failOnUploadError) {
                 throw new GradleException("Skipping upload due to invalid parameters")

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
@@ -9,6 +9,9 @@ import org.apache.http.impl.client.DefaultHttpClient
 import org.apache.http.params.HttpConnectionParams
 import org.apache.http.params.HttpParams
 import org.apache.http.util.EntityUtils
+import org.gradle.api.GradleException
+import org.gradle.api.GradleScriptException
+
 /**
  Task to upload ProGuard mapping files to Bugsnag.
 
@@ -36,7 +39,11 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
     def uploadMultipartEntity(MultipartEntity mpEntity) {
         if (apiKey == null) {
             project.logger.warn("Skipping upload due to invalid parameters")
-            return
+            if (project.bugsnag.failOnUploadError) {
+                throw new GradleException("Skipping upload due to invalid parameters")
+            } else {
+                return
+            }
         }
 
         addPropertiesToMultipartEntity(mpEntity)
@@ -50,6 +57,10 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
                 maxRetryCount - retryCount + 1, maxRetryCount))
             uploadSuccessful = uploadToServer(mpEntity)
             retryCount--
+        }
+
+        if (!uploadSuccessful && project.bugsnag.failOnUploadError) {
+            throw new GradleException("Upload did not succeed")
         }
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -113,6 +113,10 @@ class BugsnagPlugin implements Plugin<Project> {
         setupProguardAutoConfig(project, variant)
 
         variant.outputs.each { output ->
+            if (!variant.buildType.minifyEnabled && !hasDexguardPlugin(project)) {
+                return
+            }
+
             BugsnagTaskDeps deps = new BugsnagTaskDeps()
             deps.variant = variant
             deps.output = output

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
@@ -17,6 +17,7 @@ class BugsnagPluginExtension {
     boolean ndk = false
     String sharedObjectPath = null
     String projectRoot = null
+    boolean failOnUploadError = false
 
     // release API values
     String builderName = null

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
@@ -17,7 +17,7 @@ class BugsnagPluginExtension {
     boolean ndk = false
     String sharedObjectPath = null
     String projectRoot = null
-    boolean failOnUploadError = false
+    boolean failOnUploadError = true
 
     // release API values
     String builderName = null

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
@@ -4,6 +4,7 @@ import org.apache.http.entity.mime.HttpMultipartMode
 import org.apache.http.entity.mime.MultipartEntity
 import org.apache.http.entity.mime.content.FileBody
 import org.apache.http.util.TextUtils
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 
@@ -42,7 +43,11 @@ class BugsnagUploadProguardTask extends BugsnagMultiPartUploadTask {
         // will not exist (but we also won't need it).
         if (!mappingFile || !mappingFile.exists()) {
             project.logger.warn("Mapping file not found: ${mappingFile}")
-            return
+            if (project.bugsnag.failOnUploadError) {
+                throw new GradleException("Mapping file not found: ${mappingFile}")
+            } else {
+                return
+            }
         }
 
         // Read the API key and Build ID etc..

--- a/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
@@ -31,7 +31,7 @@ class PluginExtensionTest {
         assertFalse(proj.bugsnag.ndk)
         assertNull(proj.bugsnag.sharedObjectPath)
         assertFalse(BugsnagPlugin.hasDexguardPlugin(proj))
-        assertFalse(proj.bugsnag.failOnUploadError)
+        assertTrue(proj.bugsnag.failOnUploadError)
 
         assertFalse(BugsnagPlugin.hasMultipleOutputs(proj))
 

--- a/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
@@ -31,6 +31,7 @@ class PluginExtensionTest {
         assertFalse(proj.bugsnag.ndk)
         assertNull(proj.bugsnag.sharedObjectPath)
         assertFalse(BugsnagPlugin.hasDexguardPlugin(proj))
+        assertFalse(proj.bugsnag.failOnUploadError)
 
         assertFalse(BugsnagPlugin.hasMultipleOutputs(proj))
 


### PR DESCRIPTION
## Goal

Adds mazerunner scenarios to verify the changes within #150, which fails the build if a mapping file upload task was not successful.

## Changeset

- Includes the implementation from #150
- Sets `failOnUploadError` to true by default
- Fails the build if an API key is empty, in addition to null, during an upload task
- If a build variant does not have obfuscation enabled via `minifyEnabled` and has not applied the DexGuard plugin, the previous behaviour was to create an upload task that failed as there would be no mapping file. This task will no longer be created.

## Tests
- Added mazerunner steps which check the exit code of a script, and for running a script that is expected to exit with a non-zero exit code
- Created mazerunner scenarios where the build is expected to fail due to:
  - an empty API key
  - using the wrong endpoint
  - a missing mapping file
- Created mazerunner scenarios where the build is expected to pass due to:
  - Uploading in a default app, with an API key, mapping file, and correct endpoint specified
  - Deobfuscation being disabled, therefore the plugin would not need to upload any mapping files
