### PR TITLE
Add codenarc static analysis plugin to project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - sudo apt-get install -y nodejs
 
 script:
+  - ./gradlew check
   - ./gradlew clean install --stacktrace
   - ./gradlew clean build --stacktrace
   - bundle exec maze-runner -c --verbose

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
 // Gradle plugins
 plugins {
     id 'groovy'
+    id 'codenarc'
     id 'com.gradle.plugin-publish' version '0.9.7'
     id 'com.bmuschko.nexus' version '2.3.1'
     id 'com.jfrog.bintray' version '1.8.4'
@@ -142,4 +143,10 @@ bintray {
 
 task wrapper(type: Wrapper) {
     gradleVersion = '4.4'
+}
+
+codenarc {
+    // ignore baseline violations for now
+    maxPriority2Violations 86
+    maxPriority3Violations 146
 }

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -1,0 +1,28 @@
+<ruleset xmlns="http://codenarc.org/ruleset/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://codenarc.org/ruleset/1.0 http://codenarc.org/ruleset-schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://codenarc.org/ruleset-schema.xsd">
+
+  <!-- See http://codenarc.sourceforge.net/StarterRuleSet-AllRulesByCategory.groovy.txt -->
+
+  <ruleset-ref path='rulesets/basic.xml'/>
+  <ruleset-ref path='rulesets/braces.xml'/>
+  <ruleset-ref path='rulesets/concurrency.xml'/>
+  <ruleset-ref path='rulesets/convention.xml'/>
+  <ruleset-ref path='rulesets/design.xml'/>
+  <ruleset-ref path='rulesets/dry.xml'/>
+  <ruleset-ref path='rulesets/enhanced.xml'/>
+  <ruleset-ref path='rulesets/exceptions.xml'/>
+  <ruleset-ref path='rulesets/formatting.xml'/>
+  <ruleset-ref path='rulesets/generic.xml'/>
+  <ruleset-ref path='rulesets/groovyism.xml'/>
+  <ruleset-ref path='rulesets/imports.xml'/>
+  <ruleset-ref path='rulesets/logging.xml'/>
+  <ruleset-ref path='rulesets/naming.xml'/>
+  <ruleset-ref path='rulesets/security.xml'/>
+  <ruleset-ref path='rulesets/serialization.xml'/>
+  <ruleset-ref path='rulesets/size.xml'/>
+  <ruleset-ref path='rulesets/unnecessary.xml'>
+    <exclude name='UnnecessaryGString'/> <!-- Prefer double quotes over single quotes -->
+  </ruleset-ref>
+  <ruleset-ref path='rulesets/unused.xml'/>
+</ruleset>


### PR DESCRIPTION
## Goal

Adding static analysis should improve the quality of new Groovy code and catch non-idiomatic usages. It will also allow us to view existing style violations and tackle technical debt.

We should add the [CodeNarc](http://codenarc.sourceforge.net/) plugin as this is most commonly used on Groovy. If we decide to migrate code over to Java/Kotlin at a later date, then we can consider also adding Lint/Checkstyle/Detekt.

## Changeset

- Applied codenarc gradle plugin to project
- Ran codenarc on CI by default
- Used the default ruleset with the exception of suppressing of `UnnecessaryGString` as this rule had ~200 violations complaining about double quotes rather than single quotes
