### PR TITLE
Use register() rather than create() for adding tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 5.0.0 (TBD)
 
+Use register() rather than create() for adding tasks
+[#221](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/221)
+
 Remove unused BugsnagProguardConfigTask
 [#209](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/209)
 


### PR DESCRIPTION
## Goal

Replace [project.tasks.create()](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/TaskContainer.html#create-java.lang.String-) with [project.tasks.register()](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/TaskContainer.html#register-java.lang.String-) so that Bugsnag tasks are created lazily, improving build performance during Gradle's [configuration phase](https://docs.gradle.org/current/userguide/build_lifecycle.html#sec:build_phases).

It's worth noting that this PR does leave the `BugsnagReleasesTask` using the `project.tasks.create()` API, as converting this to use the new API failed mazerunner scenarios in a non-obvious way. This task will be converted in a separate PR as it's likely that it will require some additional non-trivial changes.

## Tests

Relied on existing E2E test coverage.
