### PR TITLE
Use getOrNull for manifest file in 3.6.0

### DIFF
--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPlugin.groovy
@@ -299,7 +299,7 @@ class BugsnagPlugin implements Plugin<Project> {
             if (directory instanceof File) { // 3.3.X - 3.5.X returns a File
                 return directory
             } else { // 3.6.+ returns a DirectoryProperty
-                return directory.asFile.get()
+                return directory.asFile.getOrNull()
             }
 
         } else {


### PR DESCRIPTION
Fix for https://github.com/bugsnag/bugsnag-android-gradle-plugin/issues/185

## Goal
Fixes exception when building with AGP 3.6.0 and Bugsnag Gradle Plugin version 4.7.0+

## Design

`Provider.get()` throws an exception if there is no value; use `getOrNull` instead to avoid the exception.

## Changeset

Changed one line in BugsnagPlugin.groovy

## Tests

Installed locally and verified my app builds with AGP 3.6.0-rc01.

### Linked issues

<!--

Fixes #185 
Related to #179 

-->

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
