### PR TITLE
Update plugin to extract SO files from transitive dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.5.2 TBD
+
+Update plugin to extract SO files from transitive dependencies
+[#171](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/171)
+
 ## 4.5.1 (2019-07-17)
 
 Lookup shared object files correctly in new artefact IDs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.5.2 TBD
+## 4.5.2 (2019-07-18)
 
 Update plugin to extract SO files from transitive dependencies
 [#171](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/171)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.bugsnag
-version = 4.5.1
+version = 4.5.2
 
 ANDROID_MIN_SDK_VERSION=14
 ANDROID_TARGET_SDK_VERSION=27

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagNdkSetupTask.groovy
@@ -2,7 +2,11 @@ package com.bugsnag.android.gradle
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.artifacts.ResolvedConfiguration
+import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.tasks.TaskAction
+
+import java.util.stream.Collectors
 
 class BugsnagNdkSetupTask extends DefaultTask {
 
@@ -13,29 +17,55 @@ class BugsnagNdkSetupTask extends DefaultTask {
 
     @TaskAction
     void setupNdkProject() {
-        project.configurations.findAll {
-            it.toString().contains('CompileClasspath')
-        }.each { config ->
-            ResolvedArtifact artifact = config.resolvedConfiguration.resolvedArtifacts.find {
-                String identifier = it.id.componentIdentifier.toString()
-                List<String> soArtefacts = ["bugsnag-android", "bugsnag-android-ndk",
-                                   "bugsnag-plugin-android-anr", "bugsnag-plugin-android-ndk",]
+        Set<ResolvedArtifact> artifacts = new HashSet<>()
 
-                boolean isBugsnagArtefact = soArtefacts.stream().anyMatch {
-                    identifier.contains(it)
+        findCompileConfigurations().each { config ->
+            config.firstLevelModuleDependencies.stream()
+                .filter { (it.moduleGroup == "com.bugsnag") }
+                .forEach {
+                    artifacts.addAll(resolveArtifacts(it))
                 }
-                isBugsnagArtefact && it.file != null
-            }
-            if (artifact) {
-                File artifactFile = artifact.file
-                File buildDir = project.buildDir
-                File dst = new File(buildDir, "/intermediates/bugsnag-libs")
+        }
+        artifacts.forEach { copyArtifact(it) }
+    }
 
-                project.copy {
-                    from project.zipTree(artifactFile)
-                    into(project.file(dst))
-                }
+    Set<ResolvedArtifact> resolveArtifacts(ResolvedDependency dependency) {
+        dependency.allModuleArtifacts.findAll {
+            String identifier = it.id.componentIdentifier.toString()
+            List<String> soArtefacts = ["bugsnag-android", "bugsnag-android-ndk",
+                                        "bugsnag-plugin-android-anr", "bugsnag-plugin-android-ndk",]
+
+            boolean isBugsnagArtefact = soArtefacts.stream().anyMatch {
+                identifier.contains(it)
             }
+            isBugsnagArtefact && it.file != null
         }
     }
+
+    void copyArtifact(ResolvedArtifact artifact) {
+        File artifactFile = artifact.file
+        File buildDir = project.buildDir
+        File dst = new File(buildDir, "/intermediates/bugsnag-libs")
+
+        project.copy {
+            from project.zipTree(artifactFile)
+            into(project.file(dst))
+        }
+    }
+
+    /**
+     * @return the ResolvedConfiguration for any gradle configurations which add compile-time dependencies.
+     * e.g. if 'bugsnag-android' is added as a dependency, it will be part of the 'api' configuration.
+     */
+    private Set<ResolvedConfiguration> findCompileConfigurations() {
+        project.configurations
+            .findAll { it.toString().contains('CompileClasspath') }
+            .stream()
+            .map { it.resolvedConfiguration }
+            .collect(Collectors.toSet())
+    }
+
+    /**
+     * Copies artifacts to a location in the build directory where their shared object files can be read.
+     */
 }


### PR DESCRIPTION
## Goal

The new bugsnag-android notifier will have 3 transitive AAR dependencies, 2 of which contain SO files. These need to be extracted as part of the build process so users can compile against them, but the current gradle plugin implementation does not copy files from transitive dependencies. This changeset fixes that.

## Background

A [`ResolvedArtifact`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/ResolvedArtifact.html) represents the AAR on disk. Each [`ResolvedConfiguration`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/ResolvedConfiguration.html#getResolvedArtifacts--) can have multiple artifacts, which themselves can have transitive dependencies on other artifacts. For example:

`compile 'com.bugsnag:bugsnag-android'`

Adds the bugsnag-android AAR to the 'compile' configuration, along with all its transitive dependencies (in this case 3 AARs).

## Changeset

- Extracted copy task to separate function for maintainability
- Extracted function to look up all the configurations in a given project
- Extracted function that given a `ResolvedDependency` finds a Collection of `ResolvedArtifact` which belong to bugsnag and may contain SO files
- Updated Gradle APIs used to `firstLevelModuleDependencies` and `allModuleArtifacts`, which finds all the resolved artifacts for any transitive dependencies in a configuration
- Resolved artifacts are placed in a `Set` and copied at once, which avoids unnecessary work

## Tests

Assembled the example project and ran mazerunner locally, from a clean build with no build directory.
