### PR TITLE
Alter NDK project detection to check for the cmake/ndkbuild path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.X.X (TBD)
+
+* Alter NDK project detection to check for the cmake/ndkbuild path
+[#156](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/156)
+
 ## 4.1.2 (2019-04-02)
 
 * Fix task ordering of build UUID generation when shrinkResources enabled

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -159,10 +159,9 @@ class BugsnagPlugin implements Plugin<Project> {
         if (project.bugsnag.ndk != null) { // always respect user override
             return project.bugsnag.ndk
         } else { // infer whether native build or not
-            def tasks = project.tasks.findAll()
-            return tasks.stream().anyMatch {
-                it.name.startsWith("externalNative")
-            }
+            boolean usesCmake = project.android.externalNativeBuild.cmake.path != null
+            boolean usesNdkBuild = project.android.externalNativeBuild.ndkBuild.path != null
+            return usesCmake || usesNdkBuild
         }
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
@@ -14,7 +14,7 @@ class BugsnagPluginExtension {
     boolean uploadDebugBuildMappings = false
     boolean overwrite = false
     int retryCount = 0
-    boolean ndk = false
+    Boolean ndk = null
     String sharedObjectPath = null
     String projectRoot = null
     boolean failOnUploadError = true

--- a/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
@@ -28,7 +28,7 @@ class PluginExtensionTest {
         assertFalse(proj.bugsnag.uploadDebugBuildMappings)
         assertFalse(proj.bugsnag.overwrite)
         assertEquals(0, proj.bugsnag.retryCount)
-        assertFalse(proj.bugsnag.ndk)
+        assertNull(proj.bugsnag.ndk)
         assertNull(proj.bugsnag.sharedObjectPath)
         assertFalse(BugsnagPlugin.hasDexguardPlugin(proj))
         assertTrue(proj.bugsnag.failOnUploadError)


### PR DESCRIPTION
## Goal
The NDK project detection currently checks for the presence of any task starting with 'externalNative'. I believe that depending on which task was invoked and what Gradle version is used, this task may not necessarily be created when our plugin configures its own tasks, so the JNI libs are not copied across.

This approach is somewhat flaky anyway, so we should change it to a more stable heuristic that is part of AGP's exposed API.

## Changeset
We now assume that the project uses the NDK if either the cmake path or ndkBuild path are not null. The user can override this behaviour.


