### PR TITLE
Lookup shared object files correctly in new artefact IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.5.1 (2019-07-17)
+
+Lookup shared object files correctly in new artefact IDs
+[#170](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/170)
+
 ## 4.5.0 (2019-07-15)
 
 Search for shared object files in the new artefact locations introduced by modularisation of `bugsnag-android`. This affects versions v4.17.0 and above of `bugsnag-android` and `bugsnag-android-ndk`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.bugsnag
-version = 4.5.0
+version = 4.5.1
 
 ANDROID_MIN_SDK_VERSION=14
 ANDROID_TARGET_SDK_VERSION=27

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
@@ -20,7 +20,11 @@ class BugsnagNdkSetupTask extends DefaultTask {
                 String identifier = it.id.componentIdentifier.toString()
                 List<String> soArtefacts = ["bugsnag-android", "bugsnag-android-ndk",
                                    "bugsnag-plugin-android-anr", "bugsnag-plugin-android-ndk",]
-                soArtefacts.contains(identifier) && it.file != null
+
+                boolean isBugsnagArtefact = soArtefacts.stream().anyMatch {
+                    identifier.contains(it)
+                }
+                isBugsnagArtefact && it.file != null
             }
             if (artifact) {
                 File artifactFile = artifact.file


### PR DESCRIPTION
The `identifier` variable contains the version as well, looking something like 'com.bugsnag:bugsnag-android:4.x.x'. Therefore we should match by checking whether our collections of identifiers is a substring within the identifier, rather than checking for equality, as otherwise SO files will not be extracted.

This has been tested by integrating the plugin into the example project, and running `./gradlew assembleRelease` after invalidating caches and restarting via Android Studio (to prevent any old SO files from hanging around in the build directory).