### PR TITLE
Update plugin to search for shared object files in new artefact locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## TBD
 
-Update plugin to search for shared object files in new artefact locations
+Search for shared object files in the new artefact locations introduced by modularisation of `bugsnag-android`. This affects versions v4.17.0 and above of `bugsnag-android` and `bugsnag-android-ndk`.
 [#168](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/168)
 
 ## 4.4.1 (2019-06-19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+Update plugin to search for shared object files in new artefact locations
+[#168](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/168)
+
 ## 4.4.1 (2019-06-19)
 
 Skip uploading mapping files for shared objects which have no debug info

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
@@ -18,8 +18,8 @@ class BugsnagNdkSetupTask extends DefaultTask {
         }.each { config ->
             ResolvedArtifact artifact = config.resolvedConfiguration.resolvedArtifacts.find {
                 String identifier = it.id.componentIdentifier.toString()
-                def soArtefacts = ["bugsnag-android", "bugsnag-android-ndk",
-                                   "bugsnag-plugin-android-anr", "bugsnag-plugin-android-ndk"]
+                List<String> soArtefacts = ["bugsnag-android", "bugsnag-android-ndk",
+                                   "bugsnag-plugin-android-anr", "bugsnag-plugin-android-ndk",]
                 soArtefacts.contains(identifier) && it.file != null
             }
             if (artifact) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
@@ -18,7 +18,9 @@ class BugsnagNdkSetupTask extends DefaultTask {
         }.each { config ->
             ResolvedArtifact artifact = config.resolvedConfiguration.resolvedArtifacts.find {
                 String identifier = it.id.componentIdentifier.toString()
-                identifier.contains("bugsnag-android") && it.file != null
+                def soArtefacts = ["bugsnag-android", "bugsnag-android-ndk",
+                                   "bugsnag-plugin-android-anr", "bugsnag-plugin-android-ndk"]
+                soArtefacts.contains(identifier) && it.file != null
             }
             if (artifact) {
                 File artifactFile = artifact.file


### PR DESCRIPTION
## Goal

As part of the `bugsnag-android` modularisation SO files can now be stored in several artefacts. This adds them to the list of artefacts in our gradle plugin whose files are copied to the appropriate build directory.