### PR TITLE
Remove obsolete backwards compatibility shims

### DIFF
--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagUploadNdkTask.groovy
@@ -82,19 +82,15 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
     }
 
     private Collection<ExternalNativeBuildTask> resolveExternalNativeBuildTasks() {
-        try {
-            return variant.externalNativeBuildProviders
-                .stream()
-                .map({ it.getOrNull() })
-                .filter({ it != null })
-                .collect()
-        } catch (Throwable ignored) {
-            return variant.externalNativeBuildTasks
-        }
+        return variant.externalNativeBuildProviders
+            .stream()
+            .map({ it.getOrNull() })
+            .filter({ it != null })
+            .collect()
     }
 
     private static File findSymbolPath(BaseVariantOutput variantOutput) {
-        ProcessAndroidResources resources = resolveProcessAndroidResources(variantOutput)
+        ProcessAndroidResources resources = variantOutput.processResourcesProvider.getOrNull()
 
         if (resources == null) {
             return null
@@ -108,14 +104,7 @@ class BugsnagUploadNdkTask extends BugsnagMultiPartUploadTask {
         symbolPath
     }
 
-    private static ProcessAndroidResources resolveProcessAndroidResources(BaseVariantOutput variantOutput) {
-        try {
-            return variantOutput.processResourcesProvider.getOrNull()
-        } catch (Throwable ignored) {
-            return variantOutput.processResources
-        }
-    }
-    /**
+     /**
      * Searches the subdirectories of a given path and executes a block on
      * any shared object files
      * @param path The parent path to search. Each subdirectory should

--- a/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/BugsnagVariantOutputTask.groovy
@@ -46,7 +46,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
             getBundleManifest = true
         }
 
-        ManifestProcessorTask processManifest = BugsnagPlugin.resolveProcessManifest(variantOutput)
+        ManifestProcessorTask processManifest = variantOutput.processManifestProvider.getOrNull()
 
         if (processManifest == null) {
             return manifestPaths
@@ -54,18 +54,10 @@ class BugsnagVariantOutputTask extends DefaultTask {
 
         if (getMergedManifest) {
             Object outputDir = processManifest.manifestOutputDirectory
+            Directory dir = outputDir.getOrNull()
 
-            if (outputDir instanceof File) {
-                directoryMerged = outputDir
-            } else {
-                // gradle 4.7 introduced a provider API for lazy evaluation of properties,
-                // AGP subsequently changed the API from File to Provider<File>
-                // see https://docs.gradle.org/4.7/userguide/lazy_configuration.html
-                Directory dir = outputDir.getOrNull()
-
-                if (dir != null) {
-                    directoryMerged = dir.asFile
-                }
+            if (dir != null) {
+                directoryMerged = dir.asFile
             }
 
             if (directoryMerged != null) {
@@ -111,7 +103,7 @@ class BugsnagVariantOutputTask extends DefaultTask {
             project.logger.debug("Reading manifest at: ${manifestPath}")
 
             Node xml = new XmlParser().parse(manifestPath)
-            def metaDataTags = xml.application['meta-data']
+            def metaDataTags = xml.application["meta-data"]
 
             // If the current manifest does not contain the build ID then try the next manifest in the list (if any)
             if (!(manifestPath == paths.last()) && !hasBuildUuid(metaDataTags, ns)) {


### PR DESCRIPTION
## Goal

Removes several backwards compatibility shims that are no longer required due to the bump in minimum supported versions to Gradle 5.1.1 and AGP 3.4.0.

## Changeset

- Replaced single quotes with double quotes
- Removed compatibility shims for gradle versions which don't have [a provider](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Provider.html) supplied by the AGP