### PR TITLE
Change how bugsnag plugin is disabled for build variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ See the [Upgrade Guide](./UPGRADING.md) for migration instructions.
 Support configuration caching
 [#257](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/257)
 
+Change how bugsnag plugin is disabled for build variants
+[#255](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/255)
+
 Convert plugin extension to use property syntax
 [#251](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/251)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -64,7 +64,7 @@ which meant the plugin could be configured like this:
 ```groovy
 // old API
 bugsnag {
-    enabled false
+    uploadJvmMappings false
 }
 ```
 
@@ -74,7 +74,39 @@ make the following change on any affected fields:
 ```groovy
 // new API
 bugsnag {
-    enabled = false
+    uploadJvmMappings = false
+}
+```
+
+#### Change how bugsnag plugin is disabled for build variants
+
+You should disable the bugsnag plugin for any build variants which do not use obfuscation.
+The old API for disabling the plugin on individual build variants has been removed:
+
+```groovy
+// old API
+android {
+    buildTypes {
+        debug {
+            ext.enableBugsnag = false
+        }
+    }
+}
+```
+
+You should use the new API instead. This allows for multiple build variants to be ignored at once
+and behaves similarly to AGP's [variant filtering API](https://developer.android.com/studio/build/build-variants#filter-variants):
+
+```groovy
+// new API
+bugsnag {
+    variantFilter { variant ->
+        // disables plugin for all variants with debug buildType
+        def name = variant.name.toLowerCase()
+        if (name.contains("debug")) {
+            enabled = false
+        }
+    }
 }
 ```
 

--- a/features/disabled_build_type.feature
+++ b/features/disabled_build_type.feature
@@ -1,0 +1,5 @@
+Feature: Disabling plugin for build type
+
+Scenario: Disabled build type makes no requests
+    When I build "default_app" using the "disabled_build_type" bugsnag config
+    Then I should receive 0 requests

--- a/features/disabled_product_flavor.feature
+++ b/features/disabled_product_flavor.feature
@@ -1,0 +1,16 @@
+Feature: Disabling plugin for product flavors
+
+Scenario: Disabled product flavor makes no requests
+    When I build "flavors" using the "disabled_product_flavor" bugsnag config
+    Then I should receive 2 requests
+
+    And the request 0 is valid for the Android Mapping API
+    And the field "apiKey" for multipart request 0 equals "TEST_API_KEY"
+    And the field "versionCode" for multipart request 0 equals "1"
+    And the field "versionName" for multipart request 0 equals "1.0"
+    And the field "appId" for multipart request 0 equals "com.bugsnag.android.example.bar"
+
+    And the request 1 is valid for the Build API
+    And the payload field "appVersion" equals "1.0" for request 1
+    And the payload field "apiKey" equals "TEST_API_KEY" for request 1
+    And the payload field "appVersionCode" equals "1" for request 1

--- a/features/fixtures/config/bugsnag/disabled_build_type.gradle
+++ b/features/fixtures/config/bugsnag/disabled_build_type.gradle
@@ -1,0 +1,11 @@
+project.afterEvaluate {
+    project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+
+    // disable bugsnag plugin for 'release' buildType
+    project.bugsnag.variantFilter { variant ->
+        if (variant.name.toLowerCase().contains("release")) {
+            enabled = false
+        }
+    }
+}

--- a/features/fixtures/config/bugsnag/disabled_product_flavor.gradle
+++ b/features/fixtures/config/bugsnag/disabled_product_flavor.gradle
@@ -1,0 +1,11 @@
+project.afterEvaluate {
+    project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+
+    // disable bugsnag plugin for 'foo' productFlavor
+    project.bugsnag.variantFilter { variant ->
+        if (variant.name.toLowerCase().contains("foo")) {
+            enabled = false
+        }
+    }
+}

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
@@ -82,4 +82,23 @@ open class BugsnagPluginExtension(objects: ObjectFactory) {
     fun sourceControl(action: Action<SourceControl>) {
         action.execute(sourceControl)
     }
+
+    internal var filter: Action<VariantFilter>? = null
+
+    fun variantFilter(action: Action<VariantFilter>) {
+        this.filter = action
+    }
+}
+
+interface VariantFilter {
+    val name: String
+    fun setEnabled(enabled: Boolean)
+}
+
+internal class VariantFilterImpl(override val name: String) : VariantFilter {
+    internal var variantEnabled: Boolean? = true
+
+    override fun setEnabled(enabled: Boolean) {
+        this.variantEnabled = enabled
+    }
 }


### PR DESCRIPTION
## Goal

Alters the API for disabling bugsnag on specific build variants. A comparison of the changes is shown below:

```groovy
// old API
android {
    buildTypes {
        debug {
            ext.enableBugsnag = false
        }
    }
}

// new API
bugsnag {
    variantFilter { variant ->
        // disables plugin for all variants with debug buildType
        def name = variant.name.toLowerCase()
        if (name.contains("debug")) {
            enabled = false
        }
    }
}
```

## Rationale

This improves several deficiencies of the old API:

- Kotlin users found it hard to use the API due to the syntax, e.g. #203 
- The API would not entirely disable the plugin on AGP 4.1.0+. This is because with this version of AGP bugsnag needs to register tasks before `android.variant.each` could be called
- Greater consistency with comparable plugins, such as [AGP](https://developer.android.com/studio/build/build-variants#filter-variants) and [Slack's Keeper plugin](https://slackhq.github.io/keeper/configuration/#variant-filter)

## Changeset

- Updated upgrade guide to detail migration
- Added E2E scenarios for disabling the plugin on product flavor and build types
- Added `bugsnag.variantFilter` to the plugin extension