### PR TITLE
Make AGP dependency compile only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Remove unused BugsnagProguardConfigTask
 [#209](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/209)
 
+Make AGP dependency compile only
+[#211](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/211)
+
 ## 4.7.5 (2020-05-18)
 
 Add compatibility with AGP 4.0 by using the `mappingFileProvider` API when possible

--- a/build.gradle
+++ b/build.gradle
@@ -45,11 +45,15 @@ compileGroovy {
 
 // Build dependencies
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
-    compile 'com.android.tools.build:gradle:3.4.0'
+    compileOnly gradleApi()
+    compileOnly localGroovy()
+    compileOnly 'com.android.tools.build:gradle:3.4.0'
     compile 'org.apache.httpcomponents:httpclient:4.5.2'
     compile 'org.apache.httpcomponents:httpmime:4.5.2'
+
+    testCompile gradleApi()
+    testCompile localGroovy()
+    testCompile 'com.android.tools.build:gradle:3.4.0'
     testCompile 'junit:junit:4.12'
 }
 


### PR DESCRIPTION
## Goal

Makes the AGP dependency [`compileOnly`](https://blog.gradle.org/introducing-compile-only-dependencies) rather than `compile`. This is preferable because the user will always include the AGP dependency in their own build script if they are using our plugin, and follows the convention used by other plugins.

## Tests

Relied on existing test coverage.
