### PR TITLE
Bump supported JDK version to 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 5.0.0 (TBD)
 
+Bump supported JDK version to 7
+[#224](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/224)
+
 Use register() rather than create() for adding tasks
 [#221](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/221)
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,10 +40,10 @@ repositories {
     google()
 }
 
-// Target Java 1.6 when compiling groovy code
+// Target Java 1.7 when compiling groovy code
 compileGroovy {
-    sourceCompatibility = "1.6"
-    targetCompatibility = "1.6"
+    sourceCompatibility = "1.7"
+    targetCompatibility = "1.7"
 }
 
 // Build dependencies


### PR DESCRIPTION
## Goal

Bumps the supported JDK version to 7 from 6. This is required as it's not possible to build the repository with JDK 13, and it also allows us to use Java 7's diamond syntax (along with other improvements).

JDK 6 was deprecated in 2013 so this is unlikely to affect any end-users.