### PR TITLE
Resolve pre-existing codenarc style violations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,6 @@ task wrapper(type: Wrapper) {
 
 codenarc {
     // ignore baseline violations for now
-    maxPriority2Violations 86
-    maxPriority3Violations 146
+    maxPriority2Violations 7
+    maxPriority3Violations 8
 }

--- a/build.gradle
+++ b/build.gradle
@@ -148,5 +148,5 @@ task wrapper(type: Wrapper) {
 codenarc {
     // ignore baseline violations for now
     maxPriority2Violations 7
-    maxPriority3Violations 8
+    maxPriority3Violations 9
 }

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -8,7 +8,9 @@
   <ruleset-ref path='rulesets/braces.xml'/>
   <ruleset-ref path='rulesets/concurrency.xml'/>
   <ruleset-ref path='rulesets/convention.xml'/>
-  <ruleset-ref path='rulesets/design.xml'/>
+  <ruleset-ref path='rulesets/design.xml'>
+    <exclude name='Instanceof'/>
+  </ruleset-ref>
   <ruleset-ref path='rulesets/dry.xml'/>
   <ruleset-ref path='rulesets/enhanced.xml'/>
   <ruleset-ref path='rulesets/exceptions.xml'/>
@@ -16,7 +18,11 @@
     <exclude name='ClassJavadoc'/>
   </ruleset-ref>
   <ruleset-ref path='rulesets/generic.xml'/>
-  <ruleset-ref path='rulesets/groovyism.xml'/>
+  <ruleset-ref path='rulesets/groovyism.xml'>
+    <exclude name="ExplicitArrayListInstantiation"/>
+    <exclude name="ExplicitHashSetInstantiation"/>
+    <exclude name="ExplicitHashMapInstantiation"/>
+  </ruleset-ref>
   <ruleset-ref path='rulesets/imports.xml'/>
   <ruleset-ref path='rulesets/logging.xml'/>
   <ruleset-ref path='rulesets/naming.xml'/>
@@ -28,6 +34,7 @@
   <ruleset-ref path='rulesets/unnecessary.xml'>
     <exclude name='UnnecessaryGString'/> <!-- Prefer double quotes over single quotes -->
     <exclude name='UnnecessaryElseStatement'/>
+    <exclude name='UnnecessaryToString'/>
   </ruleset-ref>
   <ruleset-ref path='rulesets/unused.xml'/>
 </ruleset>

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -20,7 +20,9 @@
   <ruleset-ref path='rulesets/imports.xml'/>
   <ruleset-ref path='rulesets/logging.xml'/>
   <ruleset-ref path='rulesets/naming.xml'/>
-  <ruleset-ref path='rulesets/security.xml'/>
+  <ruleset-ref path='rulesets/security.xml'>
+    <exclude name="JavaIoPackageAccess"/> <!-- We need to perform IO and don't care about meeting the Java Bean spec -->
+  </ruleset-ref>
   <ruleset-ref path='rulesets/serialization.xml'/>
   <ruleset-ref path='rulesets/size.xml'/>
   <ruleset-ref path='rulesets/unnecessary.xml'>

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -12,7 +12,9 @@
   <ruleset-ref path='rulesets/dry.xml'/>
   <ruleset-ref path='rulesets/enhanced.xml'/>
   <ruleset-ref path='rulesets/exceptions.xml'/>
-  <ruleset-ref path='rulesets/formatting.xml'/>
+  <ruleset-ref path='rulesets/formatting.xml'>
+    <exclude name='ClassJavadoc'/>
+  </ruleset-ref>
   <ruleset-ref path='rulesets/generic.xml'/>
   <ruleset-ref path='rulesets/groovyism.xml'/>
   <ruleset-ref path='rulesets/imports.xml'/>
@@ -23,6 +25,7 @@
   <ruleset-ref path='rulesets/size.xml'/>
   <ruleset-ref path='rulesets/unnecessary.xml'>
     <exclude name='UnnecessaryGString'/> <!-- Prefer double quotes over single quotes -->
+    <exclude name='UnnecessaryElseStatement'/>
   </ruleset-ref>
   <ruleset-ref path='rulesets/unused.xml'/>
 </ruleset>

--- a/src/main/groovy/com/bugsnag/android/gradle/Abi.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/Abi.groovy
@@ -1,5 +1,6 @@
 package com.bugsnag.android.gradle
 
+@SuppressWarnings('DuplicateStringLiteral')
 enum Abi {
 
     ARMEABI(

--- a/src/main/groovy/com/bugsnag/android/gradle/Abi.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/Abi.groovy
@@ -26,7 +26,7 @@ enum Abi {
         "x86_64",
         "x86_64",
         "x86_64-linux-android"
-    );
+    )
 
     final String abiName
     final String toolchainPrefix

--- a/src/main/groovy/com/bugsnag/android/gradle/Abi.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/Abi.groovy
@@ -44,6 +44,6 @@ enum Abi {
                 return value
             }
         }
-        return null
+        null
     }
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/Abi.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/Abi.groovy
@@ -1,6 +1,9 @@
 package com.bugsnag.android.gradle
 
+import groovy.transform.CompileStatic
+
 @SuppressWarnings('DuplicateStringLiteral')
+@CompileStatic
 enum Abi {
 
     ARMEABI(

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -54,7 +54,7 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
                 }
 
                 // Add the new BUILD_UUID_TAG element
-                application.appendNode(TAG_META_DATA, [(ns.name): BugsnagPlugin.BUILD_UUID_TAG, (ns.value): buildUUID])
+                application.appendNode(TAG_META_DATA, [(ns.name):BugsnagPlugin.BUILD_UUID_TAG, (ns.value):buildUUID])
 
                 // Write the manifest file
                 FileWriter writer = null

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -96,6 +96,6 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
                 }
             }
         }
-        return false
+        false
     }
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -2,6 +2,7 @@ package com.bugsnag.android.gradle
 
 import groovy.xml.Namespace
 import org.gradle.api.tasks.TaskAction
