### PR TITLE
Fix bugsnag-maze-runner installation issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ before_install:
   - echo y | sdkmanager "tools" >/dev/null
   - echo y | sdkmanager "build-tools;27.0.3" >/dev/null
   - echo y | sdkmanager 'cmake;3.6.4111459'
-  # - gem install bundler
-  - gem --version
-  - bundle install -V
+  - gem install bundler
+  - gem update --system 3.0.6
+  - bundle install
   - ls $ANDROID_HOME
   - ./install_ndk.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - echo y | sdkmanager "build-tools;27.0.3" >/dev/null
   - echo y | sdkmanager 'cmake;3.6.4111459'
   - gem install bundler
-  - bundle install
+  - bundle install -V
   - ls $ANDROID_HOME
   - ./install_ndk.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - echo y | sdkmanager "tools" >/dev/null
   - echo y | sdkmanager "build-tools;27.0.3" >/dev/null
   - echo y | sdkmanager 'cmake;3.6.4111459'
-  - gem install bundler
+  # - gem install bundler
   - bundle install -V
   - ls $ANDROID_HOME
   - ./install_ndk.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
   - echo y | sdkmanager "build-tools;27.0.3" >/dev/null
   - echo y | sdkmanager 'cmake;3.6.4111459'
   # - gem install bundler
+  - gem --version
   - bundle install -V
   - ls $ANDROID_HOME
   - ./install_ndk.sh


### PR DESCRIPTION
## Goal

Downgrade Rubygems to v3.0.6 as v3.1.* throws an error when install maze-runner.