### PR TITLE
Disable proguard mapping task setup when variant does not obfuscate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.X.X (TBD)
+
+* Disable proguard mapping task setup when variant does not obfuscate
+[#157](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/157)
+
 ## 4.1.2 (2019-04-02)
 
 * Fix task ordering of build UUID generation when shrinkResources enabled

--- a/features/fail_on_upload_error.feature
+++ b/features/fail_on_upload_error.feature
@@ -7,7 +7,8 @@ Scenario: Upload successfully with API key, mapping file, and correct endpoint
 
 Scenario: No uploads or build failures when obfuscation is disabled
     When I build "disabled_obfuscation" using the "standard" bugsnag config
-    Then I should receive 0 requests
+    Then I should receive 1 request
+    And the request 0 is valid for the Build API
     And the exit code equals 0
 
 Scenario: Upload failure due to empty API key

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -114,16 +114,16 @@ class BugsnagPlugin implements Plugin<Project> {
         setupProguardAutoConfig(project, variant)
 
         variant.outputs.each { output ->
-            if (!variant.buildType.minifyEnabled && !hasDexguardPlugin(project)) {
-                return
-            }
-
             BugsnagTaskDeps deps = new BugsnagTaskDeps()
             deps.variant = variant
             deps.output = output
 
             setupManifestUuidTask(project, deps)
-            setupMappingFileUpload(project, deps)
+
+            if (variant.buildType.minifyEnabled || hasDexguardPlugin(project)) {
+                setupMappingFileUpload(project, deps)
+            }
+
             setupNdkMappingFileUpload(project, deps)
             setupReleasesTask(project, deps)
         }


### PR DESCRIPTION
## Goal

Currently the plugin does not setup any tasks if ProGuard/DexGuard is disabled. This prevents the upload of NDK symbols/release information if a user has a project without obfuscation enabled.

## Changeset
Altered the plugin so that only the setup for the proguard mapping file task is skipped if a variant has obfuscation disabled.

## Tests
Ran `./gradlew assemble` in a project with `minifyEnabled false` using the current version of the plugin and then a local artefact. I visually inspected the gradle console and confirmed that the NDK upload task was run.


