### PR TITLE
feat: add ability to override android:versionCode

### DIFF
--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -34,6 +34,7 @@ class BugsnagPlugin implements Plugin<Project> {
 
     static final String API_KEY_TAG = 'com.bugsnag.android.API_KEY'
     static final String BUILD_UUID_TAG = 'com.bugsnag.android.BUILD_UUID'
+    static final String VERSION_CODE_TAG = 'com.bugsnag.android.VERSION_CODE'
     static final String GROUP_NAME = 'Bugsnag'
 
     private static final String NDK_PROJ_TASK = "externalNative"

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
@@ -11,6 +11,7 @@ class BugsnagPluginExtension {
     String endpoint = 'https://upload.bugsnag.com'
     String releasesEndpoint = 'https://build.bugsnag.com'
     String apiKey = null
+    Integer versionCode = null
     boolean autoUpload = true
     boolean autoReportBuilds = true
     boolean autoProguardConfig = true

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -112,7 +112,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
             }
 
             // Get the build version
-            versionCode = getVersionCode(xml, ns)
+            versionCode = getVersionCode(metaDataTags, xml, ns)
             if (versionCode == null) {
                 project.logger.warn("Could not find 'android:versionCode' value in your AndroidManifest.xml")
                 continue
@@ -135,6 +135,11 @@ class BugsnagVariantOutputTask extends DefaultTask {
             apiKey = project.bugsnag.apiKey
         } else {
             apiKey = getManifestMetaData(metaDataTags, ns, BugsnagPlugin.API_KEY_TAG)
+
+            if (apiKey == null) {
+                project.logger.warn("Could not find '$BugsnagPlugin.API_KEY_TAG' " +
+                    "<meta-data> tag in your AndroidManifest.xml")
+            }
         }
         apiKey
     }
@@ -146,7 +151,12 @@ class BugsnagVariantOutputTask extends DefaultTask {
     }
 
     String getBuildUuid(metaDataTags, Namespace ns) {
-        getManifestMetaData(metaDataTags, ns, BugsnagPlugin.BUILD_UUID_TAG)
+        String data = getManifestMetaData(metaDataTags, ns, BugsnagPlugin.BUILD_UUID_TAG)
+        if (data == null) {
+            project.logger.warn("Could not find '$BugsnagPlugin.BUILD_UUID_TAG'" +
+                " <meta-data> tag in your AndroidManifest.xml")
+        }
+        data
     }
 
     private String getManifestMetaData(metaDataTags, Namespace ns, String key) {
@@ -155,9 +165,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
         def tags = metaDataTags.findAll {
             (it.attributes()[ns.name] == key)
         }
-        if (tags.isEmpty()) {
-            project.logger.warn("Could not find '$key' <meta-data> tag in your AndroidManifest.xml")
-        } else {
+        if (!tags.isEmpty()) {
             value = tags[0].attributes()[ns.value]
         }
         value
@@ -167,7 +175,19 @@ class BugsnagVariantOutputTask extends DefaultTask {
         xml.attributes()[ns.versionName]
     }
 
-    String getVersionCode(Node xml, Namespace ns) {
-        xml.attributes()[ns.versionCode]
+    String getVersionCode(metaDataTags, Node xml, Namespace ns) {
+        String versionCode
+
+        if (project.bugsnag.versionCode != null) {
+            versionCode = project.bugsnag.versionCode
+        } else {
+            versionCode = getManifestMetaData(metaDataTags, ns, BugsnagPlugin.VERSION_CODE_TAG)
+        }
+
+        if (versionCode != null) {
+            return versionCode
+        } else {
+            return xml.attributes()[ns.versionCode]
+        }
     }
 }

--- a/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
@@ -25,6 +25,7 @@ class PluginExtensionTest {
     void ensureExtensionDefaults() {
         assertEquals("https://upload.bugsnag.com", proj.bugsnag.endpoint)
         assertNull(proj.bugsnag.apiKey)
+        assertNull(proj.bugsnag.versionCode)
         assertTrue(proj.bugsnag.autoUpload)
         assertTrue(proj.bugsnag.autoReportBuilds)
         assertTrue(proj.bugsnag.autoProguardConfig)


### PR DESCRIPTION
## Goal

Allows overriding the `android:versionCode` value reported via the manifest when uploading mapping files to `upload.bugsnag.com. This can be overridden in two ways:

1. Setting `project.bugsnag.versionCode` to an integer
2. Adding `com.bugsnag.android.VERSION_CODE` as a `meta-data` element in the manifest

For further context see https://github.com/bugsnag/bugsnag-android/pull/610

## Changeset

- Adds a `versionCode` field to the `bugsnag` plugin extension, which is null by default

If `project.bugsnag.versionCode` has been set, use this value for the version code. Otherwise, search the manifest first for the value of `com.bugsnag.android.VERSION_CODE`, and then for the value of `android:versionCode`.

## Tests
- Verified default value of `versionCode` field on plugin extension in test
- Installed local artefact and verified that the `versionCode` is set correctly in 3 cases: the default; setting via the manifest; and setting via the plugin extension
