### PR TITLE
Prevent existing buildUuid being overridden by gradle plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+Prevent existing buildUuid being overridden by gradle plugin
+[#192](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/192)
+
 ## 4.7.3 (2020-01-14)
 
 Use getOrNull() rather than Provider#get()

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -46,11 +46,12 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
             if (application) {
                 def metaDataTags = application[TAG_META_DATA]
 
-                // remove any old BUILD_UUID_TAG elements
-                metaDataTags.findAll {
+                // if BUILD_UUID is already present don't override what user has specified
+                def tags = metaDataTags.findAll {
                     (it.attributes()[ns.name] == BugsnagPlugin.BUILD_UUID_TAG)
-                }.each {
-                    it.parent().remove(it)
+                }
+                if (tags.size() > 0) {
+                    return
                 }
 
                 // Add the new BUILD_UUID_TAG element


### PR DESCRIPTION
## Goal

Prevents the `com.bugsnag.android.BUILD_UUID` meta-data element's value being overridden if a user has already specified it.

## Changeset

Checked if a meta-data element with the given tag is already present, and stopped the task if so.

## Tests

Verified in an example app that the buildUuid is set to the correct value both if a user sets it themselves, and if they don't.
