### PR TITLE
Use "mappingFileProvider" API when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+Add compatibility with AGP 4.0 by using the `mappingFileProvider` API when possible
+[#202](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/202)
+
 ## 4.7.3 (2020-01-14)
 
 Use getOrNull() rather than Provider#get()

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadProguardTask.groovy
@@ -5,6 +5,7 @@ import org.apache.http.entity.mime.MultipartEntity
 import org.apache.http.entity.mime.content.FileBody
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.TaskAction
 
 import java.nio.charset.Charset
@@ -75,7 +76,20 @@ class BugsnagUploadProguardTask extends BugsnagMultiPartUploadTask {
                     " falling back to AGP mapping file value")
             }
         }
-        // use AGP supplied value by default, or as fallback
+
+        // Use AGP supplied value, preferring the new "getMappingFileProvider" API but falling back
+        // to the old "mappingFile" API if necessary
+        if (variant.respondsTo("getMappingFileProvider")) {
+            FileCollection mappingFileProvider = variant.mappingFileProvider.getOrNull()
+
+            // We will warn about not finding a mapping file later, so there's no need to warn here
+            if (mappingFileProvider == null || mappingFileProvider.isEmpty()) {
+                return null
+            }
+
+            return mappingFileProvider.first()
+        }
+
         variant.mappingFile
     }
 


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
In `BugsnagUploadProguardTask` we're currently using a now deprecated API in `variant.mappingFile`, which has been replaced with `variant.mappingFileProvider`

This allows the plugin to build using AGP 4.0.0-rc01 and Gradle 6.4

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->
If we can use the new `getMappingFileProvider` API then we do, otherwise fallback to the existing method in case we're on an old version of AGP where the new API doesn't exist yet

## Tests

<!-- How was it tested? -->
This was tested manually using the example app in the bugsnag-android repo, editing the `build.gradle` file to point at AGP `4.0.0-rc01` and updating the Gradle wrapper to 6.4