### PR TITLE
Support for manifest processing in AGP 4.1.0-alpha04 and above

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ gradle-app.setting
 .idea/
 local.properties
 maze_output/
+
+*.iml

--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ compileGroovy {
 
 // Build dependencies
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
+    compileOnly gradleApi()
+    compileOnly localGroovy()
     compileOnly 'com.android.tools.build:gradle:4.1.0-beta01'
     compile 'org.apache.httpcomponents:httpclient:4.5.2'
     compile 'org.apache.httpcomponents:httpmime:4.5.2'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.0-beta01'
     }
 }
 
@@ -47,7 +47,7 @@ compileGroovy {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'com.android.tools.build:gradle:3.1.0'
+    compileOnly 'com.android.tools.build:gradle:4.1.0-beta01'
     compile 'org.apache.httpcomponents:httpclient:4.5.2'
     compile 'org.apache.httpcomponents:httpmime:4.5.2'
     testCompile 'junit:junit:4.12'
@@ -143,10 +143,6 @@ bintray {
             attributes = ['gradle-plugin': "com.bugsnag.android.gradle"]
         }
     }
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.4'
 }
 
 codenarc {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Jun 26 19:11:19 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -31,7 +31,7 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
                 continue
             }
 
-            ManifestUtil.patchManifest(manifestPath, buildUUID, logger)
+            ManifestUtil.patchManifest(manifestPath, manifestPath, buildUUID, logger)
         }
     }
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -1,6 +1,5 @@
 package com.bugsnag.android.gradle
 
-import groovy.xml.Namespace
 import org.gradle.api.tasks.TaskAction
 
 /**
@@ -34,31 +33,5 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
 
             ManifestUtil.patchManifest(manifestPath, buildUUID, logger)
         }
-    }
-
-    boolean isInstantRun() {
-        project.properties["android.optional.compilation"]?.contains("INSTANT_DEV")
-    }
-
-    boolean shouldRun() {
-        List<File> paths = manifestPaths
-
-        for (File manifestPath in paths) {
-            if (!manifestPath.exists()) {
-                continue
-            }
-
-            Namespace ns = new Namespace(NS_URI_ANDROID, NS_PREFIX_ANDROID)
-            def app = new XmlParser().parse(manifestPath).application[0]
-            if (app) {
-                int tagCount = app[TAG_META_DATA].findAll {
-                    (it.attributes()[ns.name] == BugsnagPlugin.BUILD_UUID_TAG)
-                }.size()
-                if (tagCount == 0 || !isInstantRun()) {
-                    return true
-                }
-            }
-        }
-        false
     }
 }

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTask.groovy
@@ -15,10 +15,6 @@ import org.gradle.api.tasks.TaskAction
  */
 class BugsnagManifestTask extends BugsnagVariantOutputTask {
 
-    private static final String TAG_META_DATA = 'meta-data'
-    private static final String NS_URI_ANDROID = "http://schemas.android.com/apk/res/android"
-    private static final String NS_PREFIX_ANDROID = "android"
-
     BugsnagManifestTask() {
         super()
         this.description = "Adds a unique build UUID to AndroidManifest to link proguard mappings to crash reports"
@@ -36,46 +32,7 @@ class BugsnagManifestTask extends BugsnagVariantOutputTask {
                 continue
             }
 
-            project.logger.debug("Updating manifest with build UUID: " + manifestPath)
-
-            // Parse the AndroidManifest.xml
-            Namespace ns = new Namespace(NS_URI_ANDROID, NS_PREFIX_ANDROID)
-            Node xml = new XmlParser().parse(manifestPath)
-
-            def application = xml.application[0]
-            if (application) {
-                def metaDataTags = application[TAG_META_DATA]
-
-                // if BUILD_UUID is already present don't override what user has specified
-                def tags = metaDataTags.findAll {
-                    (it.attributes()[ns.name] == BugsnagPlugin.BUILD_UUID_TAG)
-                }
-                if (tags.size() > 0) {
-                    return
-                }
-
-                // Add the new BUILD_UUID_TAG element
-                application.appendNode(TAG_META_DATA, [(ns.name):BugsnagPlugin.BUILD_UUID_TAG, (ns.value):buildUUID])
-
-                // Write the manifest file
-                FileWriter writer = null
-
-                try {
-                    writer = new FileWriter(manifestPath)
-                    XmlNodePrinter printer = new XmlNodePrinter(new PrintWriter(writer))
-                    printer.preserveWhitespace = true
-                    printer.print(xml)
-                } catch (IOException e) {
-                    project.logger.warn("Failed to update manifest with Bugsnag metadata", e)
-                } finally {
-                    if (writer != null) {
-                        writer.close()
-                    }
-                }
-            } else {
-                project.logger.error("Bugsnag detected invalid manifest with no " +
-                    "application element so did not write Build UUID")
-            }
+            ManifestUtil.patchManifest(manifestPath, buildUUID, logger)
         }
     }
 

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTaskV2.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagManifestTaskV2.groovy
@@ -1,0 +1,48 @@
+package com.bugsnag.android.gradle
+
+import com.android.Version
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.util.VersionNumber
+
+/**
+ An AGP 4.1-compatible version of {@link BugsnagManifestTask}.
+ */
+class BugsnagManifestTaskV2 extends DefaultTask {
+
+    private static MIN_AGP_VERSION = VersionNumber.parse("4.1.0-alpha04")
+
+    // NONE because we only care about its contents, not location.
+    @PathSensitive(PathSensitivity.NONE)
+    @InputFile
+    abstract RegularFileProperty mergedManifest
+
+    @OutputFile
+    abstract RegularFileProperty updatedManifest
+
+    BugsnagManifestTaskV2() {
+        super()
+        this.description = "Adds a unique build UUID to AndroidManifest to link proguard mappings to crash reports"
+    }
+
+    @TaskAction
+    void updateManifest() {
+        // Uniquely identify the build so that we can identify the proguard file.
+        String buildUUID = UUID.randomUUID().toString()
+        ManifestUtil.patchManifest(mergedManifest.asFile.get(), updatedManifest.asFile.get(), buildUUID, logger)
+    }
+
+    static boolean isApplicable() {
+        try {
+            return VersionNumber.parse(Version.ANDROID_GRADLE_PLUGIN_VERSION) >= MIN_AGP_VERSION
+        } catch (Throwable ignored) {
+            // Not on a new enough AGP version, return false
+            return false
+        }
+    }
+}

