### PR TITLE
Call register to avoid creating unnecessary tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 ### Gradle ###
 .gradle
 build/
+out/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Bump supported JDK version to 7
 
 Use register() rather than create() for adding tasks
 [#221](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/221)
+[#227](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/227)
 
 Remove unused BugsnagProguardConfigTask
 [#209](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/209)

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -2,8 +2,8 @@
 <SmellBaseline>
   <Blacklist></Blacklist>
   <Whitelist>
+    <ID>LongParameterList:BugsnagPlugin.kt$BugsnagPlugin$(task: Task, variant: ApkVariant, output: ApkVariantOutput, project: Project, bugsnag: BugsnagPluginExtension, autoUpload: Boolean)</ID>
     <ID>MagicNumber:BugsnagPluginExtension.kt$BugsnagPluginExtension$60000</ID>
-    <ID>MaxLineLength:BugsnagPlugin.kt$BugsnagPlugin$private</ID>
     <ID>TooManyFunctions:BugsnagPlugin.kt$BugsnagPlugin$BugsnagPlugin</ID>
   </Whitelist>
 </SmellBaseline>

--- a/features/agp-features/extension_properties.feature
+++ b/features/agp-features/extension_properties.feature
@@ -8,10 +8,10 @@ Scenario: Disable autoReportBuilds
 Scenario: Enable debug mapping upload
     When I build "debug_proguard" using the "upload_debug_enabled" bugsnag config
     Then I should receive 4 requests
-    And the request 2 is valid for the Build API
-    And the request 3 is valid for the Build API
     And the request 0 is valid for the Android Mapping API
     And the request 1 is valid for the Android Mapping API
+    And the request 2 is valid for the Build API
+    And the request 3 is valid for the Build API
 
 Scenario: Enable overwrite
     When I build "default_app" using the "overwrite_enabled" bugsnag config

--- a/src/main/java/com/bugsnag/android/gradle/BugsnagManifestTask.java
+++ b/src/main/java/com/bugsnag/android/gradle/BugsnagManifestTask.java
@@ -1,7 +1,7 @@
 package com.bugsnag.android.gradle;
 
-import com.android.build.gradle.api.BaseVariant;
-import com.android.build.gradle.api.BaseVariantOutput;
+import com.android.build.gradle.api.ApkVariant;
+import com.android.build.gradle.api.ApkVariantOutput;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
 import org.xml.sax.SAXException;
@@ -24,8 +24,14 @@ import java.util.UUID;
  */
 public class BugsnagManifestTask extends DefaultTask {
 
-    BaseVariantOutput variantOutput;
-    BaseVariant variant;
+    ApkVariantOutput variantOutput;
+    ApkVariant variant;
+
+    public BugsnagManifestTask() {
+        super();
+        setGroup(BugsnagPlugin.GROUP_NAME);
+        setDescription("Adds a unique build UUID to AndroidManifest to link proguard mappings to crash reports");
+    }
 
     @TaskAction
     void updateManifest() throws ParserConfigurationException, SAXException, IOException {

--- a/src/main/java/com/bugsnag/android/gradle/BugsnagMultiPartUploadRequest.java
+++ b/src/main/java/com/bugsnag/android/gradle/BugsnagMultiPartUploadRequest.java
@@ -1,7 +1,7 @@
 package com.bugsnag.android.gradle;
 
-import com.android.build.gradle.api.BaseVariant;
-import com.android.build.gradle.api.BaseVariantOutput;
+import com.android.build.gradle.api.ApkVariant;
+import com.android.build.gradle.api.ApkVariantOutput;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.ParseException;
@@ -40,9 +40,8 @@ public class BugsnagMultiPartUploadRequest {
 
     static final int MAX_RETRY_COUNT = 5;
 
-    String applicationId;
-    BaseVariantOutput variantOutput;
-    BaseVariant variant;
+    ApkVariantOutput variantOutput;
+    ApkVariant variant;
 
     void uploadMultipartEntity(MultipartEntity mpEntity, Project project) throws IOException, SAXException, ParserConfigurationException {
         AndroidManifestInfo manifestInfo = BugsnagVariantOutputUtils.readManifestFile(project, variant, variantOutput);
@@ -78,7 +77,7 @@ public class BugsnagMultiPartUploadRequest {
 
     void addPropertiesToMultipartEntity(MultipartEntity mpEntity, AndroidManifestInfo manifestInfo, BugsnagPluginExtension bugsnag, Project project) throws UnsupportedEncodingException {
         mpEntity.addPart("apiKey", new StringBody(manifestInfo.getApiKey()));
-        mpEntity.addPart("appId", new StringBody(applicationId));
+        mpEntity.addPart("appId", new StringBody(variant.getApplicationId()));
         mpEntity.addPart("versionCode", new StringBody(manifestInfo.getVersionCode()));
 
         if (manifestInfo.getBuildUUID() != null) {

--- a/src/main/java/com/bugsnag/android/gradle/BugsnagReleasesTask.java
+++ b/src/main/java/com/bugsnag/android/gradle/BugsnagReleasesTask.java
@@ -1,7 +1,8 @@
 package com.bugsnag.android.gradle;
 
-import com.android.build.gradle.api.BaseVariant;
-import com.android.build.gradle.api.BaseVariantOutput;
+import com.android.build.gradle.api.ApkVariant;
+import com.android.build.gradle.api.ApkVariant;
+import com.android.build.gradle.api.ApkVariantOutput;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
@@ -40,8 +41,14 @@ public class BugsnagReleasesTask extends DefaultTask {
     private static final String VCS_COMMAND = "git";
     private static final String CHARSET_UTF8 = "UTF-8";
 
-    BaseVariantOutput variantOutput;
-    BaseVariant variant;
+    ApkVariantOutput variantOutput;
+    ApkVariant variant;
+
+    public BugsnagReleasesTask() {
+        super();
+        setGroup(BugsnagPlugin.GROUP_NAME);
+        setDescription("Assembles information about the build that will be sent to the releases API");
+    }
 
     @TaskAction
     void fetchReleaseInfo() throws IOException, SAXException, ParserConfigurationException {

--- a/src/main/java/com/bugsnag/android/gradle/BugsnagUploadNdkTask.java
+++ b/src/main/java/com/bugsnag/android/gradle/BugsnagUploadNdkTask.java
@@ -1,10 +1,10 @@
 package com.bugsnag.android.gradle;
 
 import com.android.build.gradle.AppExtension;
-import com.android.build.gradle.api.BaseVariant;
+import com.android.build.gradle.api.ApkVariant;
 import com.android.build.gradle.tasks.ProcessAndroidResources;
 
-import com.android.build.gradle.api.BaseVariantOutput;
+import com.android.build.gradle.api.ApkVariantOutput;
 import com.android.build.gradle.tasks.ExternalNativeBuildTask;
 import kotlin.Pair;
 import org.apache.http.entity.mime.MultipartEntity;
@@ -57,9 +57,14 @@ public class BugsnagUploadNdkTask extends DefaultTask {
     File rootDir;
     String sharedObjectPath;
 
-    String applicationId;
-    BaseVariantOutput variantOutput;
-    BaseVariant variant;
+    ApkVariantOutput variantOutput;
+    ApkVariant variant;
+
+    public BugsnagUploadNdkTask() {
+        super();
+        setGroup(BugsnagPlugin.GROUP_NAME);
+        setDescription("Generates and uploads the NDK mapping file(s) to Bugsnag");
+    }
 
     @TaskAction
     void upload() throws ParserConfigurationException, SAXException, IOException {
@@ -124,7 +129,7 @@ public class BugsnagUploadNdkTask extends DefaultTask {
         return tasks;
     }
 
-    private static File findSymbolPath(BaseVariantOutput variantOutput) {
+    private static File findSymbolPath(ApkVariantOutput variantOutput) {
         ProcessAndroidResources resources = variantOutput.getProcessResourcesProvider().getOrNull();
 
         if (resources == null) {
@@ -272,7 +277,6 @@ public class BugsnagUploadNdkTask extends DefaultTask {
         mpEntity.addPart("projectRoot", new StringBody(projectRoot));
 
         BugsnagMultiPartUploadRequest request = new BugsnagMultiPartUploadRequest();
-        request.applicationId = applicationId;
         request.variant = variant;
         request.variantOutput = variantOutput;
         request.uploadMultipartEntity(mpEntity, getProject());

--- a/src/main/java/com/bugsnag/android/gradle/BugsnagUploadProguardTask.java
+++ b/src/main/java/com/bugsnag/android/gradle/BugsnagUploadProguardTask.java
@@ -1,8 +1,8 @@
 package com.bugsnag.android.gradle;
 
 import com.android.build.gradle.AppExtension;
-import com.android.build.gradle.api.BaseVariant;
-import com.android.build.gradle.api.BaseVariantOutput;
+import com.android.build.gradle.api.ApkVariant;
+import com.android.build.gradle.api.ApkVariantOutput;
 import org.apache.http.entity.mime.HttpMultipartMode;
 import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.FileBody;
@@ -11,7 +11,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.Logger;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskAction;
 import org.xml.sax.SAXException;
 
@@ -36,10 +35,14 @@ import java.nio.file.Paths;
  */
 public class BugsnagUploadProguardTask extends DefaultTask {
 
-    String partName;
-    String applicationId;
-    BaseVariantOutput variantOutput;
-    BaseVariant variant;
+    ApkVariantOutput variantOutput;
+    ApkVariant variant;
+
+    public BugsnagUploadProguardTask() {
+        super();
+        setGroup(BugsnagPlugin.GROUP_NAME);
+        setDescription("Uploads the mapping file to Bugsnag");
+    }
 
     @TaskAction
     void upload() throws IOException, SAXException, ParserConfigurationException {
@@ -70,11 +73,10 @@ public class BugsnagUploadProguardTask extends DefaultTask {
         // Construct a basic request
         Charset charset = Charset.forName("UTF-8");
         MultipartEntity mpEntity = new MultipartEntity(HttpMultipartMode.BROWSER_COMPATIBLE, null, charset);
-        mpEntity.addPart(partName, new FileBody(mappingFile));
+        mpEntity.addPart("proguard", new FileBody(mappingFile));
 
         // Send the request
         BugsnagMultiPartUploadRequest request = new BugsnagMultiPartUploadRequest();
-        request.applicationId = applicationId;
         request.variant = variant;
         request.variantOutput = variantOutput;
         request.uploadMultipartEntity(mpEntity, getProject());

--- a/src/main/java/com/bugsnag/android/gradle/BugsnagVariantOutputUtils.java
+++ b/src/main/java/com/bugsnag/android/gradle/BugsnagVariantOutputUtils.java
@@ -1,7 +1,8 @@
 package com.bugsnag.android.gradle;
 
-import com.android.build.gradle.api.BaseVariant;
-import com.android.build.gradle.api.BaseVariantOutput;
+import com.android.build.gradle.api.ApkVariant;
+import com.android.build.gradle.api.ApkVariant;
+import com.android.build.gradle.api.ApkVariantOutput;
 import com.android.build.gradle.tasks.ManifestProcessorTask;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
@@ -32,14 +33,14 @@ public class BugsnagVariantOutputUtils {
      * See: https://developer.android.com/studio/build/configure-apk-splits.html#build-apks-filename
      * https://issuetracker.google.com/issues/37085185
      */
-    static List<File> getManifestPaths(Project project, BaseVariant variant, BaseVariantOutput variantOutput) {
+    static List<File> getManifestPaths(Project project, ApkVariant variant, ApkVariantOutput variantOutput) {
         File directoryMerged = null;
         File directoryBundle;
         List<File> manifestPaths = new ArrayList();
 
         BugsnagPlugin plugin = project.getPlugins().getPlugin(BugsnagPlugin.class);
-        boolean getMergedManifest = plugin.isRunningAssembleTask(variant, variantOutput, project);
-        boolean getBundleManifest = plugin.isRunningBundleTask(variant, variantOutput, project);
+        boolean getMergedManifest = plugin.isRunningAssembleTask(project, variant, variantOutput);
+        boolean getBundleManifest = plugin.isRunningBundleTask(project, variant, variantOutput);
 
         // If the manifest location could not be reliably determined, attempt to get both
         if (!getMergedManifest && !getBundleManifest) {
@@ -95,7 +96,7 @@ public class BugsnagVariantOutputUtils {
         return null;
     }
 
-    static void addManifestPath(List<File> manifestPaths, File directory, Logger logger, BaseVariantOutput variantOutput) {
+    static void addManifestPath(List<File> manifestPaths, File directory, Logger logger, ApkVariantOutput variantOutput) {
         File manifestFile = Paths.get(directory.toString(), variantOutput.getDirName(),
             "AndroidManifest.xml").toFile();
 
@@ -108,7 +109,7 @@ public class BugsnagVariantOutputUtils {
     }
 
     // Read the API key and Build ID etc..
-    static AndroidManifestInfo readManifestFile(Project project, BaseVariant variant, BaseVariantOutput variantOutput) throws ParserConfigurationException, SAXException, IOException {
+    static AndroidManifestInfo readManifestFile(Project project, ApkVariant variant, ApkVariantOutput variantOutput) throws ParserConfigurationException, SAXException, IOException {
         // Parse the AndroidManifest.xml
         List<File> paths = getManifestPaths(project, variant, variantOutput);
 

--- a/src/main/java/com/bugsnag/android/gradle/BugsnagVariantOutputUtils.java
+++ b/src/main/java/com/bugsnag/android/gradle/BugsnagVariantOutputUtils.java
@@ -1,7 +1,6 @@
 package com.bugsnag.android.gradle;
 
 import com.android.build.gradle.api.ApkVariant;
-import com.android.build.gradle.api.ApkVariant;
 import com.android.build.gradle.api.ApkVariantOutput;
 import com.android.build.gradle.tasks.ManifestProcessorTask;
 import org.gradle.api.Project;

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagInstallJniLibsTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagInstallJniLibsTask.kt
@@ -8,10 +8,11 @@ import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.util.stream.Collectors
 
-class BugsnagNdkSetupTask : DefaultTask() {
+class BugsnagInstallJniLibsTask : DefaultTask() {
 
     init {
         description = "Copies shared object files from the bugsnag-android AAR to the required build directory"
+        group = BugsnagPlugin.GROUP_NAME
     }
 
     @TaskAction

--- a/src/test/groovy/com/bugsnag/android/gradle/FakeVariantImpl.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/FakeVariantImpl.groovy
@@ -1,6 +1,6 @@
 package com.bugsnag.android.gradle
 
-import com.android.build.gradle.api.BaseVariant
+import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.api.BaseVariantOutput
 import com.android.build.gradle.api.JavaCompileOptions
 import com.android.build.gradle.api.SourceKind
@@ -9,10 +9,13 @@ import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.android.build.gradle.tasks.GenerateBuildConfig
 import com.android.build.gradle.tasks.MergeResources
 import com.android.build.gradle.tasks.MergeSourceSetFolders
+import com.android.build.gradle.tasks.PackageAndroidArtifact
 import com.android.build.gradle.tasks.RenderscriptCompile
 import com.android.builder.model.BuildType
 import com.android.builder.model.ProductFlavor
+import com.android.builder.model.SigningConfig
 import com.android.builder.model.SourceProvider
+import org.gradle.api.DefaultTask
 import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Task
 import org.gradle.api.artifacts.ArtifactCollection
@@ -27,7 +30,7 @@ import org.gradle.api.tasks.compile.JavaCompile
 
 @SuppressWarnings(["GetterMethodCouldBeProperty", "UnnecessaryReturnKeyword",
     "ReturnsNullInsteadOfEmptyCollection", "MethodCount", "BuilderMethodWithSideEffects",])
-class FakeVariantImpl implements BaseVariant {
+class FakeVariantImpl implements ApkVariant {
 
     private final String name
 
@@ -357,6 +360,66 @@ class FakeVariantImpl implements BaseVariant {
 
     @Override
     Provider<FileCollection> getMappingFileProvider() {
+        return null
+    }
+
+    @Override
+    Object getDex() {
+        return null
+    }
+
+    @Override
+    PackageAndroidArtifact getPackageApplication() {
+        return null
+    }
+
+    @Override
+    TaskProvider<PackageAndroidArtifact> getPackageApplicationProvider() {
+        return null
+    }
+
+    @Override
+    SigningConfig getSigningConfig() {
+        return null
+    }
+
+    @Override
+    boolean isSigningReady() {
+        return false
+    }
+
+    @Override
+    Set<String> getCompatibleScreens() {
+        return null
+    }
+
+    @Override
+    DefaultTask getInstall() {
+        return null
+    }
+
+    @Override
+    TaskProvider<Task> getInstallProvider() {
+        return null
+    }
+
+    @Override
+    DefaultTask getUninstall() {
+        return null
+    }
+
+    @Override
+    TaskProvider<Task> getUninstallProvider() {
+        return null
+    }
+
+    @Override
+    int getVersionCode() {
+        return 0
+    }
+
+    @Override
+    String getVersionName() {
         return null
     }
 }

--- a/src/test/groovy/com/bugsnag/android/gradle/FakeVariantOutputImpl.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/FakeVariantOutputImpl.groovy
@@ -2,15 +2,17 @@ package com.bugsnag.android.gradle
 
 import com.android.build.FilterData
 import com.android.build.OutputFile
+import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.api.BaseVariantOutput
 import com.android.build.gradle.tasks.ManifestProcessorTask
+import com.android.build.gradle.tasks.PackageAndroidArtifact
 import com.android.build.gradle.tasks.ProcessAndroidResources
 import groovy.transform.CompileStatic
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
 
 @CompileStatic
-class FakeVariantOutputImpl implements BaseVariantOutput {
+class FakeVariantOutputImpl implements ApkVariantOutput {
 
     private final String name
 
@@ -91,5 +93,50 @@ class FakeVariantOutputImpl implements BaseVariantOutput {
     @Override
     File getOutputFile() {
         return null
+    }
+
+    @Override
+    PackageAndroidArtifact getPackageApplication() {
+        return null
+    }
+
+    @Override
+    Task getZipAlign() {
+        return null
+    }
+
+    @Override
+    void setVersionCodeOverride(int versionCodeOverride) {
+
+    }
+
+    @Override
+    int getVersionCodeOverride() {
+        return 0
+    }
+
+    @Override
+    void setVersionNameOverride(String versionNameOverride) {
+
+    }
+
+    @Override
+    String getVersionNameOverride() {
+        return null
+    }
+
+    @Override
+    String getFilter(FilterType filterType) {
+        return null
+    }
+
+    @Override
+    String getOutputFileName() {
+        return null
+    }
+
+    @Override
+    void setOutputFileName(String outputFileName) {
+
     }
 }


### PR DESCRIPTION
## Goal

Organizes the plugin so that it's possible to call `register()` rather than `create()` when creating the `BugsnagReleasesTask`. This means that the task will be created lazily rather than eagerly and should reduce the amount of time spent in the Configuration phase.

## Changeset
- Made each bugsnag task set its group and description within the class to reduce the responsibilities of `BugsnagPlugin`
- Reduced unnecessary properties on task such as `applicationId` on `BugsnagUploadNdkTask`
- Renamed methods which setup bugsnag tasks to better reflect that tasks are registered, not created
- `TaskProvider` is returned by bugsnag task methods and `get()` is called in `variant.packageApplicationProvider.configure {}`. This ensures that tasks are only created for variants which are currently being packaged.
- Used `ApkVariant` rather than `BaseVariant` to gain access to `packageApplicationProvider` property
- Removed `BugsnagTaskDeps` in favour of specifying each task input separately (this lays the groundwork for using the incremental build API in a future PR)
- Updated manifest UUID/release task to only run on variants where JVM/NDK mapping information requires upload

## Tests

Relied on existing test coverage.
