### PR TITLE
Support for manifest processing in AGP 4.1.0-alpha04 and above

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ local.properties
 maze_output/
 package-lock.json
 .cxx
+
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 5.0.0 (TBD)
 
+Support for manifest processing in AGP 4.1.0-alpha04 and above
+[#234](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/234)
+
 Alter bugsnag tasks to support the Incremental Build API
 [#230](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/230)
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ dependencies {
     compile "org.apache.httpcomponents:httpmime:4.5.2"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
 
+    // For serialization of shared data
+    implementation "com.squareup.okio:okio:2.7.0"
+    implementation "com.squareup.moshi:moshi:1.9.3"
+
     testCompile "com.android.tools.build:gradle:4.0.0"
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:2.28.2"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.0-beta04" // compile against 4.0.0, but maintain compat to 3.4.0
+        classpath "com.android.tools.build:gradle:4.1.0-beta04" // compile against 4.1.0-beta04, but maintain compat to 3.4.0
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.9.1"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.0" // compile against 4.0.0, but maintain compat to 3.4.0
+        classpath "com.android.tools.build:gradle:4.1.0-beta04" // compile against 4.0.0, but maintain compat to 3.4.0
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.9.1"
     }
@@ -42,7 +42,7 @@ repositories {
 
 // Build dependencies
 dependencies {
-    compileOnly "com.android.tools.build:gradle:4.0.0"
+    compileOnly "com.android.tools.build:gradle:4.1.0-beta04"
     compile "org.apache.httpcomponents:httpclient:4.5.2"
     compile "org.apache.httpcomponents:httpmime:4.5.2"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"

--- a/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestInfo.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestInfo.kt
@@ -29,6 +29,7 @@ data class AndroidManifestInfo(
             "versionName"
         )
 
+        @Suppress("MagicNumber") // They are indices into the OPTIONS field above
         private val ADAPTER = object : JsonAdapter<AndroidManifestInfo>() {
             override fun fromJson(reader: JsonReader): AndroidManifestInfo? {
                 if (reader.peek() == NULL) {

--- a/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestInfo.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestInfo.kt
@@ -1,8 +1,80 @@
 package com.bugsnag.android.gradle
 
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonReader.Token.NULL
+import com.squareup.moshi.JsonWriter
+import okio.buffer
+import okio.sink
+import okio.source
+import java.io.File
+
 data class AndroidManifestInfo(
     var apiKey: String,
     var versionCode: String,
     var buildUUID: String,
     var versionName: String
-)
+) {
+    internal fun write(file: File) {
+        file.sink().buffer().use {
+            ADAPTER.toJson(it, this)
+        }
+    }
+
+    internal companion object {
+        private val OPTIONS = JsonReader.Options.of(
+            "apiKey",
+            "versionCode",
+            "buildUUID",
+            "versionName"
+        )
+
+        private val ADAPTER = object : JsonAdapter<AndroidManifestInfo>() {
+            override fun fromJson(reader: JsonReader): AndroidManifestInfo? {
+                if (reader.peek() == NULL) {
+                    return reader.nextNull()
+                }
+                lateinit var apiKey: String
+                lateinit var versionCode: String
+                lateinit var buildUUID: String
+                lateinit var versionName: String
+                reader.beginObject()
+                while (reader.hasNext()) {
+                    when (reader.selectName(OPTIONS)) {
+                        0 -> apiKey = reader.nextString()
+                        1 -> versionCode = reader.nextString()
+                        2 -> buildUUID = reader.nextString()
+                        3 -> versionName = reader.nextString()
+                        -1 -> reader.skipValue()
+                    }
+                }
+                reader.endObject()
+                return AndroidManifestInfo(apiKey, versionCode, buildUUID, versionName)
+            }
+
+            override fun toJson(writer: JsonWriter, value: AndroidManifestInfo?) {
+                if (value == null) {
+                    writer.nullValue()
+                    return
+                }
+                writer.beginObject()
+                    .name("apiKey")
+                    .value(value.apiKey)
+                    .name("versionCode")
+                    .value(value.versionCode)
+                    .name("buildUUID")
+                    .value(value.buildUUID)
+                    .name("versionName")
+                    .value(value.versionName)
+                    .endObject()
+            }
+
+        }
+
+        fun read(file: File): AndroidManifestInfo {
+            return file.source().buffer().use {
+                ADAPTER.fromJson(it) ?: error("Failed to parse manifest info.")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestInfoReceiver.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestInfoReceiver.kt
@@ -1,16 +1,9 @@
 package com.bugsnag.android.gradle
 
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity.NONE
 
 interface AndroidManifestInfoReceiver {
-
-    @get:PathSensitive(NONE)
-    @get:InputFile
     val manifestInfoFile: RegularFileProperty
-
 }
 
 internal fun AndroidManifestInfoReceiver.parseManifestInfo(): AndroidManifestInfo {

--- a/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestInfoReceiver.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestInfoReceiver.kt
@@ -1,0 +1,18 @@
+package com.bugsnag.android.gradle
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.NONE
+
+interface AndroidManifestInfoReceiver {
+
+    @get:PathSensitive(NONE)
+    @get:InputFile
+    val manifestInfoFile: RegularFileProperty
+
+}
+
+internal fun AndroidManifestInfoReceiver.parseManifestInfo(): AndroidManifestInfo {
+    return AndroidManifestInfo.read(manifestInfoFile.asFile.get())
+}

--- a/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestParser.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestParser.kt
@@ -61,7 +61,7 @@ class AndroidManifestParser {
         manifestPath: File,
         outputPath: File = manifestPath,
         // Uniquely identify the build so that we can identify the proguard file.
-        buildUuid: String = UUID.randomUUID().toString()
+        buildUuid: String
     ) {
         val root = XmlParser().parse(manifestPath)
         val application = (root[TAG_APPLICATION] as NodeList)[0] as Node

--- a/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestParser.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestParser.kt
@@ -11,6 +11,7 @@ import java.io.File
 import java.io.FileWriter
 import java.io.IOException
 import java.io.PrintWriter
+import java.util.UUID
 import javax.xml.parsers.ParserConfigurationException
 
 class AndroidManifestParser {
@@ -56,7 +57,12 @@ class AndroidManifestParser {
     }
 
     @Throws(ParserConfigurationException::class, SAXException::class, IOException::class)
-    fun writeBuildUuid(manifestPath: File, buildUuid: String) {
+    fun writeBuildUuid(
+        manifestPath: File,
+        outputPath: File = manifestPath,
+        // Uniquely identify the build so that we can identify the proguard file.
+        buildUuid: String = UUID.randomUUID().toString()
+    ) {
         val root = XmlParser().parse(manifestPath)
         val application = (root[TAG_APPLICATION] as NodeList)[0] as Node
         val metadataTags = findMetadataTags(application)
@@ -70,7 +76,7 @@ class AndroidManifestParser {
             ))
 
             // Write the manifest file
-            FileWriter(manifestPath).use {
+            FileWriter(outputPath).use {
                 val printer = XmlNodePrinter(PrintWriter(it))
                 printer.isPreserveWhitespace = true
                 printer.print(root)

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
@@ -9,7 +9,9 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
@@ -20,6 +22,9 @@ abstract class BaseBugsnagManifestUuidTask : DefaultTask() {
         group = BugsnagPlugin.GROUP_NAME
         description = "Adds a unique build UUID to AndroidManifest to link proguard mappings to crash reports"
     }
+
+    @get:Input
+    abstract val buildUuid: Property<String>
 
     @get:OutputFile
     abstract val manifestInfoProvider: RegularFileProperty
@@ -55,7 +60,7 @@ abstract class BugsnagManifestUuidTask : BaseBugsnagManifestUuidTask() {
 
         // read the manifest information and store it for subsequent tasks
         val manifestParser = AndroidManifestParser()
-        manifestParser.writeBuildUuid(manifestPath!!)
+        manifestParser.writeBuildUuid(manifestPath!!, buildUuid = buildUuid.get())
         writeManifestInfo(manifestParser.readManifest(manifestPath, logger))
     }
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
@@ -14,7 +14,6 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.nio.file.Paths
-import java.util.UUID
 
 /**
  * Task to add a unique build UUID to AndroidManifest.xml during the build

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
@@ -10,6 +10,7 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.logging.Logger
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.nio.file.Paths
@@ -25,7 +26,7 @@ import java.util.UUID
  * This task must be called after "process${variantName}Manifest", since it
  * requires that an AndroidManifest.xml exists in `build/intermediates`.
  */
-open class BugsnagManifestUuidTask : DefaultTask() {
+abstract class BugsnagManifestUuidTask : DefaultTask() {
 
     init {
         group = BugsnagPlugin.GROUP_NAME
@@ -34,6 +35,8 @@ open class BugsnagManifestUuidTask : DefaultTask() {
 
     lateinit var variantOutput: ApkVariantOutput
     lateinit var variant: ApkVariant
+
+    @get:Internal
     val manifestInfoProvider: Property<AndroidManifestInfo> = project.objects.property(AndroidManifestInfo::class.java)
 
     @TaskAction
@@ -43,13 +46,11 @@ open class BugsnagManifestUuidTask : DefaultTask() {
             project.logger.warn("Failed to find manifest at $manifestPath for $variantOutput")
         }
 
-        // Uniquely identify the build so that we can identify the proguard file.
-        val buildUUID = UUID.randomUUID().toString()
         project.logger.lifecycle("Updating manifest with build UUID: $manifestPath")
 
         // read the manifest information and store it for subsequent tasks
         val manifestParser = AndroidManifestParser()
-        manifestParser.writeBuildUuid(manifestPath!!, buildUUID)
+        manifestParser.writeBuildUuid(manifestPath!!)
         manifestInfoProvider.set(manifestParser.readManifest(manifestPath, logger))
     }
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
@@ -9,6 +9,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
@@ -16,18 +17,19 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.nio.file.Paths
+import javax.inject.Inject
 
-abstract class BaseBugsnagManifestUuidTask : DefaultTask() {
+abstract class BaseBugsnagManifestUuidTask(objects: ObjectFactory) : DefaultTask() {
     init {
         group = BugsnagPlugin.GROUP_NAME
         description = "Adds a unique build UUID to AndroidManifest to link proguard mappings to crash reports"
     }
 
     @get:Input
-    abstract val buildUuid: Property<String>
+    val buildUuid: Property<String> = objects.property(String::class.java)
 
     @get:OutputFile
-    abstract val manifestInfoProvider: RegularFileProperty
+    val manifestInfoProvider: RegularFileProperty = objects.fileProperty()
 
     fun writeManifestInfo(info: AndroidManifestInfo) {
         info.write(manifestInfoProvider.get().asFile)
@@ -44,7 +46,7 @@ abstract class BaseBugsnagManifestUuidTask : DefaultTask() {
  * This task must be called after "process${variantName}Manifest", since it
  * requires that an AndroidManifest.xml exists in `build/intermediates`.
  */
-abstract class BugsnagManifestUuidTask : BaseBugsnagManifestUuidTask() {
+open class BugsnagManifestUuidTask @Inject constructor(objects: ObjectFactory) : BaseBugsnagManifestUuidTask(objects) {
 
     lateinit var variantOutput: ApkVariantOutput
     lateinit var variant: ApkVariant

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
@@ -7,10 +7,10 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.nio.file.Paths
@@ -21,8 +21,12 @@ abstract class BaseBugsnagManifestUuidTask : DefaultTask() {
         description = "Adds a unique build UUID to AndroidManifest to link proguard mappings to crash reports"
     }
 
-    @get:Internal
-    val manifestInfoProvider: Property<AndroidManifestInfo> = project.objects.property(AndroidManifestInfo::class.java)
+    @get:OutputFile
+    abstract val manifestInfoProvider: RegularFileProperty
+
+    fun writeManifestInfo(info: AndroidManifestInfo) {
+        info.write(manifestInfoProvider.get().asFile)
+    }
 }
 
 /**
@@ -52,7 +56,7 @@ abstract class BugsnagManifestUuidTask : BaseBugsnagManifestUuidTask() {
         // read the manifest information and store it for subsequent tasks
         val manifestParser = AndroidManifestParser()
         manifestParser.writeBuildUuid(manifestPath!!)
-        manifestInfoProvider.set(manifestParser.readManifest(manifestPath, logger))
+        writeManifestInfo(manifestParser.readManifest(manifestPath, logger))
     }
 
     /**

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
@@ -15,6 +15,16 @@ import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.nio.file.Paths
 
+abstract class BaseBugsnagManifestUuidTask : DefaultTask() {
+    init {
+        group = BugsnagPlugin.GROUP_NAME
+        description = "Adds a unique build UUID to AndroidManifest to link proguard mappings to crash reports"
+    }
+
+    @get:Internal
+    val manifestInfoProvider: Property<AndroidManifestInfo> = project.objects.property(AndroidManifestInfo::class.java)
+}
+
 /**
  * Task to add a unique build UUID to AndroidManifest.xml during the build
  * process. This is used by Bugsnag to identify which proguard mapping file
@@ -25,18 +35,10 @@ import java.nio.file.Paths
  * This task must be called after "process${variantName}Manifest", since it
  * requires that an AndroidManifest.xml exists in `build/intermediates`.
  */
-abstract class BugsnagManifestUuidTask : DefaultTask() {
-
-    init {
-        group = BugsnagPlugin.GROUP_NAME
-        description = "Adds a unique build UUID to AndroidManifest to link proguard mappings to crash reports"
-    }
+abstract class BugsnagManifestUuidTask : BaseBugsnagManifestUuidTask() {
 
     lateinit var variantOutput: ApkVariantOutput
     lateinit var variant: ApkVariant
-
-    @get:Internal
-    val manifestInfoProvider: Property<AndroidManifestInfo> = project.objects.property(AndroidManifestInfo::class.java)
 
     @TaskAction
     fun updateManifest() {

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTaskV2.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTaskV2.kt
@@ -2,17 +2,19 @@ package com.bugsnag.android.gradle
 
 import com.android.Version
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.util.VersionNumber
+import javax.inject.Inject
 
 /**
  * An AGP-4-compatible implementation of [BugsnagManifestUuidTask].
  */
-abstract class BugsnagManifestUuidTaskV2 : BaseBugsnagManifestUuidTask() {
+open class BugsnagManifestUuidTaskV2 @Inject constructor(objects: ObjectFactory) : BaseBugsnagManifestUuidTask(objects) {
 
     internal companion object {
         private val MIN_AGP_VERSION: VersionNumber = VersionNumber.parse("4.1.0-alpha04")
@@ -30,10 +32,10 @@ abstract class BugsnagManifestUuidTaskV2 : BaseBugsnagManifestUuidTask() {
     // NONE because we only care about its contents, not location.
     @get:PathSensitive(PathSensitivity.NONE)
     @get:InputFile
-    abstract val inputManifest: RegularFileProperty
+    val inputManifest: RegularFileProperty = objects.fileProperty()
 
     @get:OutputFile
-    abstract val outputManifest: RegularFileProperty
+    val outputManifest: RegularFileProperty = objects.fileProperty()
 
     init {
         group = BugsnagPlugin.GROUP_NAME

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTaskV2.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTaskV2.kt
@@ -15,7 +15,7 @@ import org.gradle.util.VersionNumber
 abstract class BugsnagManifestUuidTaskV2 : BaseBugsnagManifestUuidTask() {
 
     internal companion object {
-        val MIN_AGP_VERSION: VersionNumber = VersionNumber.parse("4.1.0-alpha04")
+        private val MIN_AGP_VERSION: VersionNumber = VersionNumber.parse("4.1.0-alpha04")
 
         fun isApplicable(): Boolean {
             return try {
@@ -45,6 +45,6 @@ abstract class BugsnagManifestUuidTaskV2 : BaseBugsnagManifestUuidTask() {
         val manifestParser = AndroidManifestParser()
         val output = updatedManifest.asFile.get()
         manifestParser.writeBuildUuid(mergedManifest.asFile.get(), updatedManifest.asFile.get())
-        manifestInfoProvider.set(manifestParser.readManifest(output, logger))
+        writeManifestInfo(manifestParser.readManifest(output, logger))
     }
 }

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTaskV2.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTaskV2.kt
@@ -1,9 +1,6 @@
 package com.bugsnag.android.gradle
 
-import org.gradle.api.internal.classpath.ManifestUtil
-
 import com.android.Version
-import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
@@ -13,9 +10,9 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.util.VersionNumber
 
 /**
-An AGP 4.1-compatible version of {@link BugsnagManifestTask}.
+ * An AGP-4-compatible implementation of [BugsnagManifestUuidTask].
  */
-abstract class BugsnagManifestuuidTaskV2 : DefaultTask() {
+abstract class BugsnagManifestUuidTaskV2 : BaseBugsnagManifestUuidTask() {
 
     internal companion object {
         val MIN_AGP_VERSION: VersionNumber = VersionNumber.parse("4.1.0-alpha04")
@@ -46,6 +43,8 @@ abstract class BugsnagManifestuuidTaskV2 : DefaultTask() {
     @TaskAction
     fun updateManifest() {
         val manifestParser = AndroidManifestParser()
+        val output = updatedManifest.asFile.get()
         manifestParser.writeBuildUuid(mergedManifest.asFile.get(), updatedManifest.asFile.get())
+        manifestInfoProvider.set(manifestParser.readManifest(output, logger))
     }
 }

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTaskV2.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTaskV2.kt
@@ -30,10 +30,10 @@ abstract class BugsnagManifestUuidTaskV2 : BaseBugsnagManifestUuidTask() {
     // NONE because we only care about its contents, not location.
     @get:PathSensitive(PathSensitivity.NONE)
     @get:InputFile
-    abstract val mergedManifest: RegularFileProperty
+    abstract val inputManifest: RegularFileProperty
 
     @get:OutputFile
-    abstract val updatedManifest: RegularFileProperty
+    abstract val outputManifest: RegularFileProperty
 
     init {
         group = BugsnagPlugin.GROUP_NAME
@@ -43,10 +43,10 @@ abstract class BugsnagManifestUuidTaskV2 : BaseBugsnagManifestUuidTask() {
     @TaskAction
     fun updateManifest() {
         val manifestParser = AndroidManifestParser()
-        val output = updatedManifest.asFile.get()
+        val output = outputManifest.asFile.get()
         manifestParser.writeBuildUuid(
-            mergedManifest.asFile.get(),
-            updatedManifest.asFile.get(),
+            inputManifest.asFile.get(),
+            outputManifest.asFile.get(),
             buildUuid = buildUuid.get()
         )
         writeManifestInfo(manifestParser.readManifest(output, logger))

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTaskV2.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTaskV2.kt
@@ -14,7 +14,9 @@ import javax.inject.Inject
 /**
  * An AGP-4-compatible implementation of [BugsnagManifestUuidTask].
  */
-open class BugsnagManifestUuidTaskV2 @Inject constructor(objects: ObjectFactory) : BaseBugsnagManifestUuidTask(objects) {
+open class BugsnagManifestUuidTaskV2 @Inject constructor(
+    objects: ObjectFactory
+) : BaseBugsnagManifestUuidTask(objects) {
 
     internal companion object {
         private val MIN_AGP_VERSION: VersionNumber = VersionNumber.parse("4.1.0-alpha04")

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTaskV2.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTaskV2.kt
@@ -44,7 +44,11 @@ abstract class BugsnagManifestUuidTaskV2 : BaseBugsnagManifestUuidTask() {
     fun updateManifest() {
         val manifestParser = AndroidManifestParser()
         val output = updatedManifest.asFile.get()
-        manifestParser.writeBuildUuid(mergedManifest.asFile.get(), updatedManifest.asFile.get())
+        manifestParser.writeBuildUuid(
+            mergedManifest.asFile.get(),
+            updatedManifest.asFile.get(),
+            buildUuid = buildUuid.get()
+        )
         writeManifestInfo(manifestParser.readManifest(output, logger))
     }
 }

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestuuidTaskV2.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestuuidTaskV2.kt
@@ -1,0 +1,51 @@
+package com.bugsnag.android.gradle
+
+import org.gradle.api.internal.classpath.ManifestUtil
+
+import com.android.Version
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.util.VersionNumber
+
+/**
+An AGP 4.1-compatible version of {@link BugsnagManifestTask}.
+ */
+abstract class BugsnagManifestuuidTaskV2 : DefaultTask() {
+
+    internal companion object {
+        val MIN_AGP_VERSION: VersionNumber = VersionNumber.parse("4.1.0-alpha04")
+
+        fun isApplicable(): Boolean {
+            return try {
+                VersionNumber.parse(Version.ANDROID_GRADLE_PLUGIN_VERSION) >= MIN_AGP_VERSION
+            } catch (ignored: Throwable) {
+                // Not on a new enough AGP version, return false
+                false
+            }
+        }
+    }
+
+    // NONE because we only care about its contents, not location.
+    @get:PathSensitive(PathSensitivity.NONE)
+    @get:InputFile
+    abstract val mergedManifest: RegularFileProperty
+
+    @get:OutputFile
+    abstract val updatedManifest: RegularFileProperty
+
+    init {
+        group = BugsnagPlugin.GROUP_NAME
+        description = "Adds a unique build UUID to AndroidManifest to link proguard mappings to crash reports"
+    }
+
+    @TaskAction
+    fun updateManifest() {
+        val manifestParser = AndroidManifestParser()
+        manifestParser.writeBuildUuid(mergedManifest.asFile.get(), updatedManifest.asFile.get())
+    }
+}

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
@@ -120,7 +120,8 @@ class BugsnagPlugin : Plugin<Project> {
     ): Provider<RegularFile> {
         val taskName = "processBugsnag${taskNameForOutput(output)}Manifest"
         val buildUuidProvider = project.provider { UUID.randomUUID().toString() }
-        val manifestInfoOutputFile = project.layout.buildDirectory.file("intermediates/bugsnag/manifestInfoFor${taskNameForOutput(output)}.json")
+        val path = "intermediates/bugsnag/manifestInfoFor${taskNameForOutput(output)}.json"
+        val manifestInfoOutputFile = project.layout.buildDirectory.file(path)
         return if (BugsnagManifestUuidTaskV2.isApplicable()) {
             val manifestUpdater = project.tasks.register(taskName, BugsnagManifestUuidTaskV2::class.java) {
                 it.buildUuid.set(buildUuidProvider)

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
@@ -130,8 +130,8 @@ class BugsnagPlugin : Plugin<Project> {
                     artifacts
                         .use(manifestUpdater)
                         .wiredWithFiles(
-                            BugsnagManifestUuidTaskV2::mergedManifest,
-                            BugsnagManifestUuidTaskV2::updatedManifest
+                            BugsnagManifestUuidTaskV2::inputManifest,
+                            BugsnagManifestUuidTaskV2::outputManifest
                         )
                         .toTransform(ArtifactType.MERGED_MANIFEST)
                 }

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
@@ -120,9 +120,11 @@ class BugsnagPlugin : Plugin<Project> {
     ): Provider<RegularFile> {
         val taskName = "processBugsnag${taskNameForOutput(output)}Manifest"
         val buildUuidProvider = project.provider { UUID.randomUUID().toString() }
+        val manifestInfoOutputFile = project.layout.buildDirectory.file("intermediates/bugsnag/manifestInfoFor${taskNameForOutput(output)}.json")
         return if (BugsnagManifestUuidTaskV2.isApplicable()) {
             val manifestUpdater = project.tasks.register(taskName, BugsnagManifestUuidTaskV2::class.java) {
                 it.buildUuid.set(buildUuidProvider)
+                it.manifestInfoProvider.set(manifestInfoOutputFile)
             }
             val android = project.extensions.getByType(BaseAppModuleExtension::class.java)
             android.onVariants.withName(variant.name) {
@@ -142,6 +144,7 @@ class BugsnagPlugin : Plugin<Project> {
                 it.buildUuid.set(buildUuidProvider)
                 it.variantOutput = output
                 it.variant = variant
+                it.manifestInfoProvider.set(manifestInfoOutputFile)
                 val processManifest = output.processManifestProvider.orNull
 
                 if (processManifest != null) {

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
@@ -4,7 +4,6 @@ import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.api.ApkVariantOutput
 import org.gradle.api.DefaultTask
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.provider.Property
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.internal.ExecException
 import org.json.simple.JSONObject
@@ -17,7 +16,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.charset.Charset
 
-open class BugsnagReleasesTask : DefaultTask() {
+abstract class BugsnagReleasesTask : DefaultTask(), AndroidManifestInfoReceiver {
 
     init {
         group = BugsnagPlugin.GROUP_NAME
@@ -26,11 +25,10 @@ open class BugsnagReleasesTask : DefaultTask() {
 
     lateinit var variantOutput: ApkVariantOutput
     lateinit var variant: ApkVariant
-    lateinit var manifestInfoProvider: Property<AndroidManifestInfo>
 
     @TaskAction
     fun fetchReleaseInfo() {
-        val manifestInfo = manifestInfoProvider.get()
+        val manifestInfo = parseManifestInfo()
         val logger = project.logger
         val bugsnag = project.extensions.getByType(BugsnagPluginExtension::class.java)
         val payload = generateJsonPayload(manifestInfo, bugsnag)

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
@@ -3,7 +3,12 @@ package com.bugsnag.android.gradle
 import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.api.ApkVariantOutput
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.NONE
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.internal.ExecException
 import org.json.simple.JSONObject
@@ -15,8 +20,11 @@ import java.io.OutputStream
 import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.charset.Charset
+import javax.inject.Inject
 
-abstract class BugsnagReleasesTask : DefaultTask(), AndroidManifestInfoReceiver {
+open class BugsnagReleasesTask @Inject constructor(
+    objects: ObjectFactory
+) : DefaultTask(), AndroidManifestInfoReceiver {
 
     init {
         group = BugsnagPlugin.GROUP_NAME
@@ -25,6 +33,10 @@ abstract class BugsnagReleasesTask : DefaultTask(), AndroidManifestInfoReceiver 
 
     lateinit var variantOutput: ApkVariantOutput
     lateinit var variant: ApkVariant
+
+    @get:PathSensitive(NONE)
+    @get:InputFile
+    override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
 
     @TaskAction
     fun fetchReleaseInfo() {

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadNdkTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadNdkTask.kt
@@ -197,7 +197,9 @@ abstract class BugsnagUploadNdkTask : DefaultTask(), AndroidManifestInfoReceiver
             val override = getObjDumpOverride(arch)
             val objDumpFile: File
             objDumpFile = override?.let { File(it) } ?: findObjDump(project, arch)
-            check((objDumpFile.exists() && objDumpFile.canExecute())) { "Failed to find executable objdump at $objDumpFile" }
+            check((objDumpFile.exists() && objDumpFile.canExecute())) {
+                "Failed to find executable objdump at $objDumpFile"
+            }
             return objDumpFile
         } catch (ex: Throwable) {
             project.logger.error("Error attempting to calculate objdump location: " + ex.message)

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadNdkTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadNdkTask.kt
@@ -11,11 +11,9 @@ import org.apache.http.entity.mime.content.StringBody
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
-import org.gradle.api.provider.Property
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.io.FileOutputStream
-import java.io.IOException
 import java.io.InputStream
 import java.io.Reader
 import java.util.zip.GZIPOutputStream
@@ -33,7 +31,7 @@ import java.util.zip.GZIPOutputStream
  * it is usually safe to have this be the absolute last task executed during
  * a build.
  */
-open class BugsnagUploadNdkTask : DefaultTask() {
+abstract class BugsnagUploadNdkTask : DefaultTask(), AndroidManifestInfoReceiver {
 
     init {
         group = BugsnagPlugin.GROUP_NAME
@@ -47,7 +45,6 @@ open class BugsnagUploadNdkTask : DefaultTask() {
     var sharedObjectPath: String? = null
     lateinit var variantOutput: ApkVariantOutput
     lateinit var variant: ApkVariant
-    lateinit var manifestInfoProvider: Property<AndroidManifestInfo>
 
     @TaskAction
     fun upload() {
@@ -187,7 +184,7 @@ open class BugsnagUploadNdkTask : DefaultTask() {
         val request = BugsnagMultiPartUploadRequest()
         request.variant = variant
         request.variantOutput = variantOutput
-        request.uploadMultipartEntity(project, mpEntity, manifestInfoProvider.get())
+        request.uploadMultipartEntity(project, mpEntity, parseManifestInfo())
     }
 
     /**

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadNdkTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadNdkTask.kt
@@ -11,12 +11,18 @@ import org.apache.http.entity.mime.content.StringBody
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.NONE
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
 import java.io.Reader
 import java.util.zip.GZIPOutputStream
+import javax.inject.Inject
 
 /**
  * Task to upload shared object mapping files to Bugsnag.
@@ -31,7 +37,9 @@ import java.util.zip.GZIPOutputStream
  * it is usually safe to have this be the absolute last task executed during
  * a build.
  */
-abstract class BugsnagUploadNdkTask : DefaultTask(), AndroidManifestInfoReceiver {
+open class BugsnagUploadNdkTask @Inject constructor(
+    objects: ObjectFactory
+) : DefaultTask(), AndroidManifestInfoReceiver {
 
     init {
         group = BugsnagPlugin.GROUP_NAME
@@ -45,6 +53,10 @@ abstract class BugsnagUploadNdkTask : DefaultTask(), AndroidManifestInfoReceiver
     var sharedObjectPath: String? = null
     lateinit var variantOutput: ApkVariantOutput
     lateinit var variant: ApkVariant
+
+    @get:PathSensitive(NONE)
+    @get:InputFile
+    override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
 
     @TaskAction
     fun upload() {

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadProguardTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadProguardTask.kt
@@ -9,7 +9,6 @@ import org.apache.http.entity.mime.content.FileBody
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.provider.Property
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.nio.charset.Charset
@@ -28,7 +27,7 @@ import java.nio.file.Paths
  * it is usually safe to have this be the absolute last task executed during
  * a build.
  */
-open class BugsnagUploadProguardTask : DefaultTask() {
+abstract class BugsnagUploadProguardTask : DefaultTask(), AndroidManifestInfoReceiver {
 
     init {
         group = BugsnagPlugin.GROUP_NAME
@@ -37,7 +36,6 @@ open class BugsnagUploadProguardTask : DefaultTask() {
 
     lateinit var variantOutput: ApkVariantOutput
     lateinit var variant: ApkVariant
-    lateinit var manifestInfoProvider: Property<AndroidManifestInfo>
 
     @TaskAction
     fun upload() {
@@ -72,7 +70,7 @@ open class BugsnagUploadProguardTask : DefaultTask() {
         val request = BugsnagMultiPartUploadRequest()
         request.variant = variant
         request.variantOutput = variantOutput
-        request.uploadMultipartEntity(project, mpEntity, manifestInfoProvider.get())
+        request.uploadMultipartEntity(project, mpEntity, parseManifestInfo())
     }
 
     private fun findMappingFile(project: Project): File? {

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadProguardTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadProguardTask.kt
@@ -9,10 +9,16 @@ import org.apache.http.entity.mime.content.FileBody
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.NONE
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.nio.charset.Charset
 import java.nio.file.Paths
+import javax.inject.Inject
 
 /**
  * Task to upload ProGuard mapping files to Bugsnag.
@@ -27,7 +33,9 @@ import java.nio.file.Paths
  * it is usually safe to have this be the absolute last task executed during
  * a build.
  */
-abstract class BugsnagUploadProguardTask : DefaultTask(), AndroidManifestInfoReceiver {
+open class BugsnagUploadProguardTask @Inject constructor(
+    objects: ObjectFactory
+) : DefaultTask(), AndroidManifestInfoReceiver {
 
     init {
         group = BugsnagPlugin.GROUP_NAME
@@ -36,6 +44,10 @@ abstract class BugsnagUploadProguardTask : DefaultTask(), AndroidManifestInfoRec
 
     lateinit var variantOutput: ApkVariantOutput
     lateinit var variant: ApkVariant
+
+    @get:PathSensitive(NONE)
+    @get:InputFile
+    override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
 
     @TaskAction
     fun upload() {


### PR DESCRIPTION
## Goal

Resolves #194. Continuation from #207

## Design

Part of the changes here was to compile against modern gradle and AGP APIs. Both are getting much better about type safety. Along the way, I've made AGP a `compileOnly` dependency (which is fairly standard for plugins using AGP APIs anyway). This is also safe to do since new API usages are gated off (detailed below).

This creates a new, simple `BugsnagManifestUuidTaskV2` that uses the new official API to consume a merged manifest and output a modified one with its generated build ID. This is gated by a runtime check of the AGP version, so it should be safe to use on older versions as well.

## Changeset

See above

## Tests

Want to get thoughts on the implementation before proceeding with test setup. One thing this likely merits is setting up a means of parameterized testing against multiple gradle versions
