### PR TITLE
Compile plugin against AGP 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:3.4.0"
+        classpath "com.android.tools.build:gradle:4.0.0" // compile against 4.0.0, but maintain compat to 3.4.0
     }
 }
 
@@ -46,7 +46,7 @@ compileGroovy {
 
 // Build dependencies
 dependencies {
-    compileOnly "com.android.tools.build:gradle:3.4.0"
+    compileOnly "com.android.tools.build:gradle:4.0.0"
     compile "org.apache.httpcomponents:httpclient:4.5.2"
     compile "org.apache.httpcomponents:httpmime:4.5.2"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Jul 06 17:13:48 BST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Goal

Compiles the plugin against AGP 4.0.0. This does not break compatibility with AGP 3.4.0 because the dependency is `compileOnly`.

This was required because the AGP 3.4.0 artefact seems to have shipped without documentation sources attached, which has made local development a bit harder. Additionally the gradle wrapper used to build the project has been updated to a version which includes sources.