### PR TITLE
Skip uploading mapping files for shared objects which have no debug info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+Skip uploading mapping files for shared objects which have no debug info
+[#166](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/166)
+
 ## 4.4.0 (2019-06-10)
 
 This release is companion update for bugsnag-android v4.15.0, which supports detecting and reporting C/C++ crashes without a separate library. 


### PR DESCRIPTION
## Goal

Avoid uploading mapping files generated by shared object files which don't contain any debug info, as these are useless. The API returns a 400 status code which then fails the build if these files are present in a project. An 'empty' SO mapping file looks like this:

```
examples/sdk-app-example/build/intermediates/cmake/release/obj/armeabi-v7a/libentrypoint.so:     file format elf32-littlearm

Contents of the .debug_abbrev section:
```

As the mapping file is written into a gzip stream we cannot parse the contents of the file directly, and therefore use the file's length as a proxy to check whether it contains any debug information or not.

## Changeset

If the file is <1Kb, skip uploading it.

## Tests

Verified that the size of a SO mapping file where the code only has 2 methods is ~5kb.

Ran against the example project in the Zendesk ticket and confirmed that the build is successful, and that one SO mapping file is uploaded to the admin dashboard.