### PR TITLE
Add E2E test scenario for manually uploading

### DIFF
--- a/features/manual_upload.feature
+++ b/features/manual_upload.feature
@@ -1,0 +1,8 @@
+Feature: Manual invocation of upload task
+
+Scenario: Manually invoking upload task sends requests
+    When I build "default_app" using the "all_disabled" bugsnag config
+    When I run the script "features/scripts/manual_upload.sh" synchronously
+    Then I should receive 2 requests
+    And the request 0 is valid for the Android Mapping API
+    And the request 1 is valid for the Build API

--- a/features/scripts/manual_upload.sh
+++ b/features/scripts/manual_upload.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+cd $APP_FIXTURE_DIR
+echo "Test fixture used: $APP_FIXTURE_DIR, AGP=$AGP_VERSION, Gradle=$GRADLE_WRAPPER_VERSION"
+./gradlew module:uploadBugsnagReleaseMapping :module:bugsnagReleaseRelease -x lint --stacktrace

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagManifestUuidTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagManifestUuidTask.kt
@@ -90,12 +90,11 @@ open class BugsnagManifestUuidTask @Inject constructor(objects: ObjectFactory) :
         val directoryBundle: File
         val manifestPaths = mutableListOf<File?>()
         var getMergedManifest = isRunningAssembleTask(project, variant, variantOutput)
-        var getBundleManifest = isRunningBundleTask(project, variant, variantOutput)
+        val getBundleManifest = isRunningBundleTask(project, variant, variantOutput)
 
-        // If the manifest location could not be reliably determined, attempt to get both
+        // If the manifest location could not be reliably determined, default to the assemble manifest
         if (!getMergedManifest && !getBundleManifest) {
             getMergedManifest = true
-            getBundleManifest = true
         }
         val processManifest = variantOutput.processManifestProvider.get()
         if (getMergedManifest) {


### PR DESCRIPTION
## Goal

Adds an E2E test scenario that performs a manual upload without calling assemble or bundle.

This also fixes a long-existing bug in `BugsnagManifestUuidTask` where the task attempted to edit two manifests when the AGP version was <4.1.0. The fallback behaviour is now to edit the `assemble` task manifest instead as subsequent tasks assume that only one manifest is used.
