### PR TITLE
Use gradle development plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ plugins {
 
 // Gradle plugins
 plugins {
+    id 'java-gradle-plugin'
     id 'groovy'
     id 'codenarc'
     id 'com.gradle.plugin-publish' version '0.12.0'
@@ -45,14 +46,10 @@ compileGroovy {
 
 // Build dependencies
 dependencies {
-    compileOnly gradleApi()
-    compileOnly localGroovy()
     compileOnly 'com.android.tools.build:gradle:3.4.0'
     compile 'org.apache.httpcomponents:httpclient:4.5.2'
     compile 'org.apache.httpcomponents:httpmime:4.5.2'
 
-    testCompile gradleApi()
-    testCompile localGroovy()
     testCompile 'com.android.tools.build:gradle:3.4.0'
     testCompile 'junit:junit:4.12'
 }
@@ -162,4 +159,10 @@ license {
 }
 downloadLicenses {
   dependencyConfiguration "compile"
+}
+
+// waiting for PLAT-4589, temporarily disable input/output checks from gradle development plugin
+// https://docs.gradle.org/current/userguide/java_gradle_plugin.html
+tasks.named("validatePlugins").configure {
+    it.enabled = false
 }


### PR DESCRIPTION
## Goal

The [gradle development plugin](https://docs.gradle.org/current/userguide/java_gradle_plugin.html) is typically used when developing gradle plugins. It simplifies development by avoiding the need for adding `gradleApi/localGroovy` to the buildscript and adds some additional validation checks.

One validation check relating to incremental tasks breaks the build - therefore this task has been temporarily disabled until the work to make the plugin use incremental tasks has been completed.
