### PR TITLE
Rationalize log messages in plugin

### DIFF
--- a/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestParser.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestParser.kt
@@ -19,7 +19,7 @@ class AndroidManifestParser {
 
     @Throws(ParserConfigurationException::class, SAXException::class, IOException::class)
     fun readManifest(manifestPath: File, logger: Logger): AndroidManifestInfo {
-        logger.debug("Reading manifest at: ${manifestPath}")
+        logger.debug("Bugsnag: Reading manifest at: ${manifestPath}")
         val root = XmlParser().parse(manifestPath)
         val application = (root[TAG_APPLICATION] as NodeList)[0] as Node
         val metadataTags = findMetadataTags(application)
@@ -27,38 +27,38 @@ class AndroidManifestParser {
         // Get the Bugsnag API key
         val apiKey = getManifestMetaData(metadataTags, TAG_API_KEY)
         if (apiKey == null) {
-            logger.warn("Could not find apiKey in '$TAG_API_KEY' " +
+            logger.warn("Bugsnag: Could not find apiKey in '$TAG_API_KEY' " +
                 "<meta-data> tag in your AndroidManifest.xml")
         }
 
         // Get the build version
         val versionCode = getVersionCode(metadataTags, root)
         if (versionCode == null) {
-            logger.warn("Could not find 'android:versionCode' value in your AndroidManifest.xml")
+            logger.warn("Bugsnag: Could not find 'android:versionCode' value in your AndroidManifest.xml")
         }
 
         // Uniquely identify the build so that we can identify the proguard file.
         val buildUUID = getManifestMetaData(metadataTags, TAG_BUILD_UUID)
         if (buildUUID == null) {
-            logger.warn("Could not find '$TAG_BUILD_UUID'" +
+            logger.warn("Bugsnag: Could not find '$TAG_BUILD_UUID'" +
                 " <meta-data> tag in your AndroidManifest.xml")
         }
 
         // Get the version name
         val versionName = getVersionName(metadataTags, root)
         if (versionName == null) {
-            logger.warn("Could not find 'android:versionName' value in your AndroidManifest.xml")
+            logger.warn("Bugsnag: Could not find 'android:versionName' value in your AndroidManifest.xml")
         }
 
         // Get the application ID
         val applicationId = getApplicationId(root)
         if (applicationId == null) {
-            logger.warn("Could not find 'package' value in your AndroidManifest.xml")
+            logger.warn("Bugsnag: Could not find 'package' value in your AndroidManifest.xml")
         }
 
         if (apiKey == null || "" == apiKey || versionCode == null ||
             buildUUID == null || versionName == null || applicationId == null) {
-            throw IllegalStateException("Missing apiKey/versionCode/buildUuid/versionName/package," +
+            throw IllegalStateException("Bugsnag: Missing apiKey/versionCode/buildUuid/versionName/package," +
                 " required to upload to bugsnag.")
         }
         return AndroidManifestInfo(apiKey, versionCode, buildUUID, versionName, applicationId)

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
@@ -59,10 +59,10 @@ open class BugsnagManifestUuidTask @Inject constructor(objects: ObjectFactory) :
     fun updateManifest() {
         val manifestPath = getManifestPaths(project, variant, variantOutput)
         if (manifestPath == null) {
-            project.logger.warn("Failed to find manifest at $manifestPath for $variantOutput")
+            project.logger.warn("Bugsnag: Failed to find manifest at $manifestPath for $variantOutput")
         }
 
-        project.logger.lifecycle("Updating manifest with build UUID: $manifestPath")
+        project.logger.info("Bugsnag: Updating manifest with build UUID: $manifestPath")
 
         // read the manifest information and store it for subsequent tasks
         val manifestParser = AndroidManifestParser()
@@ -116,10 +116,10 @@ open class BugsnagManifestUuidTask @Inject constructor(objects: ObjectFactory) :
     private fun addManifestPath(manifestPaths: MutableList<File?>, directory: File, logger: Logger, variantOutput: ApkVariantOutput) {
         val manifestFile = Paths.get(directory.toString(), variantOutput.dirName, "AndroidManifest.xml").toFile()
         if (manifestFile.exists()) {
-            logger.info("Found manifest at ${manifestFile}")
+            logger.info("Bugsnag: Found manifest at ${manifestFile}")
             manifestPaths.add(manifestFile)
         } else {
-            logger.error("Failed to find manifest at ${manifestFile}")
+            logger.info("Bugsnag: Failed to find manifest at ${manifestFile}")
         }
     }
 
@@ -138,7 +138,7 @@ open class BugsnagManifestUuidTask @Inject constructor(objects: ObjectFactory) :
                 }
             }
         } catch (exc: Throwable) {
-            project.logger.warn("Bugsnag failed to find output dir", exc)
+            project.logger.warn("Bugsnag: failed to find manifestOutputDir", exc)
         }
         return null
     }

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
@@ -37,7 +37,7 @@ class BugsnagMultiPartUploadRequest {
         val maxRetryCount = getRetryCount(bugsnag)
         var retryCount = maxRetryCount
         while (!uploadSuccessful && retryCount > 0) {
-            logger.warn(String.format("Retrying Bugsnag upload (%d/%d) ...",
+            logger.warn(String.format("Bugsnag: Retrying upload (%d/%d) ...",
                 maxRetryCount - retryCount + 1, maxRetryCount))
             response = uploadToServer(project, mpEntity, bugsnag)
             uploadSuccessful = response != null
@@ -63,18 +63,13 @@ class BugsnagMultiPartUploadRequest {
             mpEntity.addPart("overwrite", StringBody("true"))
         }
         val logger = project.logger
-        logger.debug("apiKey: ${manifestInfo.apiKey}")
-        logger.debug("appId: ${manifestInfo.applicationId}")
-        logger.debug("versionCode: ${manifestInfo.versionCode}")
-        logger.debug("buildUUID: ${manifestInfo.buildUUID}")
-        logger.debug("versionName: ${manifestInfo.versionName}")
+        logger.debug("Bugsnag: payload information=$manifestInfo")
     }
 
     private fun uploadToServer(project: Project,
                                mpEntity: MultipartEntity?,
                                bugsnag: BugsnagPluginExtension): String? {
         val logger = project.logger
-        logger.lifecycle("Attempting upload of mapping file to Bugsnag")
 
         // Make the request
         val httpPost = HttpPost(bugsnag.endpoint)
@@ -92,11 +87,11 @@ class BugsnagMultiPartUploadRequest {
             if (statusCode != 200) {
                 throw IllegalStateException("Bugsnag upload failed with code $statusCode $responseEntity")
             } else {
-                logger.lifecycle("Bugsnag upload successful")
+                logger.lifecycle("Bugsnag: Upload succeeded")
                 return responseEntity
             }
         } catch (exc: Throwable) {
-            throw IllegalStateException("Bugsnag upload failed", exc)
+            throw IllegalStateException("Bugsnag Upload failed", exc)
         }
     }
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
@@ -42,13 +42,14 @@ open class BugsnagReleasesTask @Inject constructor(
         val bugsnag = project.extensions.getByType(BugsnagPluginExtension::class.java)
         val payload = generateJsonPayload(manifestInfo, bugsnag)
         val json = payload.toString()
-        project.logger.debug("Releases Payload:\n$json")
+        project.logger.lifecycle("Bugsnag: Attempting upload to Releases API")
 
         object : Call(project) {
             @Throws(IOException::class)
             override fun makeApiCall(): Boolean {
                 val response = deliverPayload(payload, manifestInfo, bugsnag)
                 requestOutputFile.asFile.get().writeText(response)
+                project.logger.lifecycle("Bugsnag: Upload succeeded")
                 return true
             }
         }.execute()

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadProguardTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadProguardTask.kt
@@ -51,11 +51,11 @@ open class BugsnagUploadProguardTask @Inject constructor(
     fun upload() {
         val mappingFile = mappingFileProperty.asFile.get()
         if (mappingFile.length() == 0L) { // proguard's -dontobfuscate generates an empty mapping file
-            project.logger.warn("Ignoring empty proguard file")
+            project.logger.warn("Bugsnag: Ignoring empty proguard file")
             return
         }
         if (!mappingFile.exists()) {
-            logger.warn("Mapping file not found: $mappingFile")
+            logger.warn("Bugsnag: Mapping file not found: $mappingFile")
             val bugsnag = project.extensions.findByType(BugsnagPluginExtension::class.java)!!
             if (bugsnag.isFailOnUploadError) {
                 throw IllegalStateException("Mapping file not found: $mappingFile")
@@ -63,7 +63,7 @@ open class BugsnagUploadProguardTask @Inject constructor(
         }
 
         // Read the API key and Build ID etc..
-        logger.info("Attempting to upload mapping file: $mappingFile")
+        logger.lifecycle("Bugsnag: Attempting to upload mapping file: $mappingFile")
 
         // Construct a basic request
         val charset = Charset.forName("UTF-8")
@@ -74,7 +74,6 @@ open class BugsnagUploadProguardTask @Inject constructor(
         val request = BugsnagMultiPartUploadRequest()
         val response = request.uploadMultipartEntity(project, mpEntity, parseManifestInfo())
         requestOutputFile.asFile.get().writeText(response)
-        project.logger.lifecycle("Bugsnag uploaded proguard file")
     }
 
 }

--- a/src/main/kotlin/com.bugsnag.android.gradle/Call.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/Call.kt
@@ -13,7 +13,7 @@ internal abstract class Call protected constructor(private val project: Project)
         val maxRetryCount = retryCount
         var retryCount = maxRetryCount
         while (!uploadSuccessful && retryCount > 0) {
-            project.logger.warn(String.format("Retrying Bugsnag upload (%d/%d) ...",
+            project.logger.warn(String.format("Bugsnag: Retrying upload (%d/%d) ...",
                 maxRetryCount - retryCount + 1, maxRetryCount))
             uploadSuccessful = makeApiCall()
             retryCount--

--- a/src/main/kotlin/com.bugsnag.android.gradle/MappingFileProvider.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/MappingFileProvider.kt
@@ -20,7 +20,7 @@ fun createMappingFileProvider(project: Project,
     val fileProvider: Provider<File> = project.provider {
         val mappingFile = findMappingFile(project, variant, variantOutput)
         val logger = project.logger
-        logger.info("Using mapping file: $mappingFile")
+        logger.info("Bugsnag: Using mapping file: $mappingFile")
 
         // If we haven't enabled proguard for this variant, or the proguard
         // configuration includes -dontobfuscate, the mapping file
@@ -43,7 +43,7 @@ private fun findMappingFile(project: Project,
         if (mappingFile.exists()) {
             return mappingFile
         } else {
-            project.logger.warn("Could not find DexGuard mapping file at: $mappingFile -" +
+            project.logger.warn("Bugsnag: Could not find DexGuard mapping file at: $mappingFile -" +
                 " falling back to AGP mapping file value")
         }
     }


### PR DESCRIPTION
## Goal

Rationalizes the log messages in plugin by adding a `Bugsnag: ` prefix and rewording where necessary. The log level has also been reduced for most messages so that the only messages which are at a lifecycle level related to upload attempts:

```
> Task :module:uploadBugsnagReleaseMapping
Bugsnag: Attempting to upload mapping file: /Users/jamielynch/repos/bugsnag-android-gradle-plugin/features/fixtures/app/module/build/outputs/mapping/release/mapping.txt
Bugsnag: Upload succeeded

> Task :module:bugsnagReleaseReleaseTask
Bugsnag: Attempting upload to Releases API
Bugsnag: Upload succeeded
```
