### PR TITLE
Alter bugsnag extension to allow multiple shared object paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 5.0.0 (TBD)
 
+Alter bugsnag extension to allow multiple shared object paths
+[#237](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/237)
+
 Support for manifest processing in AGP 4.1.0-alpha04 and above
 [#234](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/234)
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
@@ -182,7 +182,7 @@ class BugsnagPlugin : Plugin<Project> {
             it.variant = variant
             it.projectDir = project.projectDir
             it.rootDir = project.rootDir
-            it.sharedObjectPath = bugsnag.sharedObjectPath
+            it.sharedObjectPaths = bugsnag.sharedObjectPaths
             addTaskToExecutionGraph(it, variant, output, project, bugsnag, true)
         }
     }

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPluginExtension.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.gradle
 import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.util.ConfigureUtil
+import java.io.File
 
 /**
  * Defines configuration options (Gradle plugin extensions) for the BugsnagPlugin
@@ -20,7 +21,7 @@ open class BugsnagPluginExtension {
     var releasesEndpoint = "https://build.bugsnag.com"
     var isOverwrite = false
     var retryCount = 0
-    var sharedObjectPath: String = ""
+    var sharedObjectPaths: List<File> = emptyList()
     var projectRoot: String? = null
     var isFailOnUploadError = true
     var requestTimeoutMs = 60000

--- a/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
+++ b/src/test/groovy/com/bugsnag/android/gradle/PluginExtensionTest.groovy
@@ -30,7 +30,7 @@ class PluginExtensionTest {
         assertFalse(proj.bugsnag.overwrite)
         assertEquals(0, proj.bugsnag.retryCount)
         assertNull(proj.bugsnag.uploadNdkMappings)
-        assertEquals("", proj.bugsnag.sharedObjectPath)
+        assertEquals(new ArrayList<String>(), proj.bugsnag.sharedObjectPaths)
         assertTrue(proj.bugsnag.failOnUploadError)
     }
 


### PR DESCRIPTION
## Goal

Allows users to specify multiple shared object paths via the bugsnag plugin extension. Previously it was only possible to specify one shared object path, which meant only one directory could be searched for SO files to upload. The previous API also had to be supplied as a relative path as a string rather than a `File` which led to user confusion.

## Changeset

- Removed `String bugsnag.sharedObjectPath` in favour of `List<File> bugsnag.sharedObjectPaths`
- Updated `BugsnagUploadNdkTask` to handle multiple shared object paths
- Added additional safety checks in shared object path logic within `BugsnagUploadNdkTask`

## Tests

Verified that each shared object path specified in a local example app is searched.
