### PR TITLE
Add configurable timeout for all http requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+Add configurable timeout for all http requests
+[#173](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/173)
+
 ## 4.5.2 (2019-07-18)
 
 Update plugin to extract SO files from transitive dependencies

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagMultiPartUploadTask.groovy
@@ -29,7 +29,6 @@ import org.gradle.api.GradleException
 class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
 
     static final int MAX_RETRY_COUNT = 5
-    static final int TIMEOUT_MILLIS = 60000 // 60 seconds
 
     String applicationId
 
@@ -95,8 +94,8 @@ class BugsnagMultiPartUploadTask extends BugsnagVariantOutputTask {
 
         HttpClient httpClient = new DefaultHttpClient()
         HttpParams params = httpClient.params
-        HttpConnectionParams.setConnectionTimeout(params, TIMEOUT_MILLIS)
-        HttpConnectionParams.setSoTimeout(params, TIMEOUT_MILLIS)
+        HttpConnectionParams.setConnectionTimeout(params, project.bugsnag.requestTimeoutMs)
+        HttpConnectionParams.setSoTimeout(params, project.bugsnag.requestTimeoutMs)
 
         int statusCode
         String responseEntity

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
@@ -21,6 +21,7 @@ class BugsnagPluginExtension {
     String sharedObjectPath = null
     String projectRoot = null
     boolean failOnUploadError = true
+    int requestTimeoutMs = 60000
 
     // release API values
     String builderName = null

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagReleasesTask.groovy
@@ -58,8 +58,8 @@ class BugsnagReleasesTask extends BugsnagVariantOutputTask {
                 setRequestMethod("POST")
                 setRequestProperty("Content-Type", "application/json")
                 setRequestProperty("Bugsnag-Api-Key", apiKey)
-                setReadTimeout(Call.TIMEOUT_MILLIS)
-                setConnectTimeout(Call.TIMEOUT_MILLIS)
+                setReadTimeout(project.bugsnag.requestTimeoutMs)
+                setConnectTimeout(project.bugsnag.requestTimeoutMs)
                 setDoOutput(true)
 
                 os = outputStream

--- a/src/main/groovy/com/bugsnag/android/gradle/Call.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/Call.groovy
@@ -5,7 +5,6 @@ import org.gradle.api.Project
 abstract class Call {
 
     static final int MAX_RETRY_COUNT = 5
-    static final int TIMEOUT_MILLIS = 60000
 
     private final Project project // 60 seconds
 


### PR DESCRIPTION
## Goal

Makes the request timeout configurable via the bugsnag plugin extension. This allows customers to alter the default from 60 seconds, to a smaller/larger value if required.

```
bugsnag {
    requestTimeoutMs = 5000 // timeout requests after 5000ms
}
```

## Tests
Verified that the `requestTimeoutMs` can be altered in an example project.