--- a/src/main/groovy/com/bugsnag/android/gradle/ManifestUtil.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/ManifestUtil.groovy
@@ -12,12 +12,16 @@ final class ManifestUtil {
     private ManifestUtil() {
     }
 
-    static void patchManifest(String manifestPath, String buildUUID, Logger logger) {
-        logger.debug("Updating manifest with build UUID: " + manifestPath)
+    static void patchManifest(String inputManifestPath,
+        String outputManifestPath,
+        String buildUUID,
+        Logger logger
+    ) {
+        logger.debug("Updating manifest with build UUID: " + inputManifestPath)
 
         // Parse the AndroidManifest.xml
         Namespace ns = new Namespace(NS_URI_ANDROID, NS_PREFIX_ANDROID)
-        Node xml = new XmlParser().parse(manifestPath)
+        Node xml = new XmlParser().parse(inputManifestPath)
 
         def application = xml.application[0]
         if (application) {
@@ -38,7 +42,7 @@ final class ManifestUtil {
             FileWriter writer = null
 
             try {
-                writer = new FileWriter(manifestPath)
+                writer = new FileWriter(outputManifestPath)
                 XmlNodePrinter printer = new XmlNodePrinter(new PrintWriter(writer))
                 printer.preserveWhitespace = true
                 printer.print(xml)

--- a/src/main/groovy/com/bugsnag/android/gradle/ManifestUtil.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/ManifestUtil.groovy
@@ -1,0 +1,57 @@
+package com.bugsnag.android.gradle
+
+import groovy.xml.Namespace
+import org.gradle.api.logging.Logger
+
+final class ManifestUtil {
+
+    private static final String TAG_META_DATA = 'meta-data'
+    private static final String NS_URI_ANDROID = "http://schemas.android.com/apk/res/android"
+    private static final String NS_PREFIX_ANDROID = "android"
+
+    private ManifestUtil() {
+    }
+
+    static void patchManifest(String manifestPath, String buildUUID, Logger logger) {
+        logger.debug("Updating manifest with build UUID: " + manifestPath)
+
+        // Parse the AndroidManifest.xml
+        Namespace ns = new Namespace(NS_URI_ANDROID, NS_PREFIX_ANDROID)
+        Node xml = new XmlParser().parse(manifestPath)
+
+        def application = xml.application[0]
+        if (application) {
+            def metaDataTags = application[TAG_META_DATA]
+
+            // if BUILD_UUID is already present don't override what user has specified
+            def tags = metaDataTags.findAll {
+                (it.attributes()[ns.name] == BugsnagPlugin.BUILD_UUID_TAG)
+            }
+            if (tags.size() > 0) {
+                return
+            }
+
+            // Add the new BUILD_UUID_TAG element
+            application.appendNode(TAG_META_DATA, [(ns.name):BugsnagPlugin.BUILD_UUID_TAG, (ns.value):buildUUID])
+
+            // Write the manifest file
+            FileWriter writer = null
+
+            try {
+                writer = new FileWriter(manifestPath)
+                XmlNodePrinter printer = new XmlNodePrinter(new PrintWriter(writer))
+                printer.preserveWhitespace = true
+                printer.print(xml)
+            } catch (IOException e) {
+                logger.warn("Failed to update manifest with Bugsnag metadata", e)
+            } finally {
+                if (writer != null) {
+                    writer.close()
+                }
+            }
+        } else {
+            logger.error("Bugsnag detected invalid manifest with no " +
+                "application element so did not write Build UUID")
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Resolves #194 

## Design

Part of the changes here was to compile against modern gradle and AGP APIs. Both are getting much better about type safety. Along the way, I've made AGP a `compileOnly` dependency (which is fairly standard for plugins using AGP APIs anyway). This is also safe to do since new API usages are gated off (detailed below).

This creates a new, simple `BugsnagManifestTaskV2` that uses the new official API to consume a merged manifest and output a modified one with its generated build ID. This is gated by a runtime check of the AGP version, so it should be safe to use on older versions as well.

## Changeset

See above

## Tests

Want to get thoughts on the implementation before proceeding with test setup. One thing this likely merits is setting up a means of parameterized testing against multiple gradle versions
