### PR TITLE
Calculate correct location for objdump on windows, fixing NDK symbol upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Calculate correct location for objdump on windows, fixing NDK symbol upload
+[#163](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/163)
+
 ## 4.3.0 (2019-05-30)
 
 * Resolve pre-existing CodeNarc style violations

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -265,8 +265,9 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
     }
 
     static File calculateObjDumpLocation(String ndkDir, Abi abi, String osName) {
+        String executable = osName.startsWith("windows") ? "objdump.exe" : "objdump"
         new File("$ndkDir/toolchains/$abi.toolchainPrefix-4.9/prebuilt/" +
-            "$osName/bin/$abi.objdumpPrefix-objdump")
+            "$osName/bin/$abi.objdumpPrefix-$executable")
     }
 
     static String calculateOsName() {

--- a/src/test/groovy/com/bugsnag/android/gradle/ObjDumpLocationTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/ObjDumpLocationTest.groovy
@@ -41,7 +41,8 @@ class ObjDumpLocationTest {
     @Test
     void defaultObjDumpLocation() {
         File file = BugsnagUploadNdkTask.calculateObjDumpLocation(ndkDir, abi, osName)
-        String expected = "$ndkDir/toolchains/$abi.toolchainPrefix-4.9/prebuilt/$osName/bin/$abi.objdumpPrefix-objdump"
+        String exec = osName.startsWith("windows") ? "objdump.exe" : "objdump"
+        String expected = "$ndkDir/toolchains/$abi.toolchainPrefix-4.9/prebuilt/$osName/bin/$abi.objdumpPrefix-$exec"
         assertEquals(expected, file.path)
     }
 }


### PR DESCRIPTION
## Goal

Add support for finding `objdump` on Windows machine, as currently the gradle plugin fails to find the file and therefore cannot upload shared object files for the project.

## Changeset

If the OS name starts with Windows, add the '.exe' extension onto the file.

## Tests

Ran mazerunner scenarios on CI to verify that the NDK feature finds objdump, and built an example app on a Windows VM with a local artefact containing this changeset.

