### PR TITLE
Remove apiKey property from bugsnag plugin extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Remove unused BugsnagProguardConfigTask
 Make AGP dependency compile only
 [#211](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/211)
 
+Remove apiKey property from bugsnag plugin extension
+[#210](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/210)
+
 ## 4.7.5 (2020-05-18)
 
 Add compatibility with AGP 4.0 by using the `mappingFileProvider` API when possible

--- a/features/fixtures/app/module/config/android/common.gradle
+++ b/features/fixtures/app/module/config/android/common.gradle
@@ -7,6 +7,10 @@ android {
         targetSdkVersion Integer.parseInt(project.ANDROID_TARGET_SDK_VERSION)
         versionCode Integer.parseInt(project.SAMPLE_VERSION_CODE)
         versionName project.SAMPLE_VERSION_NAME
+
+        manifestPlaceholders = [
+            BUGSNAG_API_KEY: "TEST_API_KEY"
+        ]
     }
     buildTypes {
         release {

--- a/features/fixtures/app/module/config/android/debug_proguard.gradle
+++ b/features/fixtures/app/module/config/android/debug_proguard.gradle
@@ -9,6 +9,9 @@ android {
         targetSdkVersion Integer.parseInt(project.ANDROID_TARGET_SDK_VERSION)
         versionCode Integer.parseInt(project.SAMPLE_VERSION_CODE)
         versionName project.SAMPLE_VERSION_NAME
+        manifestPlaceholders = [
+            BUGSNAG_API_KEY: "TEST_API_KEY"
+        ]
     }
     buildTypes {
         debug {

--- a/features/fixtures/app/module/config/android/disabled_obfuscation.gradle
+++ b/features/fixtures/app/module/config/android/disabled_obfuscation.gradle
@@ -9,6 +9,9 @@ android {
         targetSdkVersion Integer.parseInt(project.ANDROID_TARGET_SDK_VERSION)
         versionCode Integer.parseInt(project.SAMPLE_VERSION_CODE)
         versionName project.SAMPLE_VERSION_NAME
+        manifestPlaceholders = [
+            BUGSNAG_API_KEY: "TEST_API_KEY"
+        ]
     }
     buildTypes {
         release {

--- a/features/fixtures/app/module/config/bugsnag/empty_api_key.gradle
+++ b/features/fixtures/app/module/config/bugsnag/empty_api_key.gradle
@@ -1,5 +1,12 @@
+android {
+    defaultConfig {
+        manifestPlaceholders = [
+            BUGSNAG_API_KEY: ""
+        ]
+    }
+}
+
 project.afterEvaluate {
-    project.bugsnag.apiKey = ""
     project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
     project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
 }

--- a/features/fixtures/app/module/src/main/AndroidManifest.xml
+++ b/features/fixtures/app/module/src/main/AndroidManifest.xml
@@ -4,6 +4,6 @@
 
     <meta-data
       android:name="com.bugsnag.android.API_KEY"
-      android:value="TEST_API_KEY" />
+      android:value="${BUGSNAG_API_KEY}" />
   </application>
 </manifest>

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagPluginExtension.groovy
@@ -11,8 +11,6 @@ class BugsnagPluginExtension {
     String endpoint = 'https://upload.bugsnag.com'
     String releasesEndpoint = 'https://build.bugsnag.com'
 
-    @Deprecated
-    String apiKey = null
     boolean autoUpload = true
     boolean autoReportBuilds = true
     boolean uploadDebugBuildMappings = false

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -119,7 +119,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
             }
 
             // Get the Bugsnag API key
-            apiKey = getApiKey(metaDataTags, ns)
+            apiKey = getManifestMetaData(metaDataTags, ns, BugsnagPlugin.API_KEY_TAG)
             if (apiKey == null) {
                 project.logger.warn("Could not find apiKey in '$BugsnagPlugin.API_KEY_TAG' " +
                     "<meta-data> tag in your AndroidManifest.xml or in your gradle config")
@@ -146,17 +146,6 @@ class BugsnagVariantOutputTask extends DefaultTask {
             }
             return
         }
-    }
-
-    String getApiKey(metaDataTags, Namespace ns) {
-        String apiKey
-
-        if (project.bugsnag.apiKey != null) {
-            apiKey = project.bugsnag.apiKey
-        } else {
-            apiKey = getManifestMetaData(metaDataTags, ns, BugsnagPlugin.API_KEY_TAG)
-        }
-        apiKey
     }
 
     boolean hasBuildUuid(metaDataTags, Namespace ns) {

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -122,7 +122,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
             apiKey = getManifestMetaData(metaDataTags, ns, BugsnagPlugin.API_KEY_TAG)
             if (apiKey == null) {
                 project.logger.warn("Could not find apiKey in '$BugsnagPlugin.API_KEY_TAG' " +
-                    "<meta-data> tag in your AndroidManifest.xml or in your gradle config")
+                    "<meta-data> tag in your AndroidManifest.xml")
             }
 
             // Get the build version

--- a/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
@@ -24,7 +24,6 @@ class PluginExtensionTest {
     @Test
     void ensureExtensionDefaults() {
         assertEquals("https://upload.bugsnag.com", proj.bugsnag.endpoint)
-        assertNull(proj.bugsnag.apiKey)
         assertTrue(proj.bugsnag.autoUpload)
         assertTrue(proj.bugsnag.autoReportBuilds)
         assertFalse(proj.bugsnag.uploadDebugBuildMappings)


### PR DESCRIPTION
## Goal

Removes the deprecated apiKey property from the `BugsnagPluginExtension` class. This means that users must specify their API key in the AndroidManifest rather than the plugin extension, which led to confusion in the past.

## Tests

Relied on existing E2E test coverage. Updated `fail_on_upload.feature` to allow specifying an empty API key in one scenario.
