### PR TITLE
Make NDK library setup task use incremental API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 5.0.0 (TBD)
 
+Alter bugsnag tasks to support the Incremental Build API
+[#230](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/230)
+
 Bump supported JDK version to 7
 [#224](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/224)
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
@@ -70,10 +70,7 @@ class BugsnagPlugin : Plugin<Project> {
         if (buildTasks.isNotEmpty()) {
             val ndkSetupTask = project.tasks.create("bugsnagInstallJniLibsTask", BugsnagInstallJniLibsTask::class.java)
             ndkSetupTask.mustRunAfter(cleanTasks)
-            buildTasks.forEach {
-                it.dependsOn(ndkSetupTask)
-                it.doFirst { ndkSetupTask }
-            }
+            buildTasks.forEach { it.dependsOn(ndkSetupTask) }
         }
     }
 


### PR DESCRIPTION
## Goal

Refactors `BugsnagInstallJniLibsTask` to support the [Incremental Build API](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks). This means that if the tasks input/output do not change from the previous execution, then the task can be skipped.

## Changeset

- Added the build directory where SO files are copied as an output
- Added the list of Files which represent the location of bugsnag-android AARs as an input
- Simplified logic to find AARs into `resolveBugsnagArtefacts` method

## Tests

Relied on existing E2E test coverage. Additionally installed the plugin in an example app and ran the `externalNativeBuildRelease` task twice after cleaning the app, to confirm that execution of `BugsnagInstallJniLibsTask` was skipped the second time round.