+
 /**
  Task to add a unique build UUID to AndroidManifest.xml during the build
  process. This is used by Bugsnag to identify which proguard mapping file

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -67,7 +67,8 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
                     }
                 }
             } else {
-                project.logger.error("Bugsnag detected invalid manifest with no application element so did not write Build UUID")
+                project.logger.error("Bugsnag detected invalid manifest with no " +
+                    "application element so did not write Build UUID")
             }
         }
     }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -25,13 +25,13 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
     }
 
     @TaskAction
-    def updateManifest() {
-        def manifestPaths = getManifestPaths()
+    void updateManifest() {
+        List<File> manifestPaths = getManifestPaths()
 
         // Uniquely identify the build so that we can identify the proguard file.
-        def buildUUID = UUID.randomUUID().toString()
+        String buildUUID = UUID.randomUUID().toString()
 
-        for (def manifestPath in manifestPaths) {
+        for (File manifestPath in manifestPaths) {
             if (!manifestPath.exists()) {
                 continue
             }
@@ -39,8 +39,8 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
             project.logger.debug("Updating manifest with build UUID: " + manifestPath)
 
             // Parse the AndroidManifest.xml
-            def ns = new Namespace(NS_URI_ANDROID, NS_PREFIX_ANDROID)
-            def xml = new XmlParser().parse(manifestPath)
+            Namespace ns = new Namespace(NS_URI_ANDROID, NS_PREFIX_ANDROID)
+            Node xml = new XmlParser().parse(manifestPath)
 
             def application = xml.application[0]
             if (application) {
@@ -61,7 +61,7 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
 
                 try {
                     writer = new FileWriter(manifestPath)
-                    def printer = new XmlNodePrinter(new PrintWriter(writer))
+                    XmlNodePrinter printer = new XmlNodePrinter(new PrintWriter(writer))
                     printer.preserveWhitespace = true
                     printer.print(xml)
                 } catch (Exception e) {
@@ -78,22 +78,22 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
         }
     }
 
-    def isInstantRun() {
+    boolean isInstantRun() {
         project.properties["android.optional.compilation"]?.contains("INSTANT_DEV")
     }
 
-    def shouldRun() {
-        def manifestPaths = getManifestPaths()
+    boolean shouldRun() {
+        List<File> manifestPaths = getManifestPaths()
 
-        for (def manifestPath in manifestPaths) {
+        for (File manifestPath in manifestPaths) {
             if (!manifestPath.exists()) {
                 continue
             }
 
-            def ns = new Namespace(NS_URI_ANDROID, NS_PREFIX_ANDROID)
+            Namespace ns = new Namespace(NS_URI_ANDROID, NS_PREFIX_ANDROID)
             def app = new XmlParser().parse(manifestPath).application[0]
             if (app) {
-                def tagCount = app[TAG_META_DATA].findAll {
+                int tagCount = app[TAG_META_DATA].findAll {
                     (it.attributes()[ns.name] == BugsnagPlugin.BUILD_UUID_TAG)
                 }.size()
                 if (tagCount == 0 || !isInstantRun()) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -26,12 +26,12 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
 
     @TaskAction
     void updateManifest() {
-        List<File> manifestPaths = getManifestPaths()
+        List<File> paths = manifestPaths
 
         // Uniquely identify the build so that we can identify the proguard file.
         String buildUUID = UUID.randomUUID().toString()
 
-        for (File manifestPath in manifestPaths) {
+        for (File manifestPath in paths) {
             if (!manifestPath.exists()) {
                 continue
             }
@@ -83,9 +83,9 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
     }
 
     boolean shouldRun() {
-        List<File> manifestPaths = getManifestPaths()
+        List<File> paths = manifestPaths
 
-        for (File manifestPath in manifestPaths) {
+        for (File manifestPath in paths) {
             if (!manifestPath.exists()) {
                 continue
             }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -64,7 +64,7 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
                     XmlNodePrinter printer = new XmlNodePrinter(new PrintWriter(writer))
                     printer.preserveWhitespace = true
                     printer.print(xml)
-                } catch (Exception e) {
+                } catch (IOException e) {
                     project.logger.warn("Failed to update manifest with Bugsnag metadata", e)
                 } finally {
                     if (writer != null) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
@@ -10,7 +10,6 @@ import org.apache.http.params.HttpConnectionParams
 import org.apache.http.params.HttpParams
 import org.apache.http.util.EntityUtils
 import org.gradle.api.GradleException
-import org.gradle.api.GradleScriptException
 
 /**
  Task to upload ProGuard mapping files to Bugsnag.

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
@@ -3,7 +3,6 @@ package com.bugsnag.android.gradle
 import org.apache.http.HttpEntity
 import org.apache.http.HttpResponse
 import org.apache.http.ParseException
-import org.apache.http.client.ClientProtocolException
 import org.apache.http.client.HttpClient
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.entity.mime.MultipartEntity
@@ -27,16 +26,12 @@ import org.gradle.api.GradleException
  it is usually safe to have this be the absolute last task executed during
  a build.
  */
-abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
+class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
 
     static final int MAX_RETRY_COUNT = 5
     static final int TIMEOUT_MILLIS = 60000 // 60 seconds
 
     String applicationId
-
-    BugsnagMultiPartUploadTask() {
-        super()
-    }
 
     void uploadMultipartEntity(MultipartEntity mpEntity) {
         if (apiKey == null || apiKey == "") {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
@@ -64,7 +64,7 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
         }
     }
 
