### PR TITLE
Add additional unit test coverage

### DIFF
--- a/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestParser.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestParser.kt
@@ -19,7 +19,7 @@ class AndroidManifestParser {
 
     @Throws(ParserConfigurationException::class, SAXException::class, IOException::class)
     fun readManifest(manifestPath: File, logger: Logger): AndroidManifestInfo {
-        logger.debug("Bugsnag: Reading manifest at: ${manifestPath}")
+        logger.debug("Bugsnag: Reading manifest at: $manifestPath")
         val root = XmlParser().parse(manifestPath)
         val application = (root[TAG_APPLICATION] as NodeList)[0] as Node
         val metadataTags = findMetadataTags(application)
@@ -117,7 +117,7 @@ class AndroidManifestParser {
         return versionName ?: xml.attribute(namespace.get(ATTR_VERSION_NAME)) as String?
     }
 
-    fun getVersionCode(metaDataTags: List<Node>, xml: Node): String? {
+    private fun getVersionCode(metaDataTags: List<Node>, xml: Node): String? {
         val versionCode = getManifestMetaData(metaDataTags, TAG_VERSION_CODE)
         return versionCode ?: xml.attribute(namespace.get(ATTR_VERSION_CODE)) as String?
     }

--- a/src/test/kotlin/com/bugsnag/android/gradle/AbiTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/AbiTest.kt
@@ -1,0 +1,19 @@
+package com.bugsnag.android.gradle
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class AbiTest {
+
+    @Test
+    fun findExisting() {
+        val obs = Abi.findByName(Abi.ARM64_V8A.abiName)
+        assertEquals(Abi.ARM64_V8A, obs)
+    }
+
+    @Test
+    fun findNonExisting() {
+        val obs = Abi.findByName("foo")
+        assertNull(obs)
+    }
+}

--- a/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestInfoTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestInfoTest.kt
@@ -1,0 +1,42 @@
+package com.bugsnag.android.gradle
+
+import groovy.util.GroovyTestCase.assertEquals
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+class AndroidManifestInfoTest {
+
+    private val info = AndroidManifestInfo(
+        "api-key",
+        "12",
+        "build-123",
+        "5.2",
+        "com.example"
+    )
+
+    private lateinit var jsonFile: File
+
+    @Before
+    fun setUp() {
+        jsonFile = File.createTempFile("test", ".json")
+    }
+
+    @After
+    fun tearDown() {
+        jsonFile.delete()
+    }
+
+    @Test
+    fun testManifestReadWrite() {
+        info.write(jsonFile)
+        val json = jsonFile.readText()
+        assertEquals(json, """
+            {"apiKey":"api-key","versionCode":"12","buildUUID":"build-123","versionName":"5.2","applicationId":"com.example"}
+        """.trimIndent())
+
+        val copy = AndroidManifestInfo.read(jsonFile)
+        assertEquals(info, copy)
+    }
+}

--- a/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestParseTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestParseTest.kt
@@ -1,0 +1,47 @@
+package com.bugsnag.android.gradle
+
+import org.gradle.api.logging.Logger
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import java.io.File
+
+@RunWith(MockitoJUnitRunner::class)
+class AndroidManifestParseTest {
+
+    private val info = AndroidManifestInfo(
+        "api-key",
+        "12",
+        "build-uuid-123",
+        "5.2",
+        "com.example"
+    )
+
+    @Mock
+    lateinit var logger: Logger
+
+    private lateinit var manifestFile: File
+
+    @Before
+    fun setUp() {
+        manifestFile = File.createTempFile("AndroidManifest", ".xml")
+        val classLoader = AndroidManifestParseTest::class.java.classLoader
+        val res = classLoader.getResource("AndroidManifest.xml")!!
+        File(res.file).copyTo(manifestFile, true)
+    }
+
+    @After
+    fun tearDown() {
+        manifestFile.delete()
+    }
+
+    @Test
+    fun readManifest() {
+        val read = AndroidManifestParser().readManifest(manifestFile, logger)
+        assertEquals(info, read)
+    }
+}

--- a/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestWriteUuidTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestWriteUuidTest.kt
@@ -1,0 +1,37 @@
+package com.bugsnag.android.gradle
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+class AndroidManifestWriteUuidTest {
+
+    private val classLoader = AndroidManifestWriteUuidTest::class.java.classLoader
+
+    private lateinit var manifestFile: File
+    private lateinit var outputFile: File
+
+    @Before
+    fun setUp() {
+        outputFile = File.createTempFile("output", ".xml")
+        manifestFile = File.createTempFile("manifest_no_uuid", ".xml")
+        val res = classLoader.getResource("manifest_no_uuid.xml")!!
+        File(res.file).copyTo(manifestFile, true)
+    }
+
+    @After
+    fun tearDown() {
+        manifestFile.delete()
+        outputFile.delete()
+    }
+
+    @Test
+    fun writeBuildUuid() {
+        AndroidManifestParser().writeBuildUuid(manifestFile, outputFile, "build-uuid-123")
+        val obs = outputFile.readText()
+        val expected = classLoader.getResource("AndroidManifest.xml")!!.readText()
+        assertEquals(expected, obs)
+    }
+}

--- a/src/test/resources/AndroidManifest.xml
+++ b/src/test/resources/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest package="com.example" android:versionCode="12" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="5.2">
+  <application android:name="com.example.android.gradle.plugin.FooApp">
+    <meta-data android:name="com.bugsnag.android.API_KEY" android:value="api-key"/>
+    <meta-data android:name="com.bugsnag.android.BUILD_UUID" android:value="build-uuid-123"/>
+  </application>
+</manifest>

--- a/src/test/resources/manifest_no_uuid.xml
+++ b/src/test/resources/manifest_no_uuid.xml
@@ -1,0 +1,11 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.example"
+          android:versionCode="12"
+          android:versionName="5.2">
+  <application android:name="com.example.android.gradle.plugin.FooApp">
+
+    <meta-data
+      android:name="com.bugsnag.android.API_KEY"
+      android:value="api-key"/>
+  </application>
+</manifest>


### PR DESCRIPTION
## Goal

Adds additional unit test coverage for changes made as part of the build performance improvements. This adds unit tests for:

- `Abi`, to ensure that an enum value can be found by string
- `AndroidManifestInfo`, to ensure that serialization/deserialization is handled correctly
- `AndroidManifestInfoParser`, to ensure that the AndroidManifest can be read and written to
