### PR TITLE
Split checks into separate jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,6 @@ install:
   - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
   - sudo apt-get install -y nodejs
 
-script:
-  - ./gradlew check
-  - ./gradlew clean install -x groovyDoc -x codenarcMain -x codenarcTest --stacktrace
-  - ./gradlew clean build -x groovyDoc -x codenarcMain -x codenarcTest --stacktrace
-  - bundle exec maze-runner -c --verbose
-
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -42,3 +36,17 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - $HOME/.android/build-cache
+
+jobs:
+  include:
+    # Unit test job
+    - name: unit tests
+      script: ./gradlew check
+
+    # Plugin install job
+    - name: plugin install
+      script: ./gradlew build install -x groovyDoc -x codenarcMain -x codenarcTest --stacktrace
+
+    # AGP 3.4.0 E2E tests
+    - name: AGP 3.4.0 E2E tests
+      script: bundle exec maze-runner -c --verbose


### PR DESCRIPTION
## Goal

Splits the CI checks into 3 separate jobs. This should result in quicker feedback when the `check` or `build install` tasks fail, rather than having to wait for the entire mazerunner suite to finish. It also lays the ground for creating a separate job that runs mazerunner scenarios against the latest version of AGP, rather than just 4.0.0.

