### PR TITLE
Extract SO files from bugsnag-android artefact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.4.0 TBD
+
+* Extract SO files from bugsnag-android artifact
+[#164](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/164)
+
 ## 4.3.1 (2019-05-31)
 
 * Calculate correct location for objdump on windows, fixing NDK symbol upload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 4.4.0 TBD
 
-* Extract SO files from bugsnag-android artifact
+This release is companion update for bugsnag-android v4.15.0, which supports detecting and reporting C/C++ crashes without a separate library. 
+
+Extract shared object C libraries (*.so files) from bugsnag-android artifact to support using the Native API
 [#164](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/164)
 
 ## 4.3.1 (2019-05-31)

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
@@ -18,7 +18,7 @@ class BugsnagNdkSetupTask extends DefaultTask {
         }.each { config ->
             ResolvedArtifact artifact = config.resolvedConfiguration.resolvedArtifacts.find {
                 String identifier = it.id.componentIdentifier.toString()
-                identifier.contains("bugsnag-android-ndk") && it.file != null
+                identifier.contains("bugsnag-android") && it.file != null
             }
             if (artifact) {
                 File artifactFile = artifact.file


### PR DESCRIPTION
## Goal

The gradle plugin should extract shared object files from both the bugsnag-android and bugsnag-android-ndk artefacts, as in the future both will contain native bugsnag code that is required by C end-users.

## Changeset

Expanded artefact filter so that files are extracted for both bugsnag-android and bugsnag-android-ndk.

## Tests
Verified that an example project requiring the NDK can be built with bugsnag-android and a local installation of this changeset.
