### PR TITLE
Fix task ordering of build UUID generation when shrinkResources enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.2 (2019-04-02)
+
+* Fix task ordering of build UUID generation when shrinkResources enabled
+[#155](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/155)
+
 ## 4.1.1 (2019-03-21)
 
 * Add BUILD_UUID to app bundle manifests

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.bugsnag
-version = 4.1.1
+version = 4.1.2
 
 ANDROID_MIN_SDK_VERSION=14
 ANDROID_TARGET_SDK_VERSION=27

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -255,8 +255,19 @@ class BugsnagPlugin implements Plugin<Project> {
     private static void setupManifestUuidTask(Project project, BugsnagTaskDeps deps) {
         BugsnagManifestTask manifestTask = project.tasks.create("processBugsnag${taskNameForOutput(deps.output)}Manifest", BugsnagManifestTask)
         setupBugsnagTask(manifestTask, deps)
-        def processManifest = resolveProcessManifest(deps.output)
+        ManifestProcessorTask processManifest = resolveProcessManifest(deps.output)
+
         processManifest.finalizedBy(manifestTask)
+        manifestTask.dependsOn(processManifest)
+
+        def resourceTasks = project.tasks.findAll {
+            def name = it.name.toLowerCase()
+            name.contains("bundle") && name.contains("resources")
+        }
+
+        resourceTasks.forEach {
+            it.dependsOn manifestTask
+        }
     }
 
     static def resolveProcessManifest(BaseVariantOutput output) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -262,7 +262,7 @@ class BugsnagPlugin implements Plugin<Project> {
 
         def resourceTasks = project.tasks.findAll {
             def name = it.name.toLowerCase()
-            name.contains("bundle") && name.contains("resources")
+            name.startsWith("bundle") && name.endsWith("resources")
         }
 
         resourceTasks.forEach {


### PR DESCRIPTION
## Goal

In a project with App Bundles, the plugin could write to the manifest in the build directory after it had been packaged into a bundle. This meant the build UUID was not inserted into the final AAB, and crashes in generated APKs would not deobfuscate.

This behaviour only occurs in projects where [`shrinkResources`](https://developer.android.com/studio/build/shrink-code) is enabled and build app bundles. This is because the additional shrinkResource task alters the overall ordering of the tasks and results in the bundling process happening much earlier.

The fix ensures that the `bundleResources` task has a dependency on the manifest manipulation task, so that the build UUID will always be generated before bundling.

## Changeset
- Ensure the `manifestTask` depends on the AGP processManifest task, as it doesn't make sense to run if no manifest is on the filesystem
- Ensure that the `bundleResource` task (and its variants) depend on the `manifestTask`, as it doesn't make sense to bundle unless the manifest has been manipulated first

For an overview of Gradle task dependencies, please [see the docs](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:adding_dependencies_to_tasks).

## Discussion

I have reproduced the behaviour on the [following branch](https://github.com/bugsnag/bugsnag-android/tree/agp-repro), which enables resource shrinking in an example Android app.

I tested behaviour using `./gradlew sdkAppExample:bundleRelease --dry-run`. I inspected the `AndroidManifest.xml`'s build UUID using the [APK Analyzer](https://developer.android.com/studio/build/apk-analyzer) and [bundletool](https://developer.android.com/studio/command-line/bundletool).

With resource shrinking enabled, the manifest is processed after `bundleReleaseResources` and no build UUID is present in the AAB:

```
:sdkAppExample:processReleaseManifest SKIPPED
:sdkAppExample:bundleReleaseResources SKIPPED
:sdkAppExample:processBugsnagReleaseManifest SKIPPED
```

With resource shrinking disabled, the manifest is processed before `bundleReleaseResources` and a build UUID is present in the AAB

```
:sdkAppExample:processReleaseManifest SKIPPED
:sdkAppExample:processBugsnagReleaseManifest SKIPPED
:sdkAppExample:bundleReleaseResources SKIPPED
```

## Tests

I manually verified that a build UUID is inserted for App Bundles and APKs, in the simple example app.

We likely need automated tests and more complicated manual test scenarios, which is why this PR is marked as WIP.

## Workaround

This behaviour only occurs in a project which builds App Bundles with `shrinkResources` enabled. There are two workarounds, ordered in preference:

1. Users could invoke the manifest manipulation task manually, in addition to the bundle task. For a release build, this might look something like this:

```
./gradlew sdkAppExample:processBugsnagReleaseManifest sdkAppExample:bundleRelease
```

Full rules for how the `variantOutputName` is generated are documented [here](https://docs.bugsnag.com/build-integrations/gradle/#uploading-proguard-dexguard-and-r8-mappings).


2. Alternatively, users could manually specify their own build UUID in their manifest whenever JVM code is altered and a new release is deployed:

```
<meta-data
    android:name="com.bugsnag.android.BUILD_UUID"
    android:value="build-number-31" />
</application>
```