### PR TITLE
Fix task for setting up NDK libs

### DIFF
--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagInstallJniLibsTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagInstallJniLibsTask.kt
@@ -8,7 +8,7 @@ import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.util.stream.Collectors
 
-class BugsnagInstallJniLibsTask : DefaultTask() {
+open class BugsnagInstallJniLibsTask : DefaultTask() {
 
     init {
         description = "Copies shared object files from the bugsnag-android AAR to the required build directory"


### PR DESCRIPTION
## Goal

Fixes the task for copying SO files from bugsnag AAR artefacts. This was not compiling in a project using the NDK as the task was not declared as `open`.

Additionally this alters the lookup of tasks to use `withType()` instead which enables [Configuration Avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) for this task and avoids a brittle string lookup of the task.

## Tests

Verified the SO files are copied over in the example app when cleaning and then rebuilding the app, and that without the gradle plugin this process fails.
