### PR TITLE
Switch to OkHttp for networking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 5.0.0 (TBD)
 
+Switch to OkHttp for networking
+[#247](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/247)
+
 Specify shared object files as input for ndk task
 [#243](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/243)
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner'
+gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', :tag => 'v1.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,22 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: b50151bf963f81442347ff737daccf9a909b6fc7
+  revision: 5df4754e63555507d468d94f33afeb37b1d5bd7c
+  tag: v1.2.0
   specs:
-    bugsnag-maze-runner (1.0.0)
+    bugsnag-maze-runner (1.1.0)
       cucumber (~> 3.1.0)
+      cucumber-expressions (= 5.0.15)
       minitest (~> 5.0)
+      os (~> 1.0.0)
       rack (~> 2.0.0)
+      rake (~> 12.3.3)
       test-unit (~> 3.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.11.2)
-    builder (3.2.3)
+    backports (3.18.1)
+    builder (3.2.4)
     cucumber (3.1.0)
       builder (>= 2.1.2)
       cucumber-core (~> 3.1.0)
@@ -29,14 +33,16 @@ GEM
     cucumber-expressions (5.0.15)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    diff-lcs (1.3)
-    gherkin (5.0.0)
-    minitest (5.11.3)
-    multi_json (1.13.1)
+    diff-lcs (1.4.4)
+    gherkin (5.1.0)
+    minitest (5.14.1)
+    multi_json (1.15.0)
     multi_test (0.1.2)
-    power_assert (1.1.1)
-    rack (2.0.4)
-    test-unit (3.2.7)
+    os (1.0.1)
+    power_assert (1.2.0)
+    rack (2.0.9)
+    rake (12.3.3)
+    test-unit (3.2.9)
       power_assert
 
 PLATFORMS
@@ -46,4 +52,4 @@ DEPENDENCIES
   bugsnag-maze-runner!
 
 BUNDLED WITH
-   1.16.1
+   1.17.2

--- a/build.gradle
+++ b/build.gradle
@@ -61,9 +61,9 @@ dependencies {
     // For multiple I/O use cases
     implementation "com.squareup.okio:okio:2.7.0"
 
-    testCompile "com.android.tools.build:gradle:4.0.0"
-    testCompile "junit:junit:4.12"
-    testCompile "org.mockito:mockito-core:2.28.2"
+    testImplementation "com.android.tools.build:gradle:4.0.0"
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.mockito:mockito-core:2.28.2"
 }
 
 // Maven publishing settings (nexus-maven-plugins)

--- a/build.gradle
+++ b/build.gradle
@@ -49,13 +49,17 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 // Build dependencies
 dependencies {
     compileOnly "com.android.tools.build:gradle:4.1.0-beta04"
-    implementation "com.squareup.okhttp3:okhttp:4.8.0"
-    implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
 
+    // For uploading proguard/ndk files
+    implementation "com.squareup.okhttp3:okhttp:4.8.0"
+    implementation "com.squareup.retrofit2:retrofit:2.9.0"
+
     // For serialization of shared data
-    implementation "com.squareup.okio:okio:2.7.0"
     implementation "com.squareup.moshi:moshi:1.9.3"
+
+    // For multiple I/O use cases
+    implementation "com.squareup.okio:okio:2.7.0"
 
     testCompile "com.android.tools.build:gradle:4.0.0"
     testCompile "junit:junit:4.12"

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,14 @@ allprojects {
     }
 }
 
+sourceSets {
+    main {
+        java {
+            srcDir("build/generated/source/kapt/main")
+        }
+    }
+}
+
 // Repositories for dependencies
 repositories {
     jcenter()
@@ -68,6 +76,8 @@ dependencies {
     testImplementation "com.android.tools.build:gradle:4.0.0"
     testImplementation "junit:junit:4.12"
     testImplementation "org.mockito:mockito-core:2.28.2"
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.8.0"
+    testImplementation "com.squareup.okhttp3:logging-interceptor:4.8.0"
 }
 
 // Maven publishing settings (nexus-maven-plugins)

--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 // Build dependencies
 dependencies {
     compileOnly "com.android.tools.build:gradle:4.1.0-beta04"
-    implementation "org.apache.httpcomponents:httpclient:4.5.2"
-    implementation "org.apache.httpcomponents:httpmime:4.5.2"
     implementation "com.squareup.okhttp3:okhttp:4.8.0"
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:2.28.2"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.8.0"
     testImplementation "com.squareup.okhttp3:logging-interceptor:4.8.0"
+    testImplementation "com.google.truth:truth:1.0.1"
 }
 
 // Maven publishing settings (nexus-maven-plugins)

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     compileOnly "com.android.tools.build:gradle:4.1.0-beta04"
     implementation "org.apache.httpcomponents:httpclient:4.5.2"
     implementation "org.apache.httpcomponents:httpmime:4.5.2"
+    implementation "com.squareup.okhttp3:okhttp:4.8.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
 
     // For serialization of shared data

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:4.8.0"
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
+    implementation "com.squareup.retrofit2:converter-scalars:2.9.0"
 
     // For serialization of shared data
     implementation "com.squareup.moshi:moshi:1.9.3"

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation "org.apache.httpcomponents:httpclient:4.5.2"
     implementation "org.apache.httpcomponents:httpmime:4.5.2"
     implementation "com.squareup.okhttp3:okhttp:4.8.0"
+    implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
 
     // For serialization of shared data

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,12 @@ repositories {
     google()
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
 // Build dependencies
 dependencies {
     compileOnly "com.android.tools.build:gradle:4.1.0-beta04"

--- a/build.gradle
+++ b/build.gradle
@@ -43,9 +43,9 @@ repositories {
 // Build dependencies
 dependencies {
     compileOnly "com.android.tools.build:gradle:4.1.0-beta04"
-    compile "org.apache.httpcomponents:httpclient:4.5.2"
-    compile "org.apache.httpcomponents:httpmime:4.5.2"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
+    implementation "org.apache.httpcomponents:httpclient:4.5.2"
+    implementation "org.apache.httpcomponents:httpmime:4.5.2"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
 
     // For serialization of shared data
     implementation "com.squareup.okio:okio:2.7.0"

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,8 @@ plugins {
     id "com.bmuschko.nexus" version "2.3.1"
     id "com.jfrog.bintray" version "1.8.5"
 }
-apply plugin: "kotlin"
+apply plugin: "org.jetbrains.kotlin.jvm"
+apply plugin: "org.jetbrains.kotlin.kapt"
 apply plugin: "maven-publish"
 apply plugin: "io.gitlab.arturbosch.detekt"
 
@@ -48,12 +49,14 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 
 // Build dependencies
 dependencies {
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.9.3"
     compileOnly "com.android.tools.build:gradle:4.1.0-beta04"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
 
     // For uploading proguard/ndk files
     implementation "com.squareup.okhttp3:okhttp:4.8.0"
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
+    implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
 
     // For serialization of shared data
     implementation "com.squareup.moshi:moshi:1.9.3"

--- a/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestInfo.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestInfo.kt
@@ -1,14 +1,13 @@
 package com.bugsnag.android.gradle
 
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.JsonReader
-import com.squareup.moshi.JsonReader.Token.NULL
-import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
 import okio.buffer
 import okio.sink
 import okio.source
 import java.io.File
 
+@JsonClass(generateAdapter = true)
 data class AndroidManifestInfo(
     var apiKey: String,
     var versionCode: String,
@@ -23,60 +22,7 @@ data class AndroidManifestInfo(
     }
 
     internal companion object {
-        private val OPTIONS = JsonReader.Options.of(
-            "apiKey",
-            "versionCode",
-            "buildUUID",
-            "versionName",
-            "applicationId"
-        )
-
-        @Suppress("MagicNumber") // They are indices into the OPTIONS field above
-        private val ADAPTER = object : JsonAdapter<AndroidManifestInfo>() {
-            override fun fromJson(reader: JsonReader): AndroidManifestInfo? {
-                if (reader.peek() == NULL) {
-                    return reader.nextNull()
-                }
-                lateinit var apiKey: String
-                lateinit var versionCode: String
-                lateinit var buildUUID: String
-                lateinit var versionName: String
-                lateinit var applicationId: String
-                reader.beginObject()
-                while (reader.hasNext()) {
-                    when (reader.selectName(OPTIONS)) {
-                        0 -> apiKey = reader.nextString()
-                        1 -> versionCode = reader.nextString()
-                        2 -> buildUUID = reader.nextString()
-                        3 -> versionName = reader.nextString()
-                        4 -> applicationId = reader.nextString()
-                        -1 -> reader.skipValue()
-                    }
-                }
-                reader.endObject()
-                return AndroidManifestInfo(apiKey, versionCode, buildUUID, versionName, applicationId)
-            }
-
-            override fun toJson(writer: JsonWriter, value: AndroidManifestInfo?) {
-                if (value == null) {
-                    writer.nullValue()
-                    return
-                }
-                writer.beginObject()
-                    .name("apiKey")
-                    .value(value.apiKey)
-                    .name("versionCode")
-                    .value(value.versionCode)
-                    .name("buildUUID")
-                    .value(value.buildUUID)
-                    .name("versionName")
-                    .value(value.versionName)
-                    .name("applicationId")
-                    .value(value.applicationId)
-                    .endObject()
-            }
-
-        }
+        private val ADAPTER = Moshi.Builder().build().adapter(AndroidManifestInfo::class.java)
 
         fun read(file: File): AndroidManifestInfo {
             return file.source().buffer().use {

--- a/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestParser.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/AndroidManifestParser.kt
@@ -58,8 +58,14 @@ class AndroidManifestParser {
 
         if (apiKey == null || "" == apiKey || versionCode == null ||
             buildUUID == null || versionName == null || applicationId == null) {
-            throw IllegalStateException("Bugsnag: Missing apiKey/versionCode/buildUuid/versionName/package," +
-                " required to upload to bugsnag.")
+            throw IllegalStateException(
+                """Bugsnag: Missing apiKey/versionCode/buildUuid/versionName/package, required to upload to bugsnag.
+                    |apiKey=$apiKey
+                    |versionCode=$versionCode
+                    |buildUUID=$buildUUID
+                    |versionName=$versionName
+                    |applicationId=$applicationId
+                """.trimMargin())
         }
         return AndroidManifestInfo(apiKey, versionCode, buildUUID, versionName, applicationId)
     }

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagFileUploadTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagFileUploadTask.kt
@@ -1,0 +1,19 @@
+package com.bugsnag.android.gradle
+
+import org.gradle.api.provider.Property
+
+interface BugsnagFileUploadTask {
+    val failOnUploadError: Property<Boolean>
+    val overwrite: Property<Boolean>
+    val endpoint: Property<String>
+    val retryCount: Property<Int>
+    val timeoutMillis: Property<Long>
+
+    fun configureWith(bugsnag: BugsnagPluginExtension) {
+        failOnUploadError.set(bugsnag.failOnUploadError)
+        overwrite.set(bugsnag.overwrite)
+        endpoint.set(bugsnag.endpoint)
+        retryCount.set(bugsnag.retryCount)
+        timeoutMillis.set(bugsnag.requestTimeoutMs)
+    }
+}

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
@@ -155,6 +155,6 @@ internal interface BugsnagService {
     @POST
     fun uploadFile(
         @Url endpoint: String,
-        @PartMap parts: Map<String, RequestBody>
+        @PartMap parts: Map<String, @JvmSuppressWildcards RequestBody>
     ): Response<String>
 }

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
@@ -41,6 +41,7 @@ class BugsnagMultiPartUploadRequest(
 ) {
 
     private val bugsnagService = Retrofit.Builder()
+        .baseUrl("https://example.com") // Not actually used
         .callFactory(
             OkHttpClient.Builder()
                 .connectTimeout(timeoutDuration)

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
@@ -60,6 +60,8 @@ class BugsnagMultiPartUploadRequest(
 
         var response = uploadToServer(finalParts)
         var uploadSuccessful = response != null
+
+        // Note - this should eventually be moved to a native OkHttp interceptor
         val maxRetryCount = getRetryCount()
         var retryCount = maxRetryCount
         while (!uploadSuccessful && retryCount > 0) {

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
@@ -138,7 +138,7 @@ class BugsnagMultiPartUploadRequest(
 
         internal fun createService(client: OkHttpClient): BugsnagService {
             return Retrofit.Builder()
-                .baseUrl("https://example.com") // Not actually used
+                .baseUrl("https://upload.bugsnag.com") // Not actually used
                 .validateEagerly(true)
                 .callFactory(client)
                 .addConverterFactory(ScalarsConverterFactory.create())

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
@@ -10,6 +10,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.logging.Logger
 import retrofit2.Response
 import retrofit2.Retrofit
+import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.create
 import retrofit2.http.Multipart
 import retrofit2.http.POST
@@ -49,6 +50,7 @@ class BugsnagMultiPartUploadRequest(
                 .callTimeout(timeoutDuration)
                 .build()
         )
+        .addConverterFactory(ScalarsConverterFactory.create())
         .build()
         .create<BugsnagService>()
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
@@ -8,7 +8,6 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.logging.Logger
-import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.create
@@ -100,7 +99,7 @@ class BugsnagMultiPartUploadRequest(
     private fun uploadToServer(parts: Map<String, RequestBody>): String? {
         // Make the request
         try {
-            val response = bugsnagService.uploadFile(endpoint, parts)
+            val response = bugsnagService.uploadFile(endpoint, parts).execute()
             val statusCode = response.code()
             val responseEntity = response.body()
 
@@ -159,5 +158,5 @@ internal interface BugsnagService {
     fun uploadFile(
         @Url endpoint: String,
         @PartMap parts: Map<String, @JvmSuppressWildcards RequestBody>
-    ): Response<String>
+    ): retrofit2.Call<String>
 }

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
@@ -42,6 +42,7 @@ class BugsnagMultiPartUploadRequest(
 
     private val bugsnagService = Retrofit.Builder()
         .baseUrl("https://example.com") // Not actually used
+        .validateEagerly(true)
         .callFactory(
             OkHttpClient.Builder()
                 .connectTimeout(timeoutDuration)

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
@@ -40,18 +40,7 @@ class BugsnagMultiPartUploadRequest(
     timeoutDuration: Duration
 ) {
 
-    private val bugsnagService = Retrofit.Builder()
-        .baseUrl("https://example.com") // Not actually used
-        .validateEagerly(true)
-        .callFactory(
-            OkHttpClient.Builder()
-                .connectTimeout(timeoutDuration)
-                .callTimeout(timeoutDuration)
-                .build()
-        )
-        .addConverterFactory(ScalarsConverterFactory.create())
-        .build()
-        .create<BugsnagService>()
+    private val bugsnagService = createService(timeoutDuration)
 
     fun uploadMultipartEntity(
         parts: MutableMap<String, RequestBody>,
@@ -138,6 +127,23 @@ class BugsnagMultiPartUploadRequest(
                 retryCount = task.retryCount.get(),
                 timeoutDuration = Duration.ofMillis(task.timeoutMillis.get())
             )
+        }
+
+        private fun createService(timeoutDuration: Duration): BugsnagService {
+            return createService(OkHttpClient.Builder()
+                .connectTimeout(timeoutDuration)
+                .callTimeout(timeoutDuration)
+                .build())
+        }
+
+        internal fun createService(client: OkHttpClient): BugsnagService {
+            return Retrofit.Builder()
+                .baseUrl("https://example.com") // Not actually used
+                .validateEagerly(true)
+                .callFactory(client)
+                .addConverterFactory(ScalarsConverterFactory.create())
+                .build()
+                .create()
         }
     }
 }

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
@@ -1,14 +1,22 @@
 package com.bugsnag.android.gradle
 
-import org.apache.http.client.HttpClient
-import org.apache.http.client.methods.HttpPost
-import org.apache.http.entity.mime.MultipartEntity
-import org.apache.http.entity.mime.content.StringBody
-import org.apache.http.impl.client.DefaultHttpClient
-import org.apache.http.params.HttpConnectionParams
-import org.apache.http.util.EntityUtils
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.Project
+import org.gradle.api.logging.Logger
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.create
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.PartMap
+import retrofit2.http.Url
+import java.io.File
+import java.time.Duration
 
 /**
  * Task to upload ProGuard mapping files to Bugsnag.
@@ -23,66 +31,72 @@ import org.gradle.api.Project
  * it is usually safe to have this be the absolute last task executed during
  * a build.
  */
-class BugsnagMultiPartUploadRequest {
+class BugsnagMultiPartUploadRequest(
+    private val logger: Logger,
+    private val failOnUploadError: Boolean,
+    private val overwrite: Boolean,
+    private val endpoint: String,
+    private val retryCount: Int,
+    timeoutDuration: Duration
+) {
 
-    fun uploadMultipartEntity(project: Project,
-                              mpEntity: MultipartEntity,
-                              manifestInfo: AndroidManifestInfo): String {
-        val logger = project.logger
-        val bugsnag = project.extensions.getByType(BugsnagPluginExtension::class.java)
-        addPropertiesToMultipartEntity(project, mpEntity, manifestInfo, bugsnag)
+    private val bugsnagService = Retrofit.Builder()
+        .callFactory(
+            OkHttpClient.Builder()
+                .connectTimeout(timeoutDuration)
+                .callTimeout(timeoutDuration)
+                .build()
+        )
+        .build()
+        .create<BugsnagService>()
 
-        var response = uploadToServer(project, mpEntity, bugsnag)
+    fun uploadMultipartEntity(
+        parts: MutableMap<String, RequestBody>,
+        manifestInfo: AndroidManifestInfo
+    ): String {
+        addPropertiesToMultipartEntity(parts, manifestInfo)
+
+        val finalParts = parts.toMap()
+
+        var response = uploadToServer(finalParts)
         var uploadSuccessful = response != null
-        val maxRetryCount = getRetryCount(bugsnag)
+        val maxRetryCount = getRetryCount()
         var retryCount = maxRetryCount
         while (!uploadSuccessful && retryCount > 0) {
             logger.warn(String.format("Bugsnag: Retrying upload (%d/%d) ...",
                 maxRetryCount - retryCount + 1, maxRetryCount))
-            response = uploadToServer(project, mpEntity, bugsnag)
+            response = uploadToServer(finalParts)
             uploadSuccessful = response != null
             retryCount--
         }
-        if (!uploadSuccessful && bugsnag.isFailOnUploadError) {
+        if (!uploadSuccessful && failOnUploadError) {
             throw GradleException("Upload did not succeed")
         } else {
             return response!!
         }
     }
 
-    private fun addPropertiesToMultipartEntity(project: Project,
-                                               mpEntity: MultipartEntity,
-                                               manifestInfo: AndroidManifestInfo,
-                                               bugsnag: BugsnagPluginExtension) {
-        mpEntity.addPart("apiKey", StringBody(manifestInfo.apiKey))
-        mpEntity.addPart("appId", StringBody(manifestInfo.applicationId))
-        mpEntity.addPart("versionCode", StringBody(manifestInfo.versionCode))
-        mpEntity.addPart("buildUUID", StringBody(manifestInfo.buildUUID))
-        mpEntity.addPart("versionName", StringBody(manifestInfo.versionName))
-        if (bugsnag.isOverwrite) {
-            mpEntity.addPart("overwrite", StringBody("true"))
+    private fun addPropertiesToMultipartEntity(
+        parts: MutableMap<String, RequestBody>,
+        manifestInfo: AndroidManifestInfo
+    ) {
+        parts["apiKey"] = manifestInfo.apiKey.toTextRequestBody()
+        parts["appId"] = manifestInfo.applicationId.toTextRequestBody()
+        parts["versionCode"] = manifestInfo.versionCode.toTextRequestBody()
+        parts["buildUUID"] = manifestInfo.buildUUID.toTextRequestBody()
+        parts["versionName"] = manifestInfo.versionName.toTextRequestBody()
+        if (overwrite) {
+            parts["overwrite"] = "true".toTextRequestBody()
         }
-        val logger = project.logger
         logger.debug("Bugsnag: payload information=$manifestInfo")
     }
 
-    private fun uploadToServer(project: Project,
-                               mpEntity: MultipartEntity?,
-                               bugsnag: BugsnagPluginExtension): String? {
-        val logger = project.logger
-
+    private fun uploadToServer(parts: Map<String, RequestBody>): String? {
         // Make the request
-        val httpPost = HttpPost(bugsnag.endpoint)
-        httpPost.entity = mpEntity
-        val httpClient: HttpClient = DefaultHttpClient()
-        val params = httpClient.params
-        HttpConnectionParams.setConnectionTimeout(params, bugsnag.requestTimeoutMs)
-        HttpConnectionParams.setSoTimeout(params, bugsnag.requestTimeoutMs)
         try {
-            val response = httpClient.execute(httpPost)
-            val statusCode = response.statusLine.statusCode
-            val entity = response.entity
-            val responseEntity = EntityUtils.toString(entity, "utf-8")
+            val response = bugsnagService.uploadFile(endpoint, parts)
+            val statusCode = response.code()
+            val responseEntity = response.body()
 
             if (statusCode != 200) {
                 throw IllegalStateException("Bugsnag upload failed with code $statusCode $responseEntity")
@@ -101,11 +115,43 @@ class BugsnagMultiPartUploadRequest {
      *
      * @return the retry count
      */
-    private fun getRetryCount(bugsnag: BugsnagPluginExtension): Int {
-        return if (bugsnag.retryCount >= MAX_RETRY_COUNT) MAX_RETRY_COUNT else bugsnag.retryCount
+    private fun getRetryCount(): Int {
+        return if (retryCount >= MAX_RETRY_COUNT) MAX_RETRY_COUNT else retryCount
     }
 
     companion object {
         const val MAX_RETRY_COUNT = 5
+
+        internal fun <T> from(
+            task: T
+        ): BugsnagMultiPartUploadRequest where T : DefaultTask, T: BugsnagFileUploadTask {
+            return BugsnagMultiPartUploadRequest(
+                task.logger,
+                failOnUploadError = task.failOnUploadError.get(),
+                overwrite = task.overwrite.get(),
+                endpoint = task.endpoint.get(),
+                retryCount = task.retryCount.get(),
+                timeoutDuration = Duration.ofMillis(task.timeoutMillis.get())
+            )
+        }
     }
+}
+private val TEXT_PLAIN = "text/plain".toMediaType()
+private val OCTET = "application/octet-stream".toMediaType()
+
+internal fun String.toTextRequestBody(): RequestBody {
+    return toRequestBody(TEXT_PLAIN)
+}
+
+internal fun File.toOctetRequestBody(): RequestBody {
+    return asRequestBody(OCTET)
+}
+
+internal interface BugsnagService {
+    @Multipart
+    @POST
+    fun uploadFile(
+        @Url endpoint: String,
+        @PartMap parts: Map<String, RequestBody>
+    ): Response<String>
 }

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
@@ -191,6 +191,7 @@ class BugsnagPlugin : Plugin<Project> {
         return project.tasks.register(taskName, BugsnagUploadProguardTask::class.java) {
             it.requestOutputFile.set(requestOutputFile)
             addTaskToExecutionGraph(it, variant, output, project, bugsnag, bugsnag.isUploadJvmMappings)
+            it.configureWith(bugsnag)
         }
     }
 
@@ -209,6 +210,7 @@ class BugsnagPlugin : Plugin<Project> {
             it.searchDirectories.set(getSearchDirectories(project, variant))
             it.variantOutput = output
             addTaskToExecutionGraph(it, variant, output, project, bugsnag, true)
+            it.configureWith(bugsnag)
         }
     }
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
@@ -7,12 +7,16 @@ import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
+import com.bugsnag.android.gradle.BugsnagReleasesTask.Companion
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskProvider
 import java.util.UUID
 
@@ -237,6 +241,7 @@ class BugsnagPlugin : Plugin<Project> {
             it.metadata.set(bugsnag.metadata)
             it.builderName.set(bugsnag.builderName)
             addTaskToExecutionGraph(it, variant, output, project, bugsnag, bugsnag.isReportBuilds)
+            it.configureMetadata(project)
         }
     }
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
@@ -40,7 +40,12 @@ class BugsnagPlugin : Plugin<Project> {
     }
 
     override fun apply(project: Project) {
-        val bugsnag = project.extensions.create("bugsnag", BugsnagPluginExtension::class.java)
+        // After Gradle 5.2, this can use service injection for injecting ObjectFactory
+        val bugsnag = project.extensions.create(
+            "bugsnag",
+            BugsnagPluginExtension::class.java,
+            project.objects
+        )
         project.pluginManager.withPlugin("com.android.application") {
             if (!bugsnag.isEnabled) {
                 return@withPlugin

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
@@ -235,6 +235,7 @@ class BugsnagPlugin : Plugin<Project> {
             it.requestOutputFile.set(requestOutputFile)
             it.retryCount.set(bugsnag.retryCount)
             it.timeoutMillis.set(bugsnag.requestTimeoutMs)
+            it.releasesEndpoint.set(bugsnag.releasesEndpoint)
             it.sourceControlProvider.set(bugsnag.sourceControl.provider)
             it.sourceControlRepository.set(bugsnag.sourceControl.repository)
             it.sourceControlRevision.set(bugsnag.sourceControl.revision)

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
@@ -224,6 +224,13 @@ class BugsnagPlugin : Plugin<Project> {
         val requestOutputFile = project.layout.buildDirectory.file(path)
         return project.tasks.register(taskName, BugsnagReleasesTask::class.java) {
             it.requestOutputFile.set(requestOutputFile)
+            it.retryCount.set(bugsnag.retryCount)
+            it.timeoutMillis.set(bugsnag.requestTimeoutMs)
+            it.sourceControlProvider.set(bugsnag.sourceControl.provider)
+            it.sourceControlRepository.set(bugsnag.sourceControl.repository)
+            it.sourceControlRevision.set(bugsnag.sourceControl.revision)
+            it.metadata.set(bugsnag.metadata)
+            it.builderName.set(bugsnag.builderName)
             addTaskToExecutionGraph(it, variant, output, project, bugsnag, bugsnag.isReportBuilds)
         }
     }

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPluginExtension.kt
@@ -27,7 +27,8 @@ open class BugsnagPluginExtension(objects: ObjectFactory) {
     var isUploadDebugBuildMappings = false
     val endpoint: Property<String> = objects.property(String::class.javaObjectType)
         .convention("https://upload.bugsnag.com")
-    var releasesEndpoint = "https://build.bugsnag.com"
+    val releasesEndpoint = objects.property(String::class.javaObjectType)
+        .convention("https://build.bugsnag.com")
     val overwrite: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
         .convention(false)
     val retryCount: Property<Int> = objects.property(Int::class.javaObjectType)
@@ -40,8 +41,8 @@ open class BugsnagPluginExtension(objects: ObjectFactory) {
         .convention(60000)
 
     // release API values
-    var builderName: Property<String> = objects.property(String::class.java).convention(NULL_STRING)
-    var metadata: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java)
+    val builderName: Property<String> = objects.property(String::class.java).convention(NULL_STRING)
+    val metadata: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java)
         .convention(emptyMap())
     var objdumpPaths: Map<String, String>? = null
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPluginExtension.kt
@@ -2,13 +2,16 @@ package com.bugsnag.android.gradle
 
 import groovy.lang.Closure
 import org.gradle.api.Action
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import org.gradle.util.ConfigureUtil
 import java.io.File
+import javax.inject.Inject
 
 /**
  * Defines configuration options (Gradle plugin extensions) for the BugsnagPlugin
  */
-open class BugsnagPluginExtension {
+open class BugsnagPluginExtension @Inject constructor(objects: ObjectFactory) {
 
     val sourceControl: SourceControl = SourceControl()
 
@@ -17,14 +20,19 @@ open class BugsnagPluginExtension {
     var isUploadNdkMappings: Boolean? = null
     var isReportBuilds = true
     var isUploadDebugBuildMappings = false
-    var endpoint = "https://upload.bugsnag.com"
+    val endpoint: Property<String> = objects.property(String::class.javaObjectType)
+        .convention("https://upload.bugsnag.com")
     var releasesEndpoint = "https://build.bugsnag.com"
-    var isOverwrite = false
-    var retryCount = 0
+    val overwrite: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
+        .convention(false)
+    val retryCount: Property<Int> = objects.property(Int::class.javaObjectType)
+        .convention(0)
     var sharedObjectPaths: List<File> = emptyList()
     var projectRoot: String? = null
-    var isFailOnUploadError = true
-    var requestTimeoutMs = 60000
+    val failOnUploadError: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
+        .convention(true)
+    val requestTimeoutMs: Property<Long> = objects.property(Long::class.javaObjectType)
+        .convention(60000)
 
     // release API values
     var builderName: String? = null

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPluginExtension.kt
@@ -15,7 +15,8 @@ private val NULL_STRING: String? = null
 /**
  * Defines configuration options (Gradle plugin extensions) for the BugsnagPlugin
  */
-open class BugsnagPluginExtension @Inject constructor(objects: ObjectFactory) {
+// After Gradle 5.2, this can use service injection for injecting ObjectFactory
+open class BugsnagPluginExtension(objects: ObjectFactory) {
 
     val sourceControl: SourceControl = objects.newInstance(SourceControl::class.java)
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPluginExtension.kt
@@ -3,17 +3,21 @@ package com.bugsnag.android.gradle
 import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.util.ConfigureUtil
 import java.io.File
 import javax.inject.Inject
+
+// To make kotlin happy with gradle's nullability
+private val NULL_STRING: String? = null
 
 /**
  * Defines configuration options (Gradle plugin extensions) for the BugsnagPlugin
  */
 open class BugsnagPluginExtension @Inject constructor(objects: ObjectFactory) {
 
-    val sourceControl: SourceControl = SourceControl()
+    val sourceControl: SourceControl = objects.newInstance(SourceControl::class.java)
 
     var isEnabled = true
     var isUploadJvmMappings = true
@@ -35,8 +39,9 @@ open class BugsnagPluginExtension @Inject constructor(objects: ObjectFactory) {
         .convention(60000)
 
     // release API values
-    var builderName: String? = null
-    var metadata: Map<String, String>? = null
+    var builderName: Property<String> = objects.property(String::class.java).convention(NULL_STRING)
+    var metadata: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java)
+        .convention(emptyMap())
     var objdumpPaths: Map<String, String>? = null
 
     // exposes sourceControl as a nested object on the extension,

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
@@ -259,15 +259,15 @@ open class BugsnagReleasesTask @Inject constructor(
         gradleVersion.set(gradleVersionString)
         gitVersion.set(project.provider { runCmd(VCS_COMMAND, "--version") } )
         if (gradleVersionNumber >= SYS_PROPERTIES_VERSION)  {
-            osArch.set(project.provider { System.getProperty(MK_OS_ARCH) } )
-            osName.set(project.provider { System.getProperty(MK_OS_NAME) } )
-            osVersion.set(project.provider { System.getProperty(MK_OS_VERSION) } )
-            javaVersion.set(project.provider { System.getProperty(MK_JAVA_VERSION) })
-        } else {
             osArch.set(project.providers.systemProperty(MK_OS_ARCH) )
             osName.set(project.providers.systemProperty(MK_OS_NAME) )
             osVersion.set(project.providers.systemProperty(MK_OS_VERSION) )
             javaVersion.set(project.providers.systemProperty(MK_JAVA_VERSION))
+        } else {
+            osArch.set(project.provider { System.getProperty(MK_OS_ARCH) } )
+            osName.set(project.provider { System.getProperty(MK_OS_NAME) } )
+            osVersion.set(project.provider { System.getProperty(MK_OS_VERSION) } )
+            javaVersion.set(project.provider { System.getProperty(MK_JAVA_VERSION) })
         }
     }
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
@@ -191,28 +191,20 @@ open class BugsnagReleasesTask @Inject constructor(
     }
 
     private fun generateMetadataJson(): Map<String, String?> {
-        val defaultMetaData = collectDefaultMetaData()
-        metadata.orNull?.entries?.forEach { entry: Map.Entry<String, String> ->
-            defaultMetaData[entry.key] = entry.value
-        }
-        val additionalInfo = mutableMapOf<String, String?>()
-        defaultMetaData.entries.forEach { entry: Map.Entry<String, String?> ->
-            additionalInfo[entry.key] = entry.value
-        }
-        return additionalInfo
+        val metadataMap = mutableMapOf<String, String?>()
+        collectDefaultMetaData(metadataMap)
+        metadataMap.putAll(metadata.orNull.orEmpty())
+        return metadataMap.toMap()
     }
 
-    private fun collectDefaultMetaData(): MutableMap<String, String?> {
-        val gradleVersion = project.gradle.gradleVersion
+    private fun collectDefaultMetaData(map: MutableMap<String, String?>) {
         // TODO these should eventually use Gradle's newer env gradle property APIs
-        return hashMapOf(
-            "os_arch" to System.getProperty(MK_OS_ARCH),
-            "os_name" to System.getProperty(MK_OS_NAME),
-            "os_version" to System.getProperty(MK_OS_VERSION),
-            "java_version" to System.getProperty(MK_JAVA_VERSION),
-            "gradle_version" to gradleVersion,
-            "git_version" to runCmd(VCS_COMMAND, "--version")
-        )
+        map["os_arch"] = System.getProperty(MK_OS_ARCH)
+        map["os_name"] = System.getProperty(MK_OS_NAME)
+        map["os_version"] = System.getProperty(MK_OS_VERSION)
+        map["java_version"] = System.getProperty(MK_JAVA_VERSION)
+        map["gradle_version"] = project.gradle.gradleVersion
+        map["git_version"] = runCmd(VCS_COMMAND, "--version")
     }
 
     /**

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
@@ -23,6 +23,7 @@ import org.gradle.util.VersionNumber
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.create
 import retrofit2.http.Body
 import retrofit2.http.Header
@@ -146,6 +147,7 @@ open class BugsnagReleasesTask @Inject constructor(
                     .callTimeout(timeoutDuration)
                     .build()
             )
+            .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(MoshiConverterFactory.create())
             .build()
             .create<BugsnagReleasesService>()

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
@@ -112,6 +112,7 @@ open class BugsnagReleasesTask @Inject constructor(
     ): String {
         val timeoutDuration = Duration.ofMillis(timeoutMillis.get())
         val bugsnagService = Retrofit.Builder()
+            .baseUrl("https://example.com") // Not actually used
             .callFactory(
                 OkHttpClient.Builder()
                     .connectTimeout(timeoutDuration)

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
@@ -300,7 +300,7 @@ open class BugsnagReleasesTask @Inject constructor(
             okHttpClient: OkHttpClient
         ): BugsnagReleasesService {
             return Retrofit.Builder()
-                .baseUrl("https://example.com") // Not actually used
+                .baseUrl("https://upload.bugsnag.com") // Not actually used
                 .validateEagerly(true)
                 .callFactory(okHttpClient)
                 .addConverterFactory(ScalarsConverterFactory.create())

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
@@ -113,6 +113,7 @@ open class BugsnagReleasesTask @Inject constructor(
         val timeoutDuration = Duration.ofMillis(timeoutMillis.get())
         val bugsnagService = Retrofit.Builder()
             .baseUrl("https://example.com") // Not actually used
+            .validateEagerly(true)
             .callFactory(
                 OkHttpClient.Builder()
                     .connectTimeout(timeoutDuration)

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
@@ -157,7 +157,7 @@ open class BugsnagReleasesTask @Inject constructor(
                 releasesEndpoint.get(),
                 apiKey = manifestInfo.apiKey,
                 body = payload
-            )
+            ).execute()
         } catch (e: IOException) {
             throw IllegalStateException("Request to Bugsnag Releases API failed, aborting build.", e)
         }
@@ -318,5 +318,5 @@ internal interface BugsnagReleasesService {
         @Url endpoint: String,
         @Header("Bugsnag-Api-Key") apiKey: String,
         @Body body: ReleasePayload
-    ): Response<String>
+    ): retrofit2.Call<String>
 }

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadNdkTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadNdkTask.kt
@@ -224,8 +224,10 @@ open class BugsnagUploadNdkTask @Inject constructor(
          * @param outputFile The output file
          */
         private fun outputZipFile(stdout: InputStream, outputFile: File) {
-            outputFile.sink().buffer().gzip().use { gzipSink ->
-                stdout.source().buffer().readAll(gzipSink)
+            stdout.source().use { source ->
+                outputFile.sink().gzip().buffer().use { gzipSink ->
+                    gzipSink.writeAll(source)
+                }
             }
         }
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/SharedObjectMappingFileProvider.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/SharedObjectMappingFileProvider.kt
@@ -6,8 +6,6 @@ import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.FileCollection
-import org.gradle.api.provider.Provider
 import java.io.File
 
 fun getSearchDirectories(project: Project,

--- a/src/main/kotlin/com.bugsnag.android.gradle/SourceControl.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/SourceControl.kt
@@ -1,7 +1,11 @@
 package com.bugsnag.android.gradle
 
-open class SourceControl {
-    var provider: String? = null
-    var repository: String? = null
-    var revision: String? = null
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import javax.inject.Inject
+
+open class SourceControl @Inject constructor(objects: ObjectFactory) {
+    val provider: Property<String> = objects.property(String::class.java)
+    val repository: Property<String> = objects.property(String::class.java)
+    val revision: Property<String> = objects.property(String::class.java)
 }

--- a/src/test/kotlin/com/bugsnag/android/gradle/BugsnagReleasesServiceTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/BugsnagReleasesServiceTest.kt
@@ -20,9 +20,6 @@ class BugsnagReleasesServiceTest {
     fun setup() {
         val client = OkHttpClient.Builder()
             .addInterceptor(HttpLoggingInterceptor().apply { level = BODY })
-            .addInterceptor { chain ->
-                chain.proceed(chain.request())
-            }
             .build()
         service = BugsnagReleasesTask.createService(client)
     }

--- a/src/test/kotlin/com/bugsnag/android/gradle/BugsnagReleasesServiceTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/BugsnagReleasesServiceTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android.gradle
 
+import com.google.common.truth.Truth.assertThat
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.logging.HttpLoggingInterceptor.Level.BODY
@@ -51,5 +52,12 @@ class BugsnagReleasesServiceTest {
         val response = call.execute()
         check(response.code() == 200)
         check(response.body() == "Response!")
+
+        val recordedBody = server.takeRequest().body.readUtf8()
+        assertThat(recordedBody)
+            //language=JSON
+            .isEqualTo("""
+                {"buildTool":"gradle","apiKey":"testKey","appVersion":"1.0","appVersionCode":"1","metadata":{"metaKey":"value"},"sourceControl":{"sourceControlKey":"value"},"builderName":"builder"}
+            """.trimIndent())
     }
 }

--- a/src/test/kotlin/com/bugsnag/android/gradle/BugsnagReleasesServiceTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/BugsnagReleasesServiceTest.kt
@@ -1,0 +1,58 @@
+package com.bugsnag.android.gradle
+
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import okhttp3.logging.HttpLoggingInterceptor.Level.BODY
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class BugsnagReleasesServiceTest {
+
+    @get:Rule
+    val server = MockWebServer()
+
+    private lateinit var service: BugsnagReleasesService
+
+    @Before
+    fun setup() {
+        val client = OkHttpClient.Builder()
+            .addInterceptor(HttpLoggingInterceptor().apply { level = BODY })
+            .addInterceptor { chain ->
+                chain.proceed(chain.request())
+            }
+            .build()
+        service = BugsnagReleasesTask.createService(client)
+    }
+
+    @Test
+    fun simplePayload() {
+        val url  = server.url("/")
+        server.enqueue(MockResponse()
+            .setResponseCode(200)
+            .setBody("Response!"))
+        val call = service.upload(
+            endpoint = url.toString(),
+            apiKey = "testKey",
+            payload = ReleasePayload(
+                buildTool = "gradle",
+                apiKey = "testKey",
+                appVersion = "1.0",
+                appVersionCode = "1",
+                metadata = mapOf(
+                    "metaKey" to "value"
+                ),
+                sourceControl = mapOf(
+                    "sourceControlKey" to "value"
+                ),
+                builderName = "builder"
+            )
+        )
+
+        val response = call.execute()
+        check(response.code() == 200)
+        check(response.body() == "Response!")
+    }
+}

--- a/src/test/kotlin/com/bugsnag/android/gradle/BugsnagServiceTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/BugsnagServiceTest.kt
@@ -65,7 +65,7 @@ class BugsnagServiceTest {
         check(response.code() == 200)
         check(response.body() == "Response!")
 
-        // Check our parts. We ignore the uuid lines since they change every request
+        // Check our parts. We ignore the boundaries since they change every request
         val recordedBody = server.takeRequest().body.readUtf8()
             .lineSequence()
             .filterNot { it.startsWith("--") }

--- a/src/test/kotlin/com/bugsnag/android/gradle/BugsnagServiceTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/BugsnagServiceTest.kt
@@ -1,0 +1,67 @@
+package com.bugsnag.android.gradle
+
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody
+import okhttp3.logging.HttpLoggingInterceptor
+import okhttp3.logging.HttpLoggingInterceptor.Level.BODY
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class BugsnagServiceTest {
+
+    @get:Rule
+    val server = MockWebServer()
+
+    @get:Rule
+    val tmpFolder = TemporaryFolder()
+
+    private lateinit var service: BugsnagService
+
+    @Before
+    fun setup() {
+        val client = OkHttpClient.Builder()
+            .addInterceptor(HttpLoggingInterceptor().apply { level = BODY })
+            .build()
+        service = BugsnagMultiPartUploadRequest.createService(client)
+    }
+
+    @Test
+    fun simplePayload() {
+        val url  = server.url("/")
+        server.enqueue(MockResponse()
+            .setResponseCode(200)
+            .setBody("Response!"))
+
+        val manifestInfo = AndroidManifestInfo(
+            apiKey = "api key",
+            versionCode = "1",
+            buildUUID = "lfkajsdflkajdskfhasd",
+            versionName = "1.0",
+            applicationId = "com.example.test"
+        )
+
+        val parts = mutableMapOf<String, RequestBody>()
+        parts["apiKey"] = manifestInfo.apiKey.toTextRequestBody()
+        parts["appId"] = manifestInfo.applicationId.toTextRequestBody()
+        parts["versionCode"] = manifestInfo.versionCode.toTextRequestBody()
+        parts["buildUUID"] = manifestInfo.buildUUID.toTextRequestBody()
+        parts["versionName"] = manifestInfo.versionName.toTextRequestBody()
+
+        val mappingFile = tmpFolder.newFile()
+        mappingFile.writeText("this is totally a mapping file")
+        parts["proguard"] = mappingFile.toOctetRequestBody()
+
+        val call = service.uploadFile(
+            endpoint = url.toString(),
+            parts = parts
+        )
+
+        val response = call.execute()
+        check(response.code() == 200)
+        check(response.body() == "Response!")
+    }
+}

--- a/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
@@ -25,14 +25,14 @@ class PluginExtensionTest {
     @Test
     fun ensureExtensionDefaults() {
         val bugsnag = proj.extensions.getByType(BugsnagPluginExtension::class.java)
-        assertEquals("https://upload.bugsnag.com", bugsnag.endpoint)
+        assertEquals("https://upload.bugsnag.com", bugsnag.endpoint.get())
         assertTrue(bugsnag.isUploadJvmMappings)
         assertTrue(bugsnag.isReportBuilds)
         assertFalse(bugsnag.isUploadDebugBuildMappings)
-        assertFalse(bugsnag.isOverwrite)
-        assertEquals(0, bugsnag.retryCount)
+        assertFalse(bugsnag.overwrite.get())
+        assertEquals(0, bugsnag.retryCount.get())
         assertNull(bugsnag.isUploadNdkMappings)
         assertEquals(ArrayList<File>(), bugsnag.sharedObjectPaths)
-        assertTrue(bugsnag.isFailOnUploadError)
+        assertTrue(bugsnag.failOnUploadError.get())
     }
 }


### PR DESCRIPTION
## Goal

Apache HTTP is largely deprecated. OkHttp is a reliable industry standard and kotlin-friendly API

Part of this involved starting to move the plugin extension to use more modern gradle property APIs for lazier configuration and a few opportunistic cleanups elsewhere

## Tests

Existing tests should continue working as regression tests