-    def addPropertiesToMultipartEntity(MultipartEntity mpEntity) {
+    void addPropertiesToMultipartEntity(MultipartEntity mpEntity) {
         mpEntity.addPart("apiKey", new StringBody(apiKey))
         mpEntity.addPart("appId", new StringBody(applicationId))
         mpEntity.addPart("versionCode", new StringBody(versionCode))
@@ -102,7 +102,7 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
         HttpConnectionParams.setSoTimeout(params, TIMEOUT_MILLIS)
 
         int statusCode
-        def responseEntity
+        String responseEntity
         try {
             HttpResponse response = httpClient.execute(httpPost)
             statusCode = response.statusLine.statusCode

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
@@ -2,6 +2,8 @@ package com.bugsnag.android.gradle
 
 import org.apache.http.HttpEntity
 import org.apache.http.HttpResponse
+import org.apache.http.ParseException
+import org.apache.http.client.ClientProtocolException
 import org.apache.http.client.HttpClient
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.entity.mime.MultipartEntity
@@ -108,7 +110,7 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
             statusCode = response.statusLine.statusCode
             HttpEntity entity = response.entity
             responseEntity = EntityUtils.toString(entity, "utf-8")
-        } catch (Exception e) {
+        } catch (IOException | ParseException e) {
             project.logger.error(String.format("Bugsnag upload failed: %s", e))
             return false
         }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
@@ -119,7 +119,7 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
 
         project.logger.error(String.format("Bugsnag upload failed with code %d: %s",
             statusCode, responseEntity))
-        return false
+        false
     }
 
     /**
@@ -129,7 +129,7 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
      * @return the retry count
      */
     int getRetryCount() {
-        return project.bugsnag.retryCount >= MAX_RETRY_COUNT ? MAX_RETRY_COUNT : project.bugsnag.retryCount
+        project.bugsnag.retryCount >= MAX_RETRY_COUNT ? MAX_RETRY_COUNT : project.bugsnag.retryCount
     }
 
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
@@ -39,7 +39,7 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
         if (apiKey == null || apiKey == "") {
             project.logger.warn("Skipping upload due to invalid parameters")
             if (project.bugsnag.failOnUploadError) {
-                throw new GradleException("Skipping upload due to invalid parameters")
+                throw new GradleException("Aborting upload due to invalid parameters")
             } else {
                 return
             }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
@@ -35,7 +35,7 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
         super()
     }
 
-    def uploadMultipartEntity(MultipartEntity mpEntity) {
+    void uploadMultipartEntity(MultipartEntity mpEntity) {
         if (apiKey == null || apiKey == "") {
             project.logger.warn("Skipping upload due to invalid parameters")
             if (project.bugsnag.failOnUploadError) {
@@ -49,8 +49,8 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
 
         boolean uploadSuccessful = uploadToServer(mpEntity)
 
-        def maxRetryCount = getRetryCount()
-        def retryCount = maxRetryCount
+        int maxRetryCount = getRetryCount()
+        int retryCount = maxRetryCount
         while (!uploadSuccessful && retryCount > 0) {
             project.logger.warn(String.format("Retrying Bugsnag upload (%d/%d) ...",
                 maxRetryCount - retryCount + 1, maxRetryCount))

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
@@ -1,5 +1,6 @@
 package com.bugsnag.android.gradle
 
+import org.apache.http.HttpEntity
 import org.apache.http.HttpResponse
 import org.apache.http.client.HttpClient
 import org.apache.http.client.methods.HttpPost
@@ -49,7 +50,7 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
 
         boolean uploadSuccessful = uploadToServer(mpEntity)
 
-        int maxRetryCount = getRetryCount()
+        int maxRetryCount = retryCount
         int retryCount = maxRetryCount
         while (!uploadSuccessful && retryCount > 0) {
             project.logger.warn(String.format("Retrying Bugsnag upload (%d/%d) ...",
@@ -96,7 +97,7 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
         httpPost.setEntity(mpEntity)
 
         HttpClient httpClient = new DefaultHttpClient()
-        HttpParams params = httpClient.getParams()
+        HttpParams params = httpClient.params
         HttpConnectionParams.setConnectionTimeout(params, TIMEOUT_MILLIS)
         HttpConnectionParams.setSoTimeout(params, TIMEOUT_MILLIS)
 
@@ -104,8 +105,9 @@ abstract class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
         def responseEntity
         try {
             HttpResponse response = httpClient.execute(httpPost)
-            statusCode = response.getStatusLine().getStatusCode()
-            responseEntity = EntityUtils.toString(response.getEntity(), "utf-8")
+            statusCode = response.statusLine.statusCode
+            HttpEntity entity = response.entity
+            responseEntity = EntityUtils.toString(entity, "utf-8")
         } catch (Exception e) {
             project.logger.error(String.format("Bugsnag upload failed: %s", e))
             return false

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
@@ -15,12 +15,12 @@ class BugsnagNdkSetupTask extends DefaultTask {
         def configs = project.configurations.findAll {
             it.toString().contains('CompileClasspath')
         }.each { config ->
-            def artifact = config.resolvedConfiguration.getResolvedArtifacts().find {
-                String identifier = it.getId().getComponentIdentifier().toString()
-                identifier.contains("bugsnag-android-ndk") && it.getFile() != null
+            def artifact = config.resolvedConfiguration.resolvedArtifacts.find {
+                String identifier = it.id.componentIdentifier.toString()
+                identifier.contains("bugsnag-android-ndk") && it.file != null
             }
             if (artifact) {
-                File artifactFile = artifact.getFile()
+                File artifactFile = artifact.file
                 File buildDir = project.buildDir
                 File dst = new File(buildDir, "/intermediates/bugsnag-libs")
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
@@ -1,6 +1,7 @@
 package com.bugsnag.android.gradle
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.tasks.TaskAction
 
 class BugsnagNdkSetupTask extends DefaultTask {
@@ -12,10 +13,10 @@ class BugsnagNdkSetupTask extends DefaultTask {
 
     @TaskAction
     void setupNdkProject() {
-        def configs = project.configurations.findAll {
+        project.configurations.findAll {
             it.toString().contains('CompileClasspath')
         }.each { config ->
-            def artifact = config.resolvedConfiguration.resolvedArtifacts.find {
+            ResolvedArtifact artifact = config.resolvedConfiguration.resolvedArtifacts.find {
                 String identifier = it.id.componentIdentifier.toString()
                 identifier.contains("bugsnag-android-ndk") && it.file != null
             }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
@@ -16,11 +16,11 @@ class BugsnagNdkSetupTask extends DefaultTask {
             it.toString().contains('CompileClasspath')
         }.each { config ->
             def artifact = config.resolvedConfiguration.getResolvedArtifacts().find {
-                def identifier = it.getId().getComponentIdentifier().toString()
+                String identifier = it.getId().getComponentIdentifier().toString()
                 identifier.contains("bugsnag-android-ndk") && it.getFile() != null
             }
             if (artifact) {
-                def artifactFile = artifact.getFile()
+                File artifactFile = artifact.getFile()
                 File buildDir = project.buildDir
                 File dst = new File(buildDir, "/intermediates/bugsnag-libs")
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
@@ -31,7 +31,4 @@ class BugsnagNdkSetupTask extends DefaultTask {
             }
         }
     }
-
 }
-
-

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -339,7 +339,7 @@ class BugsnagPlugin implements Plugin<Project> {
 
     private static void dependTaskOnPackageTask(BaseVariant variant, Task task) {
         if (variant instanceof LibraryVariant) {
-            variant.getPackageLibrary().dependsOn task
+            variant.packageLibrary.dependsOn task
         } else {
             resolvePackageApplication(variant).dependsOn task
         }
@@ -409,7 +409,7 @@ class BugsnagPlugin implements Plugin<Project> {
         Set<String> taskNames = new HashSet<>()
         taskNames.addAll(findTaskNamesForPrefix(variant, output, prefix))
 
-        project.gradle.taskGraph.getAllTasks().any { task ->
+        project.gradle.taskGraph.allTasks.any { task ->
             taskNames.any {
                 task.name.endsWith(it)
             }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -188,7 +188,7 @@ class BugsnagPlugin implements Plugin<Project> {
         }
     }
 
-    private static def setupBugsnagTask(BugsnagVariantOutputTask task, BugsnagTaskDeps deps) {
+    private static void setupBugsnagTask(BugsnagVariantOutputTask task, BugsnagTaskDeps deps) {
         task.group = GROUP_NAME
         task.variantOutput = deps.output
         task.variant = deps.variant
@@ -252,7 +252,7 @@ class BugsnagPlugin implements Plugin<Project> {
         taskNames
     }
 
-    private static def resolveAssembleTask(BaseVariant variant) {
+    private static Task resolveAssembleTask(BaseVariant variant) {
         try {
             return variant.assembleProvider.get()
         } catch (Throwable ignored) {
@@ -279,7 +279,7 @@ class BugsnagPlugin implements Plugin<Project> {
         }
     }
 
-    static def resolveProcessManifest(BaseVariantOutput output) {
+    static ManifestProcessorTask resolveProcessManifest(BaseVariantOutput output) {
         try {
             return output.processManifestProvider.get()
         } catch (Throwable ignored) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -151,7 +151,7 @@ class BugsnagPlugin implements Plugin<Project> {
     private static void setupNdkMappingFileUpload(Project project, BugsnagTaskDeps deps) {
         if (isNdkProject(project)) {
             // Create a Bugsnag task to upload NDK mapping file(s)
-            def taskName = "uploadBugsnagNdk${taskNameForOutput(deps.output)}Mapping"
+            String taskName = "uploadBugsnagNdk${taskNameForOutput(deps.output)}Mapping"
             BugsnagUploadNdkTask uploadNdkTask = project.tasks.create(taskName, BugsnagUploadNdkTask)
             prepareUploadTask(uploadNdkTask, deps, project)
 
@@ -270,7 +270,7 @@ class BugsnagPlugin implements Plugin<Project> {
         manifestTask.dependsOn(processManifest)
 
         def resourceTasks = project.tasks.findAll {
-            def name = it.name.toLowerCase()
+            String name = it.name.toLowerCase()
             name.startsWith(BUNDLE_TASK) && name.endsWith("resources")
         }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -35,6 +35,11 @@ class BugsnagPlugin implements Plugin<Project> {
     static final String BUILD_UUID_TAG = 'com.bugsnag.android.BUILD_UUID'
     static final String GROUP_NAME = 'Bugsnag'
 
+    private static final String NDK_PROJ_TASK = "externalNative"
+    private static final String CLEAN_TASK = "Clean"
+    private static final String ASSEMBLE_TASK = "assemble"
+    private static final String BUNDLE_TASK = "bundle"
+
     VersionNumber bugsnagVersionNumber
 
     void apply(Project project) {
@@ -86,10 +91,10 @@ class BugsnagPlugin implements Plugin<Project> {
 
     private static void setupNdkProject(Project project) {
         def cleanTasks = project.tasks.findAll {
-            it.name.startsWith("externalNative") && it.name.contains("Clean")
+            it.name.startsWith(NDK_PROJ_TASK) && it.name.contains(CLEAN_TASK)
         }
         def buildTasks = project.tasks.findAll {
-            it.name.startsWith("externalNative") && !it.name.contains("Clean")
+            it.name.startsWith(NDK_PROJ_TASK) && !it.name.contains(CLEAN_TASK)
         }
 
         def ndkSetupTask = project.tasks.create("bugsnagInstallJniLibsTask", BugsnagNdkSetupTask)
@@ -217,8 +222,8 @@ class BugsnagPlugin implements Plugin<Project> {
      */
     private static Set<Task> findAssembleBundleTasks(BaseVariant variant, BaseVariantOutput output, Project project) {
         Set<String> taskNames = new HashSet<>()
-        taskNames.addAll(findTaskNamesForPrefix(variant, output, "assemble"))
-        taskNames.addAll(findTaskNamesForPrefix(variant, output, "bundle"))
+        taskNames.addAll(findTaskNamesForPrefix(variant, output, ASSEMBLE_TASK))
+        taskNames.addAll(findTaskNamesForPrefix(variant, output, BUNDLE_TASK))
 
         project.tasks.findAll {
             taskNames.contains(it.name)
@@ -236,14 +241,14 @@ class BugsnagPlugin implements Plugin<Project> {
         def assembleTask = resolveAssembleTask(variant)
         String assembleTaskName = assembleTask.name
         String buildTypeTaskName = assembleTaskName.replaceAll(variantName, "")
-        String buildType = buildTypeTaskName.replaceAll("assemble", "")
+        String buildType = buildTypeTaskName.replaceAll(ASSEMBLE_TASK, "")
         String variantTaskName = assembleTaskName.replaceAll(buildType, "")
 
         Set<String> taskNames = new HashSet<>()
         taskNames.add(prefix)
-        taskNames.add(assembleTaskName.replaceAll("assemble", prefix))
-        taskNames.add(buildTypeTaskName.replaceAll("assemble", prefix))
-        taskNames.add(variantTaskName.replaceAll("assemble", prefix))
+        taskNames.add(assembleTaskName.replaceAll(ASSEMBLE_TASK, prefix))
+        taskNames.add(buildTypeTaskName.replaceAll(ASSEMBLE_TASK, prefix))
+        taskNames.add(variantTaskName.replaceAll(ASSEMBLE_TASK, prefix))
         taskNames
     }
 
@@ -266,7 +271,7 @@ class BugsnagPlugin implements Plugin<Project> {
 
         def resourceTasks = project.tasks.findAll {
             def name = it.name.toLowerCase()
-            name.startsWith("bundle") && name.endsWith("resources")
+            name.startsWith(BUNDLE_TASK) && name.endsWith("resources")
         }
 
         resourceTasks.forEach {
@@ -385,14 +390,14 @@ class BugsnagPlugin implements Plugin<Project> {
      * Whether or not an assemble task is going to be run for this variant
      */
     static boolean isRunningAssembleTask(BaseVariant variant, BaseVariantOutput output, Project project) {
-        isRunningTaskWithPrefix(variant, output, project, "assemble")
+        isRunningTaskWithPrefix(variant, output, project, ASSEMBLE_TASK)
     }
 
     /**
      * Whether or not a bundle task is going to be run for this variant
      */
     static boolean isRunningBundleTask(BaseVariant variant, BaseVariantOutput output, Project project) {
-        isRunningTaskWithPrefix(variant, output, project, "bundle")
+        isRunningTaskWithPrefix(variant, output, project, BUNDLE_TASK)
     }
 
     /**

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -7,6 +7,7 @@ import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
 import com.android.build.gradle.api.LibraryVariant
 import com.android.build.gradle.tasks.ManifestProcessorTask
+import com.android.build.gradle.tasks.PackageApplication
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -345,11 +346,11 @@ class BugsnagPlugin implements Plugin<Project> {
         }
     }
 
-    static def resolvePackageApplication(BaseVariant variant) {
+    static PackageApplication resolvePackageApplication(BaseVariant variant) {
         try {
-            return variant.getPackageApplicationProvider().get()
+            return variant.packageApplicationProvider.get()
         } catch (Throwable ignored) {
-            return variant.getPackageApplication()
+            return variant.packageApplication
         }
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -137,7 +137,8 @@ class BugsnagPlugin implements Plugin<Project> {
      * Creates a bugsnag task to upload proguard mapping file
      */
     private static void setupMappingFileUpload(Project project, BugsnagTaskDeps deps) {
-        def uploadTask = project.tasks.create("uploadBugsnag${taskNameForOutput(deps.output)}Mapping", BugsnagUploadProguardTask)
+        String taskName = "uploadBugsnag${taskNameForOutput(deps.output)}Mapping"
+        def uploadTask = project.tasks.create(taskName, BugsnagUploadProguardTask)
         uploadTask.partName = "proguard"
         prepareUploadTask(uploadTask, deps, project)
     }
@@ -145,7 +146,8 @@ class BugsnagPlugin implements Plugin<Project> {
     private static void setupNdkMappingFileUpload(Project project, BugsnagTaskDeps deps) {
         if (isNdkProject(project)) {
             // Create a Bugsnag task to upload NDK mapping file(s)
-            BugsnagUploadNdkTask uploadNdkTask = project.tasks.create("uploadBugsnagNdk${taskNameForOutput(deps.output)}Mapping", BugsnagUploadNdkTask)
+            def taskName = "uploadBugsnagNdk${taskNameForOutput(deps.output)}Mapping"
+            BugsnagUploadNdkTask uploadNdkTask = project.tasks.create(taskName, BugsnagUploadNdkTask)
             prepareUploadTask(uploadNdkTask, deps, project)
 
             uploadNdkTask.variantName = taskNameForVariant(deps.variant)
@@ -166,7 +168,8 @@ class BugsnagPlugin implements Plugin<Project> {
     }
 
     private static void setupReleasesTask(Project project, BugsnagTaskDeps deps) {
-        def releasesTask = project.tasks.create("bugsnagRelease${taskNameForOutput(deps.output)}Task", BugsnagReleasesTask)
+        String taskName = "bugsnagRelease${taskNameForOutput(deps.output)}Task"
+        def releasesTask = project.tasks.create(taskName, BugsnagReleasesTask)
         setupBugsnagTask(releasesTask, deps)
 
         if (shouldUploadDebugMappings(project, deps.output)) {
@@ -186,7 +189,8 @@ class BugsnagPlugin implements Plugin<Project> {
         task.variant = deps.variant
     }
 
-    private static void prepareUploadTask(BugsnagMultiPartUploadTask uploadTask, BugsnagTaskDeps deps, Project project) {
+    private static void prepareUploadTask(BugsnagMultiPartUploadTask uploadTask,
+                                          BugsnagTaskDeps deps, Project project) {
         setupBugsnagTask(uploadTask, deps)
         uploadTask.applicationId = deps.variant.applicationId
 
@@ -252,7 +256,8 @@ class BugsnagPlugin implements Plugin<Project> {
     }
 
     private static void setupManifestUuidTask(Project project, BugsnagTaskDeps deps) {
-        BugsnagManifestTask manifestTask = project.tasks.create("processBugsnag${taskNameForOutput(deps.output)}Manifest", BugsnagManifestTask)
+        String taskName = "processBugsnag${taskNameForOutput(deps.output)}Manifest"
+        BugsnagManifestTask manifestTask = project.tasks.create(taskName, BugsnagManifestTask)
         setupBugsnagTask(manifestTask, deps)
         ManifestProcessorTask processManifest = resolveProcessManifest(deps.output)
 
@@ -303,7 +308,8 @@ class BugsnagPlugin implements Plugin<Project> {
      * as it is now part of the "transforms" process.
      */
     private void setupProguardAutoConfig(Project project, BaseVariant variant) {
-        BugsnagProguardConfigTask proguardConfigTask = project.tasks.create("processBugsnag${taskNameForVariant(variant)}Proguard", BugsnagProguardConfigTask)
+        String taskname = "processBugsnag${taskNameForVariant(variant)}Proguard"
+        BugsnagProguardConfigTask proguardConfigTask = project.tasks.create(taskname, BugsnagProguardConfigTask)
         proguardConfigTask.group = GROUP_NAME
         proguardConfigTask.variant = variant
 
@@ -393,7 +399,8 @@ class BugsnagPlugin implements Plugin<Project> {
      * Whether or any of a list of the task names for a prefix are going to be run by checking the list
      * against all of the tasks in the task graph
      */
-    private static boolean isRunningTaskWithPrefix(BaseVariant variant, BaseVariantOutput output, Project project, String prefix) {
+    private static boolean isRunningTaskWithPrefix(BaseVariant variant,
+                                                   BaseVariantOutput output, Project project, String prefix) {
         Set<String> taskNames = new HashSet<>()
         taskNames.addAll(findTaskNamesForPrefix(variant, output, prefix))
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -76,12 +76,12 @@ class BugsnagPlugin implements Plugin<Project> {
             .flatten()
 
         def bugsnagVersion = deps.stream()
-            .filter { dep -> return dep.group == "com.bugsnag" && dep.name == "bugsnag-android" }
+            .filter { dep -> dep.group == "com.bugsnag" && dep.name == "bugsnag-android" }
             .distinct()
-            .map({ dep -> return dep.version })
+            .map({ dep -> dep.version })
             .findFirst()
 
-        return bugsnagVersion.present ? VersionNumber.parse(bugsnagVersion.get()) : VersionNumber.UNKNOWN
+        bugsnagVersion.present ? VersionNumber.parse(bugsnagVersion.get()) : VersionNumber.UNKNOWN
     }
 
     private static void setupNdkProject(Project project) {
@@ -244,7 +244,7 @@ class BugsnagPlugin implements Plugin<Project> {
         taskNames.add(assembleTaskName.replaceAll("assemble", prefix))
         taskNames.add(buildTypeTaskName.replaceAll("assemble", prefix))
         taskNames.add(variantTaskName.replaceAll("assemble", prefix))
-        return taskNames
+        taskNames
     }
 
     private static def resolveAssembleTask(BaseVariant variant) {
@@ -354,14 +354,14 @@ class BugsnagPlugin implements Plugin<Project> {
         }
 
         // Ignore any conflicting properties, bail if anything has a disable flag.
-        return (variant.productFlavors + variant.buildType).any(hasDisabledBugsnag)
+        (variant.productFlavors + variant.buildType).any(hasDisabledBugsnag)
     }
 
     /**
      * Returns true if the DexGuard plugin has been applied to the project
      */
     static boolean hasDexguardPlugin(Project project) {
-        return project.pluginManager.hasPlugin("dexguard")
+        project.pluginManager.hasPlugin("dexguard")
     }
 
     /**
@@ -378,21 +378,21 @@ class BugsnagPlugin implements Plugin<Project> {
         variants.forEach { variant ->
             outputSize += variant.outputs.size()
         }
-        return outputSize > variantSize
+        outputSize > variantSize
     }
 
     /**
      * Whether or not an assemble task is going to be run for this variant
      */
     static boolean isRunningAssembleTask(BaseVariant variant, BaseVariantOutput output, Project project) {
-        return isRunningTaskWithPrefix(variant, output, project, "assemble")
+        isRunningTaskWithPrefix(variant, output, project, "assemble")
     }
 
     /**
      * Whether or not a bundle task is going to be run for this variant
      */
     static boolean isRunningBundleTask(BaseVariant variant, BaseVariantOutput output, Project project) {
-        return isRunningTaskWithPrefix(variant, output, project, "bundle")
+        isRunningTaskWithPrefix(variant, output, project, "bundle")
     }
 
     /**
@@ -404,7 +404,7 @@ class BugsnagPlugin implements Plugin<Project> {
         Set<String> taskNames = new HashSet<>()
         taskNames.addAll(findTaskNamesForPrefix(variant, output, prefix))
 
-        return project.gradle.taskGraph.getAllTasks().any { task ->
+        project.gradle.taskGraph.getAllTasks().any { task ->
             taskNames.any {
                 task.name.endsWith(it)
             }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
@@ -1,8 +1,11 @@
 package com.bugsnag.android.gradle
 
+import groovy.transform.CompileStatic
+
 /**
  * Defines configuration options (Gradle plugin extensions) for the BugsnagPlugin
  */
+@CompileStatic
 class BugsnagPluginExtension {
 
     String endpoint = 'https://upload.bugsnag.com'
@@ -26,6 +29,7 @@ class BugsnagPluginExtension {
 
 }
 
+@CompileStatic
 class SourceControl {
     String provider = null
     String repository = null

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -37,7 +37,7 @@ class BugsnagProguardConfigTask extends DefaultTask {
         File file = project.file(PROGUARD_CONFIG_PATH)
 
         // Create the directory if it doesnt exist already
-        file.getParentFile().mkdirs()
+        file.parentFile.mkdirs()
 
         // Write our recommended proguard settings to this file
         FileWriter fr = null

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -32,9 +32,9 @@ class BugsnagProguardConfigTask extends DefaultTask {
     }
 
     @TaskAction
-    def createProguardConfig() {
+    void createProguardConfig() {
         // Create a file handle for the Bugsnag proguard config file
-        def file = project.file(PROGUARD_CONFIG_PATH)
+        File file = project.file(PROGUARD_CONFIG_PATH)
 
         // Create the directory if it doesnt exist already
         file.getParentFile().mkdirs()

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -46,7 +46,7 @@ class BugsnagProguardConfigTask extends DefaultTask {
             fr = new FileWriter(file.path)
             fr.write(PROGUARD_CONFIG_SETTINGS)
             fr.write("\n")
-        } catch (Exception e) {
+        } catch (IOException e) {
             project.logger.warn("Failed to write Bugsnag ProGuard settings", e)
         } finally {
             if (fr != null) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -32,7 +32,7 @@ class BugsnagProguardConfigTask extends DefaultTask {
     }
 
     @TaskAction
-    void createProguardConfig() {
+    void writeBugsnagProguardConfig() {
         // Create a file handle for the Bugsnag proguard config file
         File file = project.file(PROGUARD_CONFIG_PATH)
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -1,7 +1,6 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.BaseVariant
-import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
@@ -11,7 +10,6 @@ import org.gradle.api.tasks.TaskAction
 
  This task must be called before ProGuard is run.
  */
-@CompileStatic
 class BugsnagProguardConfigTask extends DefaultTask {
 
     static final String PROGUARD_CONFIG_PATH = "build/intermediates/bugsnag/bugsnag.pro"
@@ -57,6 +55,6 @@ class BugsnagProguardConfigTask extends DefaultTask {
         }
 
         // Add this proguard settings file to the list
-        variant.buildType.proguardFiles.add(file)
+        variant.getBuildType().buildType.proguardFiles(file)
     }
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -4,7 +4,6 @@ import com.android.build.gradle.api.BaseVariant
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
-
 /**
  Task to add an additional ProGuard configuration file (bugsnag.pro)
  which ensures that our required ProGuard settings are applied.

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagProguardConfigTask.groovy
@@ -1,6 +1,7 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.BaseVariant
+import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
@@ -10,6 +11,7 @@ import org.gradle.api.tasks.TaskAction
 
  This task must be called before ProGuard is run.
  */
+@CompileStatic
 class BugsnagProguardConfigTask extends DefaultTask {
 
     static final String PROGUARD_CONFIG_PATH = "build/intermediates/bugsnag/bugsnag.pro"
@@ -55,6 +57,6 @@ class BugsnagProguardConfigTask extends DefaultTask {
         }
 
         // Add this proguard settings file to the list
-        variant.getBuildType().buildType.proguardFiles(file)
+        variant.buildType.proguardFiles.add(file)
     }
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
@@ -42,7 +42,7 @@ class BugsnagReleasesTask extends BugsnagVariantOutputTask {
         new Call(project) {
             @Override
             boolean makeApiCall() {
-                return deliverPayload(payload)
+                deliverPayload(payload)
             }
         }.execute()
     }
@@ -171,11 +171,11 @@ class BugsnagReleasesTask extends BugsnagVariantOutputTask {
     }
 
     static boolean isValidPayload(String apiKey, String versionName) {
-        return apiKey != null && versionName != null
+        apiKey != null && versionName != null
     }
 
     static boolean isValidVcsProvider(String provider) {
-        return provider == null || VALID_VCS_PROVIDERS.contains(provider)
+        provider == null || VALID_VCS_PROVIDERS.contains(provider)
     }
 
     static String parseProviderUrl(String url) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
@@ -65,7 +65,7 @@ class BugsnagReleasesTask extends BugsnagVariantOutputTask {
             os = conn.outputStream
             os.write(payload.toString().getBytes(CHARSET_UTF8))
 
-            int statusCode = conn.getResponseCode()
+            int statusCode = conn.responseCode
 
             if (statusCode == 200) {
                 project.logger.info("Uploaded release info to Bugsnag")

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
@@ -209,5 +209,3 @@ class BugsnagReleasesTask extends BugsnagVariantOutputTask {
         }
     }
 }
-
-

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
@@ -165,16 +165,12 @@ class BugsnagReleasesTask extends BugsnagVariantOutputTask {
 
     private Map<String, String> collectDefaultMetaData() {
         Map<String, String> metadata = new HashMap<>()
-        String version = project.gradle.gradleVersion
-
-        metadata.with {
-            put("os_arch", System.getProperty(MK_OS_ARCH))
-            put("os_name", System.getProperty(MK_OS_NAME))
-            put("os_version", System.getProperty(MK_OS_VERSION))
-            put("java_version", System.getProperty(MK_JAVA_VERSION))
-            put("gradle_version", version)
-            put("git_version", runCmd(VCS_COMMAND, "--version"))
-        }
+        metadata.put("os_arch", System.getProperty(MK_OS_ARCH))
+        metadata.put("os_name", System.getProperty(MK_OS_NAME))
+        metadata.put("os_version", System.getProperty(MK_OS_VERSION))
+        metadata.put("java_version", System.getProperty(MK_JAVA_VERSION))
+        metadata.put("gradle_version", project.gradle.gradleVersion)
+        metadata.put("git_version", runCmd(VCS_COMMAND, "--version"))
         metadata
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -86,7 +86,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
     }
 
     private static File findSymbolPath(BaseVariantOutput variantOutput) {
-        def resources = resolveProcessAndroidResources(variantOutput)
+        ProcessAndroidResources resources = resolveProcessAndroidResources(variantOutput)
         def symbolPath = resources.textSymbolOutputFile
 
         if (symbolPath == null) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -52,7 +52,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
             project.logger.lifecycle("Found shared object file (${arch}) ${sharedObject}")
             sharedObjectFound = true
 
-            File outputFile = createSymbolsForSharedObject(sharedObject, arch)
+            File outputFile = generateSymbolsForSharedObject(sharedObject, arch)
             if (outputFile) {
                 uploadSymbols(outputFile, arch, sharedObject.name)
             }
@@ -126,7 +126,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
      * @param arch the arch of the file
      * @return the output file location, or null on error
      */
-    File createSymbolsForSharedObject(File sharedObject, String arch) {
+    File generateSymbolsForSharedObject(File sharedObject, String arch) {
         // Get the path the version of objdump to use to get symbols
         File objDumpPath = getObjDumpExecutable(arch)
         if (objDumpPath != null) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -178,23 +178,23 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
      * @param outputFile The output file
      */
     static void outputZipFile(InputStream stdout, File outputFile) {
-        GZIPOutputStream zipStream = null;
+        GZIPOutputStream zipStream = null
 
         try {
-            zipStream = new GZIPOutputStream(new FileOutputStream(outputFile));
+            zipStream = new GZIPOutputStream(new FileOutputStream(outputFile))
 
-            byte[] buffer = new byte[8192];
-            int len;
+            byte[] buffer = new byte[8192]
+            int len
             while((len=stdout.read(buffer)) != -1){
-                zipStream.write(buffer, 0, len);
+                zipStream.write(buffer, 0, len)
             }
 
         } finally {
             if (zipStream != null) {
-                zipStream.close();
+                zipStream.close()
             }
 
-            stdout.close();
+            stdout.close()
         }
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -143,7 +143,8 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
                 project.logger.lifecycle("Creating symbol file at ${outputFile}")
 
                 // Call objdump, redirecting output to the output file
-                ProcessBuilder builder = new ProcessBuilder(objDumpPath.toString(), "--dwarf=info", "--dwarf=rawline", sharedObject.toString())
+                ProcessBuilder builder = new ProcessBuilder(objDumpPath.toString(),
+                    "--dwarf=info", "--dwarf=rawline", sharedObject.toString())
                 builder.redirectError(errorOutputFile)
                 Process process = builder.start()
 
@@ -154,7 +155,8 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
                 if (process.waitFor() == 0) {
                     return outputFile
                 } else {
-                    project.logger.error("failed to generate symbols for " + arch + ", see " + errorOutputFile.toString() + " for more details")
+                    project.logger.error("failed to generate symbols for " + arch + ", see "
+                        + errorOutputFile.toString() + " for more details")
                     return null
                 }
             } catch (Exception e) {
@@ -262,7 +264,8 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
     }
 
     static File calculateObjDumpLocation(String ndkDir, Abi abi, String osName) {
-        new File("$ndkDir/toolchains/$abi.toolchainPrefix-4.9/prebuilt/$osName/bin/$abi.objdumpPrefix-objdump")
+        new File("$ndkDir/toolchains/$abi.toolchainPrefix-4.9/prebuilt/" +
+            "$osName/bin/$abi.objdumpPrefix-objdump")
     }
 
     static String calculateOsName() {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -169,8 +169,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
         } else {
             project.logger.error("Unable to upload NDK symbols: Could not find objdump location for " + arch)
         }
-
-        return null
+        null
     }
 
     /**
@@ -241,12 +240,12 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
         } catch (Throwable ex) {
             project.logger.error("Error attempting to calculate objdump location: " + ex.message)
         }
-        return null
+        null
     }
 
     private Object getObjDumpOverride(String arch) {
         Map<String, String> paths = project.bugsnag.objdumpPaths
-        return paths != null ? paths[arch] : null
+        paths != null ? paths[arch] : null
     }
 
     static File findObjDump(Project project, String arch) {
@@ -260,7 +259,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
         if (osName == null) {
             throw new IllegalStateException("Failed to calculate OS name")
         }
-        return calculateObjDumpLocation(ndkDir, abi, osName)
+        calculateObjDumpLocation(ndkDir, abi, osName)
     }
 
     static File calculateObjDumpLocation(String ndkDir, Abi abi, String osName) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -186,7 +186,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
 
             byte[] buffer = new byte[8192]
             int len
-            while((len=stdout.read(buffer)) != -1){
+            while ((len = stdout.read(buffer)) != -1) {
                 zipStream.write(buffer, 0, len)
             }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -40,7 +40,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
     }
 
     @TaskAction
-    def upload() {
+    void upload() {
         super.readManifestFile()
         symbolPath = findSymbolPath(variantOutput)
         project.logger.lifecycle("Symbolpath: ${symbolPath}")

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -87,7 +87,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
 
     private static File findSymbolPath(BaseVariantOutput variantOutput) {
         ProcessAndroidResources resources = resolveProcessAndroidResources(variantOutput)
-        def symbolPath = resources.textSymbolOutputFile
+        File symbolPath = resources.textSymbolOutputFile
 
         if (symbolPath == null) {
             throw new IllegalStateException("Could not find symbol path")
@@ -157,12 +157,12 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
                 if (process.waitFor() == 0) {
                     return outputFile
                 } else {
-                    project.logger.error("failed to generate symbols for " + arch + ", see "
+                    project.logger.error("failed to generate symbols for $arch, see "
                         + errorOutputFile.toString() + " for more details")
                     return null
                 }
             } catch (Exception e) {
-                project.logger.error("failed to generate symbols for " + arch + ": " + e.message, e)
+                project.logger.error("failed to generate symbols for $arch $e.message", e)
             } finally {
                 if (outReader != null) {
                     outReader.close()
@@ -236,7 +236,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
             }
 
             if (!objDumpFile.exists() || !objDumpFile.canExecute()) {
-                throw new RuntimeException("Failed to find executable objdump at $objDumpFile")
+                throw new IllegalStateException("Failed to find executable objdump at $objDumpFile")
             }
             return objDumpFile
         } catch (Throwable ex) {
@@ -275,11 +275,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
         } else if (Os.isFamily(Os.FAMILY_UNIX)) {
             return "linux-x86_64"
         } else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            if ("x86" == System.getProperty("os.arch")) { // 32-bit
-                return "windows"
-            } else {
-                return "windows-x86_64"
-            }
+            return "x86" == System.getProperty("os.arch") ? "windows" : "windows-x86_64"
         } else {
             return null
         }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -149,7 +149,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
                 Process process = builder.start()
 
                 // Output the file to a zip
-                InputStream stdout = process.getInputStream()
+                InputStream stdout = process.inputStream
                 outputZipFile(stdout, outputFile)
 
                 if (process.waitFor() == 0) {
@@ -160,7 +160,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
                     return null
                 }
             } catch (Exception e) {
-                project.logger.error("failed to generate symbols for " + arch + ": " + e.getMessage(), e)
+                project.logger.error("failed to generate symbols for " + arch + ": " + e.message, e)
             } finally {
                 if (outReader != null) {
                     outReader.close()

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -1,5 +1,7 @@
 package com.bugsnag.android.gradle
 
+import com.android.build.gradle.tasks.ProcessAndroidResources
+
 import static groovy.io.FileType.FILES
 
 import com.android.build.gradle.api.BaseVariantOutput
@@ -93,7 +95,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
         symbolPath
     }
 
-    private static def resolveProcessAndroidResources(BaseVariantOutput variantOutput) {
+    private static ProcessAndroidResources resolveProcessAndroidResources(BaseVariantOutput variantOutput) {
         try {
             return variantOutput.processResourcesProvider.get()
         } catch (Throwable ignored) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -1,5 +1,7 @@
 package com.bugsnag.android.gradle
 
+import static groovy.io.FileType.FILES
+
 import com.android.build.gradle.api.BaseVariantOutput
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import org.apache.http.entity.mime.MultipartEntity
@@ -10,8 +12,6 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 
 import java.util.zip.GZIPOutputStream
-
-import static groovy.io.FileType.FILES
 
 /**
  Task to upload shared object mapping files to Bugsnag.

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -1,8 +1,8 @@
 package com.bugsnag.android.gradle
 
-import com.android.build.gradle.tasks.ProcessAndroidResources
-
 import static groovy.io.FileType.FILES
+
+import com.android.build.gradle.tasks.ProcessAndroidResources
 
 import com.android.build.gradle.api.BaseVariantOutput
 import com.android.build.gradle.tasks.ExternalNativeBuildTask

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
@@ -75,7 +75,7 @@ class BugsnagUploadProguardTask extends BugsnagMultiPartUploadTask {
             }
         }
         // use AGP supplied value by default, or as fallback
-        return variant.mappingFile
+        variant.mappingFile
     }
 
     /**
@@ -96,7 +96,7 @@ class BugsnagUploadProguardTask extends BugsnagMultiPartUploadTask {
                 outputDir = ""
             }
         }
-        return Paths.get(buildDir, "outputs", "mapping", variant.dirName, outputDir, "mapping.txt").toFile()
+        Paths.get(buildDir, "outputs", "mapping", variant.dirName, outputDir, "mapping.txt").toFile()
     }
 
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
@@ -33,7 +33,7 @@ class BugsnagUploadProguardTask extends BugsnagMultiPartUploadTask {
     }
 
     @TaskAction
-    def upload() {
+    void upload() {
         File mappingFile = findMappingFile()
         project.logger.info("Using mapping file: $mappingFile")
 
@@ -54,7 +54,7 @@ class BugsnagUploadProguardTask extends BugsnagMultiPartUploadTask {
         project.logger.info("Attempting to upload mapping file: ${mappingFile}")
 
         // Construct a basic request
-        def charset = Charset.forName("UTF-8")
+        Charset charset = Charset.forName("UTF-8")
         MultipartEntity mpEntity = new MultipartEntity(HttpMultipartMode.BROWSER_COMPATIBLE, null, charset)
         mpEntity.addPart(partName, new FileBody(mappingFile))
 
@@ -64,7 +64,7 @@ class BugsnagUploadProguardTask extends BugsnagMultiPartUploadTask {
 
     private File findMappingFile() {
         if (BugsnagPlugin.hasDexguardPlugin(project) && BugsnagPlugin.hasMultipleOutputs(project)) {
-            def mappingFile = findDexguardMappingFile(project)
+            File mappingFile = findDexguardMappingFile(project)
 
             if (mappingFile && mappingFile.exists()) {
                 return mappingFile

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
@@ -3,7 +3,6 @@ package com.bugsnag.android.gradle
 import org.apache.http.entity.mime.HttpMultipartMode
 import org.apache.http.entity.mime.MultipartEntity
 import org.apache.http.entity.mime.content.FileBody
-import org.apache.http.util.TextUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -71,7 +71,8 @@ class BugsnagVariantOutputTask extends DefaultTask {
     }
 
     void addManifestPath(List<File> manifestPaths, File directory) {
-        File manifestFile = Paths.get(directory.toString(), variantOutput.dirName, "AndroidManifest.xml").toFile()
+        File manifestFile = Paths.get(directory.toString(), variantOutput.dirName,
+            "AndroidManifest.xml").toFile()
 
         if (!manifestFile.exists()) {
             project.logger.error("Failed to find manifest at ${manifestFile}")
@@ -105,7 +106,8 @@ class BugsnagVariantOutputTask extends DefaultTask {
             // Get the Bugsnag API key
             apiKey = getApiKey(metaDataTags, ns)
             if (!apiKey) {
-                project.logger.warn("Could not find apiKey in '$BugsnagPlugin.API_KEY_TAG' <meta-data> tag in your AndroidManifest.xml or in your gradle config")
+                project.logger.warn("Could not find apiKey in '$BugsnagPlugin.API_KEY_TAG' " +
+                    "<meta-data> tag in your AndroidManifest.xml or in your gradle config")
             }
 
             // Get the build version

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -135,17 +135,17 @@ class BugsnagVariantOutputTask extends DefaultTask {
         } else {
             apiKey = getManifestMetaData(metaDataTags, ns, BugsnagPlugin.API_KEY_TAG)
         }
-        return apiKey
+        apiKey
     }
 
     boolean hasBuildUuid(metaDataTags, Namespace ns) {
-        return metaDataTags.any {
+        metaDataTags.any {
             it.attributes()[ns.name] == BugsnagPlugin.BUILD_UUID_TAG
         }
     }
 
     String getBuildUuid(metaDataTags, Namespace ns) {
-        return getManifestMetaData(metaDataTags, ns, BugsnagPlugin.BUILD_UUID_TAG)
+        getManifestMetaData(metaDataTags, ns, BugsnagPlugin.BUILD_UUID_TAG)
     }
 
     private String getManifestMetaData(metaDataTags, Namespace ns, String key) {
@@ -159,7 +159,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
         } else {
             value = tags[0].attributes()[ns.value]
         }
-        return value
+        value
     }
 
     String getVersionName(Node xml, Namespace ns) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -88,7 +88,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
         Namespace ns = new Namespace("http://schemas.android.com/apk/res/android", "android")
         List<File> manifestPaths = getManifestPaths()
 
-        for (def manifestPath in manifestPaths) {
+        for (File manifestPath in manifestPaths) {
             if (!manifestPath.exists()) {
                 continue
             }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -86,9 +86,9 @@ class BugsnagVariantOutputTask extends DefaultTask {
     void readManifestFile() {
         // Parse the AndroidManifest.xml
         Namespace ns = new Namespace("http://schemas.android.com/apk/res/android", "android")
-        List<File> manifestPaths = getManifestPaths()
+        List<File> paths = manifestPaths
 
-        for (File manifestPath in manifestPaths) {
+        for (File manifestPath in paths) {
             if (!manifestPath.exists()) {
                 continue
             }
@@ -99,7 +99,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
             def metaDataTags = xml.application['meta-data']
 
             // If the current manifest does not contain the build ID then try the next manifest in the list (if any)
-            if (!(manifestPath == manifestPaths.last()) && !hasBuildUuid(metaDataTags, ns)) {
+            if (!(manifestPath == paths.last()) && !hasBuildUuid(metaDataTags, ns)) {
                 continue
             }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -2,6 +2,7 @@ package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
+import com.android.build.gradle.tasks.ManifestProcessorTask
 import groovy.xml.Namespace
 import org.gradle.api.DefaultTask
 
@@ -44,10 +45,10 @@ class BugsnagVariantOutputTask extends DefaultTask {
             getBundleManifest = true
         }
 
-        def processManifest = BugsnagPlugin.resolveProcessManifest(variantOutput)
+        ManifestProcessorTask processManifest = BugsnagPlugin.resolveProcessManifest(variantOutput)
 
         if (getMergedManifest) {
-            def outputDir = processManifest.manifestOutputDirectory
+            Object outputDir = processManifest.manifestOutputDirectory
 
             if (outputDir instanceof File) {
                 directoryMerged = outputDir

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -74,11 +74,11 @@ class BugsnagVariantOutputTask extends DefaultTask {
         File manifestFile = Paths.get(directory.toString(), variantOutput.dirName,
             "AndroidManifest.xml").toFile()
 
-        if (!manifestFile.exists()) {
-            project.logger.error("Failed to find manifest at ${manifestFile}")
-        } else {
+        if (manifestFile.exists()) {
             project.logger.info("Found manifest at ${manifestFile}")
             manifestPaths.add(manifestFile)
+        } else {
+            project.logger.error("Failed to find manifest at ${manifestFile}")
         }
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/Call.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/Call.groovy
@@ -9,7 +9,7 @@ abstract class Call {
 
     private final Project project // 60 seconds
 
-    Call(Project project) {
+    protected Call(Project project) {
         this.project = project
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/Call.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/Call.groovy
@@ -19,7 +19,7 @@ abstract class Call {
     void execute() {
         boolean uploadSuccessful = makeApiCall()
 
-        int maxRetryCount = getRetryCount()
+        int maxRetryCount = retryCount
         int retryCount = maxRetryCount
         while (!uploadSuccessful && retryCount > 0) {
             project.logger.warn(String.format("Retrying Bugsnag upload (%d/%d) ...",

--- a/src/main/groovy/com/bugsnag/android/gradle/Call.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/Call.groovy
@@ -44,7 +44,7 @@ abstract class Call {
      * @return the retry count
      */
     int getRetryCount() {
-        return project.bugsnag.retryCount >= MAX_RETRY_COUNT ? MAX_RETRY_COUNT : project.bugsnag.retryCount
+        project.bugsnag.retryCount >= MAX_RETRY_COUNT ? MAX_RETRY_COUNT : project.bugsnag.retryCount
     }
 
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/Call.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/Call.groovy
@@ -19,8 +19,8 @@ abstract class Call {
     void execute() {
         boolean uploadSuccessful = makeApiCall()
 
-        def maxRetryCount = getRetryCount()
-        def retryCount = maxRetryCount
+        int maxRetryCount = getRetryCount()
+        int retryCount = maxRetryCount
         while (!uploadSuccessful && retryCount > 0) {
             project.logger.warn(String.format("Retrying Bugsnag upload (%d/%d) ...",
                 maxRetryCount - retryCount + 1, maxRetryCount))

--- a/src/test/groovy/com/bugsnag/android/gradle/BugsnagReleasesTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/BugsnagReleasesTest.groovy
@@ -1,16 +1,25 @@
 package com.bugsnag.android.gradle
 
+import static com.bugsnag.android.gradle.BugsnagReleasesTask.isValidPayload
+import static com.bugsnag.android.gradle.BugsnagReleasesTask.isValidVcsProvider
+import static com.bugsnag.android.gradle.BugsnagReleasesTask.parseProviderUrl
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertNull
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
+
+import groovy.transform.CompileStatic
+
 import org.junit.Test
 
-import static com.bugsnag.android.gradle.BugsnagReleasesTask.*
-import static org.junit.Assert.*
-
+@CompileStatic
 class BugsnagReleasesTest {
 
     @Test
     void ensureProviderValidation() {
         assertTrue(isValidVcsProvider(null))
-        Collection<String> valid = Arrays.asList("github", "github-enterprise", "bitbucket", "bitbucket-server", "gitlab", "gitlab-onpremise")
+        Collection<String> valid = Arrays.asList("github", "github-enterprise",
+            "bitbucket", "bitbucket-server", "gitlab", "gitlab-onpremise")
 
         for (String provider : valid) {
             assertTrue(isValidVcsProvider(provider))

--- a/src/test/groovy/com/bugsnag/android/gradle/FakeVariantImpl.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/FakeVariantImpl.groovy
@@ -4,10 +4,17 @@ import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
 import com.android.build.gradle.api.JavaCompileOptions
 import com.android.build.gradle.api.SourceKind
-import com.android.build.gradle.tasks.*
+import com.android.build.gradle.tasks.AidlCompile
+import com.android.build.gradle.tasks.ExternalNativeBuildTask
+import com.android.build.gradle.tasks.GenerateBuildConfig
+import com.android.build.gradle.tasks.MergeResources
+import com.android.build.gradle.tasks.MergeSourceSetFolders
+import com.android.build.gradle.tasks.NdkCompile
+import com.android.build.gradle.tasks.RenderscriptCompile
 import com.android.builder.model.BuildType
 import com.android.builder.model.ProductFlavor
 import com.android.builder.model.SourceProvider
+import groovy.transform.CompileStatic
 import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Task
 import org.gradle.api.artifacts.ArtifactCollection
@@ -17,6 +24,9 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.AbstractCopyTask
 import org.gradle.api.tasks.compile.JavaCompile
 
+@CompileStatic
+@SuppressWarnings(["GetterMethodCouldBeProperty", "UnnecessaryReturnKeyword",
+    "ReturnsNullInsteadOfEmptyCollection", "MethodCount", "BuilderMethodWithSideEffects",])
 class FakeVariantImpl implements BaseVariant {
 
     private final String name

--- a/src/test/groovy/com/bugsnag/android/gradle/FakeVariantOutputImpl.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/FakeVariantOutputImpl.groovy
@@ -1,7 +1,10 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.internal.api.BaseVariantOutputImpl
+import groovy.transform.CompileStatic
 
+@CompileStatic
+@SuppressWarnings(["GetterMethodCouldBeProperty", "UnnecessaryReturnKeyword", "ReturnsNullInsteadOfEmptyCollection"])
 class FakeVariantOutputImpl extends BaseVariantOutputImpl {
 
     private final String name

--- a/src/test/groovy/com/bugsnag/android/gradle/ObjDumpLocationTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/ObjDumpLocationTest.groovy
@@ -1,12 +1,13 @@
 package com.bugsnag.android.gradle
 
+import static org.junit.Assert.assertEquals
+
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
-import static org.junit.Assert.*
-
-@RunWith(Parameterized.class)
+@RunWith(Parameterized)
+@SuppressWarnings(["PublicInstanceField", "NonFinalPublicField", "NestedForLoop"])
 class ObjDumpLocationTest {
 
     @Parameterized.Parameter(0)
@@ -20,21 +21,21 @@ class ObjDumpLocationTest {
 
     @Parameterized.Parameters
     static Collection<Object[]> inputs() {
-        Collection<Object> inputs = new ArrayList<>();
+        Collection<Object> inputs = new ArrayList<>()
 
-        for (Abi abi: Abi.values()) {
-            for (String os: ["darwin-x86_64", "linux-x86_64", "windows", "windows-x86_64"]) {
-                for (String ndkDir: ["/Users/bob/Library/Android/sdk/ndk-bundle", "/etc/ndk-bundle"]) {
+        for (Abi abi : Abi.values()) {
+            for (String os : ["darwin-x86_64", "linux-x86_64", "windows", "windows-x86_64"]) {
+                for (String ndkDir : ["/Users/bob/Library/Android/sdk/ndk-bundle", "/etc/ndk-bundle"]) {
                     inputs.add([abi, os, ndkDir].toArray())
                 }
             }
         }
-        return inputs
+        inputs
     }
 
     @Parameterized.Parameters
     static Collection<String> os() {
-        return Arrays.asList("windows", "linux")
+        Arrays.asList("windows", "linux")
     }
 
     @Test
@@ -43,5 +44,4 @@ class ObjDumpLocationTest {
         String expected = "$ndkDir/toolchains/$abi.toolchainPrefix-4.9/prebuilt/$osName/bin/$abi.objdumpPrefix-objdump"
         assertEquals(expected, file.path)
     }
-
 }

--- a/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
@@ -1,11 +1,14 @@
 package com.bugsnag.android.gradle
 
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertNull
+import static org.junit.Assert.assertTrue
+
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Before
 import org.junit.Test
-
-import static org.junit.Assert.*
 
 class PluginExtensionTest {
 
@@ -32,9 +35,7 @@ class PluginExtensionTest {
         assertNull(proj.bugsnag.sharedObjectPath)
         assertFalse(BugsnagPlugin.hasDexguardPlugin(proj))
         assertTrue(proj.bugsnag.failOnUploadError)
-
         assertFalse(BugsnagPlugin.hasMultipleOutputs(proj))
-
     }
 
 }

--- a/src/test/groovy/com/bugsnag/android/gradle/PluginTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/PluginTest.groovy
@@ -1,14 +1,16 @@
 package com.bugsnag.android.gradle
 
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertNotNull
+
+import groovy.transform.CompileStatic
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Before
 import org.junit.Test
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotNull
-
+@CompileStatic
 class PluginTest {
 
     private Project proj


### PR DESCRIPTION
## Goal
The CodeNarc static analysis tool was added in #158 - this PR addresses pre-existing violations, where they have been simple to address. In total 16 violations have been left in the codebase with a view to addressing them as separate tickets at a later date.

## Changeset

- Reduced violation count to 16, adjusted baseline accordingly
- Added [`@CompileStatic`](http://docs.groovy-lang.org/latest/html/gapi/groovy/transform/CompileStatic.html) where changes made this possible, to gain the benefits of type-safety
- Suppressed the following overzealous checks by default:
  - InstanceOf
  - ClassJavadoc
  - ExplicitArrayListInstantiation
  - ExplicitHashSetInstantiation
  - ExplicitHashMapInstantiation
  - JavaPackageAccess
  - UnnecessaryElseStatement
  - UnnecessaryToString

Existing violations were addressed in both the main + test sourcesets. The following made up the majority of the issues:

- Use of `def` rather than an explicit type such as `String`
- Incorrect ordering of imports
- Unnecessary use of semicolon (not required in Groovy)
- Duplicate string literals
- Not using property access syntax (e.g. `foo` instead of `getFoo()`)
- Unnecessary use of return keyword (not required in Groovy)


## Tests

- Ran existing unit tests
- Ran existing mazerunner scenarios
- Ran `./gradlew assemble` in an example Android app using Gradle 5.4.0 and AGP 3.3.0 and confirmed upload of mapping files was triggered
