### PR TITLE
Only add bugsnag tasks when JVM minification/shared object files are present

### DIFF
--- a/features/agp-features/fail_on_upload_error.feature
+++ b/features/agp-features/fail_on_upload_error.feature
@@ -7,8 +7,7 @@ Scenario: Upload successfully with API key, mapping file, and correct endpoint
 
 Scenario: No uploads or build failures when obfuscation is disabled
     When I build "disabled_obfuscation" using the "standard" bugsnag config
-    Then I should receive 1 request
-    And the request 0 is valid for the Build API
+    Then I should receive 0 requests
     And the exit code equals 0
 
 Scenario: Upload failure due to empty API key

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
@@ -89,6 +89,11 @@ class BugsnagPlugin : Plugin<Project> {
             val jvmMinificationEnabled = variant.buildType.isMinifyEnabled || hasDexguardPlugin(project)
             val ndkEnabled = isNdkUploadEnabled(bugsnag, project.extensions.getByType(AppExtension::class.java))
 
+            // skip tasks for variant if JVM/NDK minification not enabled
+            if (!jvmMinificationEnabled && !ndkEnabled) {
+                return@configureEach
+            }
+
             // register bugsnag tasks
             val manifestInfoFile = registerManifestUuidTask(project, variant, output)
             val proguardTask = when {


### PR DESCRIPTION
## Goal

Avoids adding bugsnag tasks for a variant if JVM minification/shared object files are not present. This prevents the manifest UUID task and releases task from running for variants where it is not necessary. It should reduce the impact of the bugsnag plugin on users builds as this processing time is no longer required and the UUID generation no longer invalidates the build cache for compilation.
