### PR TITLE
Bump gradle publish plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 plugins {
     id 'groovy'
     id 'codenarc'
-    id 'com.gradle.plugin-publish' version '0.9.7'
+    id 'com.gradle.plugin-publish' version '0.11.0'
     id 'com.bmuschko.nexus' version '2.3.1'
     id 'com.jfrog.bintray' version '1.8.4'
 }


### PR DESCRIPTION
Bumps the gradle publish plugin version to the latest as 0.9.7 contains a security vulnerability which causes plugins.gradle to reject any uploads: https://blog.gradle.org/plugin-portal-update