### PR TITLE
Avoid unnecessary SO mapping file uploads for ABI splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 5.0.0 (TBD)
 
+Avoid unnecessary SO mapping file uploads for ABI splits
+[#238](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/238)
+
 Alter bugsnag extension to allow multiple shared object paths
 [#237](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/237)
 

--- a/features/agp3-features/ndk_app.feature
+++ b/features/agp3-features/ndk_app.feature
@@ -70,3 +70,62 @@ Scenario: Custom objdump location
     And the payload field "arch" equals "x86_64" for request 2
 
     And the request 3 is valid for the Build API
+
+Scenario: NDK app only uploads SO file matching architecture for ABI splits
+    When I set environment variable "ABI_SPLITS" to "enabled"
+    When I build the NDK app
+    Then I should receive 18 requests
+
+    And the request 0 is valid for the Android Mapping API
+    And the payload field "versionCode" equals "5" for request 0
+
+    And the request 1 is valid for the Android Mapping API
+    And the payload field "versionCode" equals "4" for request 1
+
+    And the request 2 is valid for the Android Mapping API
+    And the payload field "versionCode" equals "1" for request 2
+
+    And the request 3 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "x86_64" for request 3
+
+    And the request 4 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "x86" for request 4
+
+    And the request 5 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "arm64-v8a" for request 5
+
+    And the request 6 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "armeabi-v7a" for request 6
+
+    And the request 7 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "x86" for request 7
+
+    And the request 8 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "x86_64" for request 8
+
+    And the request 9 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "armeabi-v7a" for request 9
+
+    And the request 10 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "arm64-v8a" for request 10
+
+    And the request 11 is valid for the Android Mapping API
+    And the payload field "versionCode" equals "3" for request 11
+
+    And the request 12 is valid for the Android Mapping API
+    And the payload field "versionCode" equals "2" for request 12
+
+    And the request 13 is valid for the Build API
+    And the payload field "appVersionCode" equals "5" for request 13
+
+    And the request 14 is valid for the Build API
+    And the payload field "appVersionCode" equals "4" for request 14
+
+    And the request 15 is valid for the Build API
+    And the payload field "appVersionCode" equals "1" for request 15
+
+    And the request 16 is valid for the Build API
+    And the payload field "appVersionCode" equals "3" for request 16
+
+    And the request 17 is valid for the Build API
+    And the payload field "appVersionCode" equals "2" for request 17

--- a/features/agp4-features/ndk_app.feature
+++ b/features/agp4-features/ndk_app.feature
@@ -108,3 +108,86 @@ Scenario: Custom objdump location
     And the payload field "arch" equals "x86_64" for request 4
 
     And the request 5 is valid for the Build API
+
+Scenario: NDK app only uploads SO file matching architecture for ABI splits
+    When I set environment variable "ABI_SPLITS" to "enabled"
+    When I build the NDK app
+    Then I should receive 26 requests
+
+    And the request 0 is valid for the Android Mapping API
+    And the payload field "versionCode" equals "5" for request 0
+
+    And the request 1 is valid for the Android Mapping API
+    And the payload field "versionCode" equals "4" for request 1
+
+    And the request 2 is valid for the Android Mapping API
+    And the payload field "versionCode" equals "1" for request 2
+
+    And the request 3 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "x86_64" for request 3
+
+    And the request 4 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "x86_64" for request 4
+
+    And the request 5 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "x86" for request 5
+
+    And the request 6 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "x86" for request 6
+
+    And the request 7 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "arm64-v8a" for request 7
+
+    And the request 8 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "arm64-v8a" for request 8
+
+    And the request 9 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "armeabi-v7a" for request 9
+
+    And the request 10 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "armeabi-v7a" for request 10
+
+    And the request 11 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "x86" for request 11
+
+    And the request 12 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "x86" for request 12
+
+    And the request 13 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "x86_64" for request 13
+
+    And the request 14 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "x86_64" for request 14
+
+    And the request 15 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "armeabi-v7a" for request 15
+
+    And the request 16 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "armeabi-v7a" for request 16
+
+    And the request 17 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "arm64-v8a" for request 17
+
+    And the request 18 is valid for the Android NDK Mapping API
+    And the payload field "arch" equals "arm64-v8a" for request 18
+
+    And the request 19 is valid for the Android Mapping API
+    And the payload field "versionCode" equals "3" for request 19
+
+    And the request 20 is valid for the Android Mapping API
+    And the payload field "versionCode" equals "2" for request 20
+
+    And the request 21 is valid for the Build API
+    And the payload field "appVersionCode" equals "5" for request 21
+
+    And the request 22 is valid for the Build API
+    And the payload field "appVersionCode" equals "4" for request 22
+
+    And the request 23 is valid for the Build API
+    And the payload field "appVersionCode" equals "1" for request 23
+
+    And the request 24 is valid for the Build API
+    And the payload field "appVersionCode" equals "3" for request 24
+
+    And the request 25 is valid for the Build API
+    And the payload field "appVersionCode" equals "2" for request 25

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.android.application'
 
+ext.abiCodes = ['arm64-v8a':2, 'armeabi-v7a':3, 'x86':4, 'x86_64':5]
+
 android {
     compileSdkVersion 29
     ndkVersion "16.1.4479499"
@@ -32,6 +34,28 @@ android {
     }
     lintOptions {
         checkReleaseBuilds false
+    }
+
+    if ("enabled" == System.env.ABI_SPLITS) {
+        splits {
+            abi {
+                reset()
+                enable true
+                universalApk true
+                include 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
+            }
+        }
+
+        applicationVariants.all { variant ->
+            variant.outputs.each { output ->
+                def abiVersionCode =
+                    project.ext.abiCodes.get(output.getFilter("ABI"))
+
+                if (abiVersionCode != null) {
+                    output.versionCodeOverride = abiVersionCode
+                }
+            }
+        }
     }
 }
 

--- a/features/fixtures/ndkapp_agp340/app/build.gradle
+++ b/features/fixtures/ndkapp_agp340/app/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.android.application'
 
+ext.abiCodes = ['arm64-v8a':2, 'armeabi-v7a':3, 'x86':4, 'x86_64':5]
+
 android {
     compileSdkVersion 29
 
@@ -31,6 +33,27 @@ android {
     }
     lintOptions {
         checkReleaseBuilds false
+    }
+    if ("enabled" == System.env.ABI_SPLITS) {
+        splits {
+            abi {
+                reset()
+                enable true
+                universalApk true
+                include 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
+            }
+        }
+
+        applicationVariants.all { variant ->
+            variant.outputs.each { output ->
+                def abiVersionCode =
+                    project.ext.abiCodes.get(output.getFilter("ABI"))
+
+                if (abiVersionCode != null) {
+                    output.versionCodeOverride = abiVersionCode
+                }
+            }
+        }
     }
 }
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/Abi.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/Abi.kt
@@ -28,14 +28,7 @@ enum class Abi(val abiName: String, val toolchainPrefix: String, val objdumpPref
     );
 
     companion object {
-        fun findByName(abiName: String): Abi? {
-            for (value in values()) {
-                if (value.abiName == abiName) {
-                    return value
-                }
-            }
-            return null
-        }
+        fun findByName(abiName: String) = values().firstOrNull { it.abiName == abiName }
     }
 
 }

--- a/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestParser.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestParser.kt
@@ -20,7 +20,7 @@ class AndroidManifestParser {
 
     @Throws(ParserConfigurationException::class, SAXException::class, IOException::class)
     fun readManifest(manifestPath: File, logger: Logger): AndroidManifestInfo {
-        logger.debug("Reading manifest at: \${manifestPath}")
+        logger.debug("Reading manifest at: ${manifestPath}")
         val root = XmlParser().parse(manifestPath)
         val application = (root[TAG_APPLICATION] as NodeList)[0] as Node
         val metadataTags = findMetadataTags(application)

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
@@ -116,10 +116,10 @@ open class BugsnagManifestUuidTask @Inject constructor(objects: ObjectFactory) :
     private fun addManifestPath(manifestPaths: MutableList<File?>, directory: File, logger: Logger, variantOutput: ApkVariantOutput) {
         val manifestFile = Paths.get(directory.toString(), variantOutput.dirName, "AndroidManifest.xml").toFile()
         if (manifestFile.exists()) {
-            logger.info("Found manifest at \${manifestFile}")
+            logger.info("Found manifest at ${manifestFile}")
             manifestPaths.add(manifestFile)
         } else {
-            logger.error("Failed to find manifest at \${manifestFile}")
+            logger.error("Failed to find manifest at ${manifestFile}")
         }
     }
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
@@ -73,12 +73,11 @@ class BugsnagMultiPartUploadRequest {
             mpEntity.addPart("overwrite", StringBody("true"))
         }
         val logger = project.logger
-        logger.debug("apiKey: \${manifestInfo.apiKey}")
-        logger.debug("appId: \${applicationId}")
-        logger.debug("versionCode: \${manifestInfo.versionCode}")
-        logger.debug("buildUUID: \${manifestInfo.buildUUID}")
-        logger.debug("versionName: \${manifestInfo.versionName}")
-        logger.debug("overwrite: \${project.bugsnag.overwrite}")
+        logger.debug("apiKey: ${manifestInfo.apiKey}")
+        logger.debug("appId: ${variant.applicationId}")
+        logger.debug("versionCode: ${manifestInfo.versionCode}")
+        logger.debug("buildUUID: ${manifestInfo.buildUUID}")
+        logger.debug("versionName: ${manifestInfo.versionName}")
     }
 
     private fun uploadToServer(project: Project,

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
@@ -74,7 +74,7 @@ open class BugsnagReleasesTask @Inject constructor(
             os.write(payload.toString().toByteArray(charset(CHARSET_UTF8)))
             val statusCode = conn.responseCode
             if (statusCode == 200) {
-                logger.info("Uploaded release info to Bugsnag")
+                logger.lifecycle("Bugsnag uploaded release info")
                 return true
             } else {
                 var reader: BufferedReader? = null

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadProguardTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadProguardTask.kt
@@ -57,16 +57,16 @@ open class BugsnagUploadProguardTask @Inject constructor(
     fun upload() {
         val mappingFile = findMappingFile(project)
         val logger = project.logger
-        logger.info("Using mapping file: \$mappingFile")
+        logger.info("Using mapping file: $mappingFile")
 
         // If we haven't enabled proguard for this variant, or the proguard
         // configuration includes -dontobfuscate, the mapping file
         // will not exist (but we also won't need it).
         if (mappingFile == null || !mappingFile.exists()) {
-            logger.warn("Mapping file not found: \${mappingFile}")
+            logger.warn("Mapping file not found: ${mappingFile}")
             val bugsnag = project.extensions.findByType(BugsnagPluginExtension::class.java)!!
             if (bugsnag.isFailOnUploadError) {
-                throw GradleException("Mapping file not found: \${mappingFile}")
+                throw GradleException("Mapping file not found: ${mappingFile}")
             } else {
                 return
             }
@@ -75,7 +75,7 @@ open class BugsnagUploadProguardTask @Inject constructor(
         }
 
         // Read the API key and Build ID etc..
-        logger.info("Attempting to upload mapping file: \${mappingFile}")
+        logger.info("Attempting to upload mapping file: ${mappingFile}")
 
         // Construct a basic request
         val charset = Charset.forName("UTF-8")
@@ -87,6 +87,7 @@ open class BugsnagUploadProguardTask @Inject constructor(
         request.variant = variant
         request.variantOutput = variantOutput
         request.uploadMultipartEntity(project, mpEntity, parseManifestInfo())
+        project.logger.lifecycle("Bugsnag uploaded proguard file") // TODO remove me
     }
 
     private fun findMappingFile(project: Project): File? {
@@ -97,7 +98,7 @@ open class BugsnagUploadProguardTask @Inject constructor(
             if (mappingFile.exists()) {
                 return mappingFile
             } else {
-                project.logger.warn("Could not find DexGuard mapping file at: \$mappingFile -" +
+                project.logger.warn("Could not find DexGuard mapping file at: $mappingFile -" +
                     " falling back to AGP mapping file value")
             }
         }


### PR DESCRIPTION
## Goal

The plugin currently uploads SO mapping files for every architecture for [APK splits](https://developer.android.com/studio/build/configure-apk-splits#configure-APK-versions). As splits can be done on ABI it's unnecessary work to upload SO mapping files for every architecture. This changeset refactors the plugin to only upload SO mapping files for the APK split's current architecture.

## Changeset

- Fixed string interpolation throughout codebase by replacing `\$` with `$`
- Filtered SO file search in `findSharedObjectFiles` by APK split architecture

## Tests

Added E2E scenario which uses SO files and APK splits by ABI. Different ABI splits are distinguished in the received payloads by specifying a different `versionCode` for each.
