### PR TITLE
Fix AGP 3.6.0 breaking project builds due to changed return type of getBundleManifestOutputDirectory()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+Fix AGP 3.6.0 breaking project builds due to changed return type of `getBundleManifestOutputDirectory()`
+[#179](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/179)
+
 ## 4.7.0 (2019-10-14)
 
 Add ability to override reported value for versionCode

--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,7 @@ task wrapper(type: Wrapper) {
 codenarc {
     // ignore baseline violations for now
     maxPriority2Violations 7
-    maxPriority3Violations 11
+    maxPriority3Violations 10
 }
 
 // license checking

--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,7 @@ task wrapper(type: Wrapper) {
 codenarc {
     // ignore baseline violations for now
     maxPriority2Violations 7
-    maxPriority3Violations 9
+    maxPriority3Violations 11
 }
 
 // license checking

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -293,7 +293,7 @@ class BugsnagPlugin implements Plugin<Project> {
         if (processManifest.hasProperty("bundleManifestOutputDirectory")) {
 
             // For AGP versions >= 3.3.0 the bundle manifest is output to its own directory
-            def directory = processManifest.getBundleManifestOutputDirectory()
+            def directory = processManifest.bundleManifestOutputDirectory
 
             if (directory instanceof File) { // 3.3.X - 3.5.X returns a File
                 return directory

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -291,8 +291,16 @@ class BugsnagPlugin implements Plugin<Project> {
 
     static File resolveBundleManifestOutputDirectory(ManifestProcessorTask processManifest) {
         if (processManifest.hasProperty("bundleManifestOutputDirectory")) {
+
             // For AGP versions >= 3.3.0 the bundle manifest is output to its own directory
-            return processManifest.bundleManifestOutputDirectory
+            def directory = processManifest.getBundleManifestOutputDirectory()
+
+            if (directory instanceof File) { // 3.3.X - 3.5.X returns a File
+                return directory
+            } else { // 3.6.+ returns a DirectoryProperty
+                return directory.asFile.get()
+            }
+
         } else {
             // For AGP versions < 3.3.0 the bundle manifest is the merged manifest
             return processManifest.manifestOutputDirectory


### PR DESCRIPTION
## Goal

AGP 3.6.0 changed the type of `bundleManifestOutputDirectory` to a `DirectoryProperty` from a `File`. This alters the plugin to always return a `File` depending on which version of the plugin is used.

Fixes #177 

## Changeset

This change checks whether the return value of `getBundleManifestOutputDirectory()` is a `File`. If the AGP is >3.6.0 this will be a `DirectoryProperty`, so we convert that to a `File` instead.

### Static analysis

As part of this change 1 CodeNarc violations was introduced, which has been suppressed by increasing the `maxPriority3Violations` threshold. This was the surrounding the use of `def`, as in this context it allows us to avoid type-casting to a `DirectoryProperty` directly.

```
def directory = processManifest.getBundleManifestOutputDirectory()
```

## Tests

Installed the plugin locally and confirmed that with both 3.4.2 and 3.6.0-beta01, a mapping file is uploaded to a dashboard when running `./gradlew bundle`. Also relied on CI coverage of existing mazerunner tests.
