### PR TITLE
Avoid uploading zero-length proguard mapping files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+Avoid uploading zero-length proguard mapping files
+[#180](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/180)
+
 ## 4.7.0 (2019-10-14)
 
 Add ability to override reported value for versionCode

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
@@ -47,6 +47,8 @@ class BugsnagUploadProguardTask extends BugsnagMultiPartUploadTask {
             } else {
                 return
             }
+        } else if (mappingFile.length() == 0) { // proguard's -dontobfuscate generates an empty mapping file
+            return
         }
 
         // Read the API key and Build ID etc..


### PR DESCRIPTION
## Goal

ProGuard (but not R8) can generate an empty mapping file if the -dontobufscate flag is set. We
should skip upload if the file is empty as it cannot contain useful information and will be rejected
by our API, failing the build.

Fixes #178 

## Changeset

Checked the length of the mapping file and skipped the upload task if it is zero.

## Tests

Manually verified that if ProGuard is enabled in a project with the `dontobfuscate` flag set, the build does not break when building an APK, and that no empty mapping file is uploaded.