### PR TITLE
Add AGP 4.2.0 and Gradle 6.6 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,3 +80,10 @@ jobs:
         - AGP_VERSION=4.1.0-beta04
         - GRADLE_WRAPPER_VERSION=6.5.1
       script: bundle exec maze-runner -c --verbose
+
+      # AGP 4.2.0 E2E tests
+    - name: AGP 4.2.0 E2E tests
+      env:
+        - AGP_VERSION=4.2.0-alpha07
+        - GRADLE_WRAPPER_VERSION=6.6-rc-6
+      script: bundle exec maze-runner -c --verbose


### PR DESCRIPTION
## Goal

Adds AGP 4.2.0 canary and Gradle 6.6-rc-6 to the CI test matrix. Changes made in #257 use new APIs from Gradle 6.6 if they are available, so we should add this to the CI test matrix.
