### PR TITLE
Rename properties on bugsnag extension that control request autoUpload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Alter bugsnag tasks to support the Incremental Build API
 [#230](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/230)
 
+Rename properties on bugsnag extension that control request autoUpload
+[#231](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/231)
+
 Bump supported JDK version to 7
 [#224](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/224)
 

--- a/features/fixtures/app/module/config/bugsnag/all_disabled.gradle
+++ b/features/fixtures/app/module/config/bugsnag/all_disabled.gradle
@@ -1,6 +1,6 @@
 project.afterEvaluate {
     project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
     project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.autoUpload = false
-    project.bugsnag.autoReportBuilds = false
+    project.bugsnag.uploadJvmMappings = false
+    project.bugsnag.reportBuilds = false
 }

--- a/features/fixtures/app/module/config/bugsnag/auto_report_builds_disabled.gradle
+++ b/features/fixtures/app/module/config/bugsnag/auto_report_builds_disabled.gradle
@@ -1,5 +1,5 @@
 project.afterEvaluate {
     project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
     project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.autoReportBuilds = false
+    project.bugsnag.reportBuilds = false
 }

--- a/features/fixtures/app/module/config/bugsnag/custom_build_info.gradle
+++ b/features/fixtures/app/module/config/bugsnag/custom_build_info.gradle
@@ -1,7 +1,7 @@
 project.afterEvaluate {
     project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
     project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.autoUpload = false
+    project.bugsnag.uploadJvmMappings = false
 
     project.bugsnag.builderName = "Mark Twain"
     project.bugsnag.sourceControl.provider = "bitbucket"

--- a/features/fixtures/app/module/config/bugsnag/overwrite_enabled.gradle
+++ b/features/fixtures/app/module/config/bugsnag/overwrite_enabled.gradle
@@ -1,6 +1,6 @@
 project.afterEvaluate {
     project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
     project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.autoReportBuilds = false
+    project.bugsnag.reportBuilds = false
     project.bugsnag.overwrite = true
 }

--- a/features/fixtures/app_agp340/module/config/bugsnag/all_disabled.gradle
+++ b/features/fixtures/app_agp340/module/config/bugsnag/all_disabled.gradle
@@ -1,6 +1,6 @@
 project.afterEvaluate {
     project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
     project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.autoUpload = false
-    project.bugsnag.autoReportBuilds = false
+    project.bugsnag.uploadJvmMappings = false
+    project.bugsnag.reportBuilds = false
 }

--- a/features/fixtures/app_agp340/module/config/bugsnag/auto_report_builds_disabled.gradle
+++ b/features/fixtures/app_agp340/module/config/bugsnag/auto_report_builds_disabled.gradle
@@ -1,5 +1,5 @@
 project.afterEvaluate {
     project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
     project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.autoReportBuilds = false
+    project.bugsnag.reportBuilds = false
 }

--- a/features/fixtures/app_agp340/module/config/bugsnag/custom_build_info.gradle
+++ b/features/fixtures/app_agp340/module/config/bugsnag/custom_build_info.gradle
@@ -1,7 +1,7 @@
 project.afterEvaluate {
     project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
     project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.autoUpload = false
+    project.bugsnag.uploadJvmMappings = false
 
     project.bugsnag.builderName = "Mark Twain"
     project.bugsnag.sourceControl.provider = "bitbucket"

--- a/features/fixtures/app_agp340/module/config/bugsnag/overwrite_enabled.gradle
+++ b/features/fixtures/app_agp340/module/config/bugsnag/overwrite_enabled.gradle
@@ -1,6 +1,6 @@
 project.afterEvaluate {
     project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
     project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.autoReportBuilds = false
+    project.bugsnag.reportBuilds = false
     project.bugsnag.overwrite = true
 }

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    ndk true
+    uploadNdkMappings true
     endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
     releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
 

--- a/features/fixtures/ndkapp_agp340/app/build.gradle
+++ b/features/fixtures/ndkapp_agp340/app/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    ndk true
+    uploadNdkMappings true
     endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
     releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
@@ -138,7 +138,7 @@ class BugsnagPlugin : Plugin<Project> {
         return project.tasks.register(taskName, BugsnagUploadProguardTask::class.java) {
             it.variantOutput = output
             it.variant = variant
-            addTaskToExecutionGraph(it, variant, output, project, bugsnag, bugsnag.isAutoUpload)
+            addTaskToExecutionGraph(it, variant, output, project, bugsnag, bugsnag.isUploadJvmMappings)
         }
     }
 
@@ -155,7 +155,7 @@ class BugsnagPlugin : Plugin<Project> {
             it.projectDir = project.projectDir
             it.rootDir = project.rootDir
             it.sharedObjectPath = bugsnag.sharedObjectPath
-            addTaskToExecutionGraph(it, variant, output, project, bugsnag, bugsnag.isAutoUpload)
+            addTaskToExecutionGraph(it, variant, output, project, bugsnag, true)
         }
     }
 
@@ -167,7 +167,7 @@ class BugsnagPlugin : Plugin<Project> {
         return project.tasks.register(taskName, BugsnagReleasesTask::class.java) {
             it.variantOutput = output
             it.variant = variant
-            addTaskToExecutionGraph(it, variant, output, project, bugsnag, bugsnag.isAutoReportBuilds)
+            addTaskToExecutionGraph(it, variant, output, project, bugsnag, bugsnag.isReportBuilds)
         }
     }
 
@@ -195,7 +195,7 @@ class BugsnagPlugin : Plugin<Project> {
 
     private fun isNdkProject(bugsnag: BugsnagPluginExtension,
                              android: AppExtension): Boolean {
-        val ndk = bugsnag.ndk
+        val ndk = bugsnag.isUploadNdkMappings
         return if (ndk != null) { // always respect user override
             ndk
         } else { // infer whether native build or not

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPluginExtension.kt
@@ -12,14 +12,14 @@ open class BugsnagPluginExtension {
     val sourceControl: SourceControl = SourceControl()
 
     var isEnabled = true
+    var isUploadJvmMappings = true
+    var isUploadNdkMappings: Boolean? = null
+    var isReportBuilds = true
+    var isUploadDebugBuildMappings = false
     var endpoint = "https://upload.bugsnag.com"
     var releasesEndpoint = "https://build.bugsnag.com"
-    var isAutoUpload = true
-    var isAutoReportBuilds = true
-    var isUploadDebugBuildMappings = false
     var isOverwrite = false
     var retryCount = 0
-    var ndk: Boolean? = null
     var sharedObjectPath: String? = null
     var projectRoot: String? = null
     var isFailOnUploadError = true

--- a/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
@@ -24,12 +24,12 @@ class PluginExtensionTest {
     @Test
     void ensureExtensionDefaults() {
         assertEquals("https://upload.bugsnag.com", proj.bugsnag.endpoint)
-        assertTrue(proj.bugsnag.autoUpload)
-        assertTrue(proj.bugsnag.autoReportBuilds)
+        assertTrue(proj.bugsnag.uploadJvmMappings)
+        assertTrue(proj.bugsnag.reportBuilds)
         assertFalse(proj.bugsnag.uploadDebugBuildMappings)
         assertFalse(proj.bugsnag.overwrite)
         assertEquals(0, proj.bugsnag.retryCount)
-        assertNull(proj.bugsnag.ndk)
+        assertNull(proj.bugsnag.uploadNdkMappings)
         assertNull(proj.bugsnag.sharedObjectPath)
         assertTrue(proj.bugsnag.failOnUploadError)
     }


### PR DESCRIPTION
## Goal

Renames properties on the plugin extension for consistency across the API surface. The old API looked like the following:

```
bugsnag {
    autoUpload = false
    autoReportBuilds = false
    ndk = false
}
```

The new API looks like this:
```
bugsnag {
    uploadJvmMappings = false
    uploadNdkMappings = false
    reportBuilds = false
}
```
