### PR TITLE
Deduplicate unnecessary upload requests for APK splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 5.0.0 (TBD)
 
+Deduplicate unnecessary upload requests for APK splits
+[#248](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/248)
+
 Add autoUpdateBuildUuid flag to prevent manifest UUID generation
 [#249](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/249)
 

--- a/features/apk_splits_same_version.feature
+++ b/features/apk_splits_same_version.feature
@@ -1,0 +1,9 @@
+Feature: Plugin integrated in project with APK splits
+
+@skip_agp4_1_or_higher
+Scenario: APK splits avoid uploading duplicate requests for same version information
+    When I build "apk_splits" using the "auto_update_build_uuid" bugsnag config
+    Then I should receive 2 requests
+
+    And the request 0 is valid for the Android Mapping API
+    And the request 1 is valid for the Build API

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagMultiPartUploadRequest.kt
@@ -97,7 +97,6 @@ class BugsnagMultiPartUploadRequest(
             if (statusCode != 200) {
                 throw IllegalStateException("Bugsnag upload failed with code $statusCode $responseEntity")
             } else {
-                logger.lifecycle("Bugsnag: Upload succeeded")
                 return responseEntity
             }
         } catch (exc: Throwable) {

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPlugin.kt
@@ -39,6 +39,10 @@ class BugsnagPlugin : Plugin<Project> {
         const val BUNDLE_TASK = "bundle"
     }
 
+    private val releasesUploadClient = UploadRequestClient()
+    private val proguardUploadClient = UploadRequestClient()
+    private val ndkUploadClient = UploadRequestClient()
+
     override fun apply(project: Project) {
         // After Gradle 5.2, this can use service injection for injecting ObjectFactory
         val bugsnag = project.extensions.create(
@@ -139,12 +143,15 @@ class BugsnagPlugin : Plugin<Project> {
                 val mappingFileProvider = createMappingFileProvider(project, variant, output)
                 task.mappingFileProperty.set(mappingFileProvider)
                 releasesTask.get().jvmMappingFileProperty.set(mappingFileProvider)
+                task.uploadRequestClient.set(proguardUploadClient)
             }
 
             symbolFileTask?.get()?.let { task ->
                 val ndkSearchDirs = symbolFileTask.get().searchDirectories
                 releasesTask.get().ndkMappingFileProperty.set(ndkSearchDirs)
+                task.uploadRequestClient.set(ndkUploadClient)
             }
+            releasesTask.get().uploadRequestClient.set(releasesUploadClient)
             releasesTask.get().manifestInfoFile.set(manifestInfoFile)
             symbolFileTask?.get()?.manifestInfoFile?.set(manifestInfoFile)
             releasesTask.get().manifestInfoFile.set(manifestInfoFile)

--- a/src/main/kotlin/com.bugsnag.android.gradle/UploadRequestClient.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/UploadRequestClient.kt
@@ -1,0 +1,33 @@
+package com.bugsnag.android.gradle
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.FutureTask
+
+class UploadRequestClient {
+
+    private val requestMap = ConcurrentHashMap<String, FutureTask<String>>()
+
+    /**
+     * Executes request with automatic de-duplication of similar requests.
+     *
+     * If the version information and payload match another request that
+     * has already been enqueued, the response value of the existing request
+     * will be returned. If no existing requests match, a new request will
+     * be enqueued and executed.
+     *
+     * Equality is measured by the [AndroidManifestInfo] (excluding buildUuid)
+     * and the request payload.
+     */
+    fun makeRequestIfNeeded(manifestInfo: AndroidManifestInfo,
+                            payload: String,
+                            request: () -> String): String {
+        val versionInfoHash = manifestInfo.hashCode()
+        val requestIdHash = versionInfoHash + payload.hashCode()
+
+        val future = requestMap.getOrPut(requestIdHash.toString()) {
+            FutureTask { request() }
+        }
+        future.run()
+        return future.get()
+    }
+}

--- a/src/test/kotlin/com/bugsnag/android/gradle/UploadRequestClientTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/UploadRequestClientTest.kt
@@ -1,0 +1,54 @@
+package com.bugsnag.android.gradle
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UploadRequestClientTest {
+
+    private val info = AndroidManifestInfo(
+        "api-key",
+        "5",
+        "build-uuid-123",
+        "1.0",
+        "com.example"
+    )
+
+    @Test
+    fun testRequestDiffVersionInfo() {
+        val client = UploadRequestClient()
+        var requestCount = 0
+        val request = {
+            requestCount += 1
+            ""
+        }
+        client.makeRequestIfNeeded(info, "{}", request)
+        client.makeRequestIfNeeded(info.copy(apiKey = "40fadb0123094f"), "{}", request)
+        assertEquals(2, requestCount)
+    }
+
+    @Test
+    fun testRequestDiffPayload() {
+        val client = UploadRequestClient()
+        var requestCount = 0
+        val request = {
+            requestCount += 1
+            ""
+        }
+        client.makeRequestIfNeeded(info, "{}", request)
+        client.makeRequestIfNeeded(info, "[]", request)
+        assertEquals(2, requestCount)
+    }
+
+    @Test
+    fun testRequestSameInfo() {
+        val client = UploadRequestClient()
+        var requestCount = 0
+        val request = {
+            requestCount += 1
+            ""
+        }
+        client.makeRequestIfNeeded(info, "{}", request)
+        client.makeRequestIfNeeded(info, "{}", request)
+        assertEquals(1, requestCount)
+    }
+}


### PR DESCRIPTION
## Goal

Deduplicates unnecessary upload requests for [APK splits](https://developer.android.com/studio/build/configure-apk-splits). For each APK split if the mapping file and version information is the same, then the upload is skipped if a request has already been enqueued.

## Changeset

Added `UploadRequestClient`, which takes an `AndroidManifestInfo` and payload to calculate a unique request hash. If the request hash already exists, the enqueued request's response is retrieved. If no request already exists for a hash, a request is enqueued and its response is stored for future use.

A separate `UploadRequestClient` has been created for the Release/JVM/NDK APIs, to avoid the unlikely possibility of any hash collisions.

## Tests
- Added E2E scenario to check that releases/JVM mapping API send 2 rather than 58 requests for a project using APK splits.
- Added unit test for `UploadRequestClient`
