### PR TITLE
Allow overriding the 'appVersion' field from the AndroidManifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+Allow overriding the 'appVersion' field from the AndroidManifest
+[#181](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/181)
+
 ## 4.7.1 (2019-10-24)
 
 Fix AGP 3.6.0 breaking project builds due to changed return type of `getBundleManifestOutputDirectory()`

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -35,6 +35,7 @@ class BugsnagPlugin implements Plugin<Project> {
     static final String API_KEY_TAG = 'com.bugsnag.android.API_KEY'
     static final String BUILD_UUID_TAG = 'com.bugsnag.android.BUILD_UUID'
     static final String VERSION_CODE_TAG = 'com.bugsnag.android.VERSION_CODE'
+    static final String APP_VERSION_TAG = 'com.bugsnag.android.APP_VERSION'
     static final String GROUP_NAME = 'Bugsnag'
 
     private static final String NDK_PROJ_TASK = "externalNative"

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -126,7 +126,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
             }
 
             // Get the version name
-            versionName = getVersionName(xml, ns)
+            versionName = getVersionName(metaDataTags, xml, ns)
             if (versionName == null) {
                 project.logger.warn("Could not find 'android:versionName' value in your AndroidManifest.xml")
             }
@@ -163,8 +163,14 @@ class BugsnagVariantOutputTask extends DefaultTask {
         value
     }
 
-    String getVersionName(Node xml, Namespace ns) {
-        xml.attributes()[ns.versionName]
+    String getVersionName(metaDataTags, Node xml, Namespace ns) {
+        String versionName = getManifestMetaData(metaDataTags, ns, BugsnagPlugin.APP_VERSION_TAG)
+
+        if (versionName != null) {
+            return versionName
+        } else {
+            return xml.attributes()[ns.versionName]
+        }
     }
 
     String getVersionCode(metaDataTags, Node xml, Namespace ns) {


### PR DESCRIPTION
## Goal

Supplying a meta-data element for `com.bugsnag.android.APP_VERSION` now allows the `android:versionName` to be overridden when reporting builds/sending uploads.

## Tests

The notifier example app had the following added to its AndroidManifest:

```
<meta-data
    android:name="com.bugsnag.android.APP_VERSION"
    android:value="1.2.3" />
```

It was then confirmed that the upload/build/notify APIs reported '1.2.3' in the expected field. If this meta-data element was removed, the value of 'android:versionName' was reported instead.