### PR TITLE
Convert plugin extension to use property syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ See the [Upgrade Guide](./UPGRADING.md) for migration instructions.
 
 ### Changes
 
+Convert plugin extension to use property syntax
+[#251](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/251)
+
 Deduplicate unnecessary upload requests for APK splits
 [#248](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/248)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -59,7 +59,7 @@ bugsnag {
 
 Previously the `bugsnag` plugin extension did not use Gradle's 
 [Property API](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html),
-which meant the plugin could be configured like thus:
+which meant the plugin could be configured like this:
 
 ```groovy
 // old API

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -55,6 +55,29 @@ bugsnag {
 }
 ```
 
+#### `bugsnag` plugin extension uses Property API
+
+Previously the `bugsnag` plugin extension did not use Gradle's 
+[Property API](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html),
+which meant the plugin could be configured like thus:
+
+```groovy
+// old API
+bugsnag {
+    enabled false
+}
+```
+
+All fields on the `bugsnag` plugin extension are now declared as properties. To migrate, you should
+make the following change on any affected fields:
+
+```groovy
+// new API
+bugsnag {
+    enabled = false
+}
+```
+
 #### Added `autoUpdateBuildUuid` flag to prevent manifest UUID generation
 
 A new flag has been added to disable the generation of UUIDs in the manifest. When this flag

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -67,7 +67,7 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        uploadNdkMappings true
+        uploadNdkMappings = true
         endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
         releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
 

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagInstallJniLibsTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagInstallJniLibsTask.kt
@@ -1,33 +1,39 @@
 package com.bugsnag.android.gradle
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import java.io.File
+import javax.inject.Inject
 
-open class BugsnagInstallJniLibsTask : DefaultTask() {
+open class BugsnagInstallJniLibsTask @Inject constructor(
+    objects: ObjectFactory
+) : DefaultTask() {
 
     init {
         description = "Copies shared object files from the bugsnag-android AAR to the required build directory"
         group = BugsnagPlugin.GROUP_NAME
     }
 
-    private val sharedObjectAarIds = listOf("bugsnag-android", "bugsnag-android-ndk",
-        "bugsnag-plugin-android-anr", "bugsnag-plugin-android-ndk")
-
     @get:OutputDirectory
-    var buildDirDestination = File(project.buildDir, "/intermediates/bugsnag-libs")
+    val buildDirDestination: RegularFileProperty = objects.fileProperty()
 
     @get:InputFiles
-    var bugsnagArtefacts = resolveBugsnagArtefacts()
+    val bugsnagArtefacts: Property<FileCollection> = objects.property(FileCollection::class.java)
 
     /**
      * Looks at all the dependencies and their dependencies and finds the `com.bugsnag` artifacts with SO files.
      */
     @TaskAction
     fun setupNdkProject() {
-        bugsnagArtefacts.forEach { file: File ->
+        bugsnagArtefacts.get().forEach { file: File ->
             project.copy {
                 it.from(project.zipTree(file))
                 it.into(project.file(buildDirDestination))
@@ -35,18 +41,24 @@ open class BugsnagInstallJniLibsTask : DefaultTask() {
         }
     }
 
-    private fun resolveBugsnagArtefacts(): Set<File> {
-        return project.configurations
-            .filter { it.toString().contains("CompileClasspath") }
-            .map { it.resolvedConfiguration }
-            .flatMap { it.firstLevelModuleDependencies }
-            .filter { it.moduleGroup == "com.bugsnag" }
-            .flatMap { it.allModuleArtifacts }
-            .filter {
-                val identifier = it.id.componentIdentifier.toString()
-                sharedObjectAarIds.any { bugsnagId -> identifier.contains(bugsnagId) }
-            }
-            .map { it.file }
-            .toSet()
+    companion object {
+        private val sharedObjectAarIds = listOf("bugsnag-android", "bugsnag-android-ndk",
+            "bugsnag-plugin-android-anr", "bugsnag-plugin-android-ndk")
+
+        internal fun resolveBugsnagArtefacts(project: Project): FileCollection {
+            val files = project.configurations
+                .filter { it.toString().contains("CompileClasspath") }
+                .map { it.resolvedConfiguration }
+                .flatMap { it.firstLevelModuleDependencies }
+                .filter { it.moduleGroup == "com.bugsnag" }
+                .flatMap { it.allModuleArtifacts }
+                .filter {
+                    val identifier = it.id.componentIdentifier.toString()
+                    sharedObjectAarIds.any { bugsnagId -> identifier.contains(bugsnagId) }
+                }
+                .map { it.file }
+                .toSet()
+            return project.files(files)
+        }
     }
 }

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagManifestUuidTask.kt
@@ -49,11 +49,11 @@ abstract class BaseBugsnagManifestUuidTask(objects: ObjectFactory) : DefaultTask
  */
 open class BugsnagManifestUuidTask @Inject constructor(objects: ObjectFactory) : BaseBugsnagManifestUuidTask(objects) {
 
-    @Internal
-    lateinit var variantOutput: ApkVariantOutput
+    @get:Internal
+    internal lateinit var variantOutput: ApkVariantOutput
 
-    @Internal
-    lateinit var variant: ApkVariant
+    @get:Internal
+    internal lateinit var variant: ApkVariant
 
     @TaskAction
     fun updateManifest() {

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagPluginExtension.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.gradle
 import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.util.ConfigureUtil
@@ -10,6 +11,7 @@ import java.io.File
 
 // To make kotlin happy with gradle's nullability
 private val NULL_STRING: String? = null
+private val NULL_BOOLEAN: Boolean? = null
 
 /**
  * Defines configuration options (Gradle plugin extensions) for the BugsnagPlugin
@@ -19,33 +21,55 @@ open class BugsnagPluginExtension(objects: ObjectFactory) {
 
     val sourceControl: SourceControl = objects.newInstance(SourceControl::class.java)
 
-    var isEnabled = true
-    var isUploadJvmMappings = true
-    var isUploadNdkMappings: Boolean? = null
-    var isReportBuilds = true
-    var isUploadDebugBuildMappings = false
+    val enabled: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
+        .convention(true)
+
+    val uploadJvmMappings: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
+        .convention(true)
+
+    val uploadNdkMappings: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
+        .convention(NULL_BOOLEAN)
+
+    val reportBuilds: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
+        .convention(true)
+
+    val uploadDebugBuildMappings: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
+        .convention(false)
+
     val autoUpdateBuildUuid: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
         .convention(true)
+
     val endpoint: Property<String> = objects.property(String::class.javaObjectType)
         .convention("https://upload.bugsnag.com")
+
     val releasesEndpoint = objects.property(String::class.javaObjectType)
         .convention("https://build.bugsnag.com")
+
     val overwrite: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
         .convention(false)
+
     val retryCount: Property<Int> = objects.property(Int::class.javaObjectType)
         .convention(0)
-    var sharedObjectPaths: List<File> = emptyList()
-    var projectRoot: String? = null
+
+    val sharedObjectPaths: ListProperty<File> = objects.listProperty(File::class.java)
+        .convention(emptyList())
+
+    val projectRoot: Property<String> = objects.property(String::class.java).convention(NULL_STRING)
+
     val failOnUploadError: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
         .convention(true)
+
     val requestTimeoutMs: Property<Long> = objects.property(Long::class.javaObjectType)
         .convention(60000)
 
     // release API values
     val builderName: Property<String> = objects.property(String::class.java).convention(NULL_STRING)
+
     val metadata: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java)
         .convention(emptyMap())
-    var objdumpPaths: Map<String, String>? = null
+
+    val objdumpPaths: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java)
+        .convention(emptyMap())
 
     // exposes sourceControl as a nested object on the extension,
     // see https://docs.gradle.org/current/userguide/custom_gradle_types.html#nested_objects

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagReleasesTask.kt
@@ -46,7 +46,7 @@ open class BugsnagReleasesTask @Inject constructor(
     }
 
     @get:Internal
-    val uploadRequestClient: Property<UploadRequestClient> = objects.property(UploadRequestClient::class.java)
+    internal val uploadRequestClient: Property<UploadRequestClient> = objects.property(UploadRequestClient::class.java)
 
     @get:PathSensitive(NONE)
     @get:InputFile

--- a/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadProguardTask.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/BugsnagUploadProguardTask.kt
@@ -37,7 +37,7 @@ open class BugsnagUploadProguardTask @Inject constructor(
     }
 
     @get:Internal
-    val uploadRequestClient: Property<UploadRequestClient> = objects.property(UploadRequestClient::class.java)
+    internal val uploadRequestClient: Property<UploadRequestClient> = objects.property(UploadRequestClient::class.java)
 
     @get:PathSensitive(NONE)
     @get:InputFile

--- a/src/main/kotlin/com.bugsnag.android.gradle/SharedObjectMappingFileProvider.kt
+++ b/src/main/kotlin/com.bugsnag.android.gradle/SharedObjectMappingFileProvider.kt
@@ -11,7 +11,7 @@ import java.io.File
 fun getSearchDirectories(project: Project,
                          variant: ApkVariant): ConfigurableFileCollection {
     val bugsnag = project.extensions.getByType(BugsnagPluginExtension::class.java)
-    val searchDirectories = bugsnag.sharedObjectPaths.toMutableSet()
+    val searchDirectories = bugsnag.sharedObjectPaths.get().toMutableSet()
 
     resolveExternalNativeBuildTasks(variant).forEach { task ->
         searchDirectories.add(task.objFolder)

--- a/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
@@ -9,7 +9,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.File
-import java.util.ArrayList
 
 class PluginExtensionTest {
 
@@ -25,15 +24,28 @@ class PluginExtensionTest {
     @Test
     fun ensureExtensionDefaults() {
         val bugsnag = proj.extensions.getByType(BugsnagPluginExtension::class.java)
-        assertEquals("https://upload.bugsnag.com", bugsnag.endpoint.get())
-        assertTrue(bugsnag.autoUpdateBuildUuid.get())
-        assertTrue(bugsnag.isUploadJvmMappings)
-        assertTrue(bugsnag.isReportBuilds)
-        assertFalse(bugsnag.isUploadDebugBuildMappings)
-        assertFalse(bugsnag.overwrite.get())
-        assertEquals(0, bugsnag.retryCount.get())
-        assertNull(bugsnag.isUploadNdkMappings)
-        assertEquals(ArrayList<File>(), bugsnag.sharedObjectPaths)
-        assertTrue(bugsnag.failOnUploadError.get())
+
+        with(bugsnag) {
+            assertTrue(autoUpdateBuildUuid.get())
+            assertNull(builderName.orNull)
+            assertTrue(enabled.get())
+            assertEquals("https://upload.bugsnag.com", endpoint.get())
+            assertTrue(failOnUploadError.get())
+            assertEquals(emptyMap<String, String>(), metadata.get())
+            assertEquals(emptyMap<String, String>(), objdumpPaths.get())
+            assertFalse(overwrite.get())
+            assertNull(projectRoot.orNull)
+            assertEquals("https://build.bugsnag.com", releasesEndpoint.get())
+            assertTrue(reportBuilds.get())
+            assertEquals(60000, requestTimeoutMs.get())
+            assertEquals(0, retryCount.get())
+            assertEquals(emptyList<File>(), sharedObjectPaths.get())
+            assertFalse(uploadDebugBuildMappings.get())
+            assertTrue(uploadJvmMappings.get())
+            assertNull(uploadNdkMappings.orNull)
+            assertNull(sourceControl.repository.orNull)
+            assertNull(sourceControl.revision.orNull)
+            assertNull(sourceControl.provider.orNull)
+        }
     }
 }


### PR DESCRIPTION
## Goal

Converts the `bugsnag` plugin extension to use Gradle's [Property API](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html). This conversion is required for future work to support [Configuration caching](https://docs.gradle.org/current/userguide/configuration_cache.html). The changeset is a breaking change depending on how users have configured bugsnag - upgrade steps are documented in the Upgrade guide.

## Changeset

- Made all public properties on `BugsnagPluginExtension` use the `Property` container object
- Reduced the visibility of task properties annotated with `@Internal` to allow non-breaking changes in future
- Converted task inputs to use properties where possible
- Ensured `PluginExtensionTest` unit test covers all default values

