### PR TITLE
Respect bugsnag.enabled flag when registering tasks

### DIFF
--- a/features/disabled_bugsnag.feature
+++ b/features/disabled_bugsnag.feature
@@ -1,0 +1,5 @@
+Feature: Bugsnag disabled
+
+Scenario: No requests are received when bugsnag is disabled
+    When I build "default_app" using the "disabled_bugsnag" bugsnag config
+    Then I should receive 0 requests

--- a/features/fixtures/app/module/build.gradle
+++ b/features/fixtures/app/module/build.gradle
@@ -5,9 +5,7 @@ def bugsnagConfig = System.env.BUGSNAG_CONFIG ?: "standard"
 apply from: "../../config/android/${moduleConfig}.gradle"
 
 if (!System.env.UPDATING_GRADLEW) {
-    // apply config first (not overwritten by applying bugsnag plugin)
-    apply from: "../../config/bugsnag/${bugsnagConfig}.gradle"
 
     // apply bugsnag plugin configuration (e.g. custom sourceControl info)
-    apply plugin: 'com.bugsnag.android.gradle'
+    apply from: "../../config/bugsnag/${bugsnagConfig}.gradle"
 }

--- a/features/fixtures/config/bugsnag/all_disabled.gradle
+++ b/features/fixtures/config/bugsnag/all_disabled.gradle
@@ -1,6 +1,8 @@
-project.afterEvaluate {
-    project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.uploadJvmMappings = false
-    project.bugsnag.reportBuilds = false
+apply plugin: 'com.bugsnag.android.gradle'
+
+bugsnag {
+    endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    uploadJvmMappings = false
+    reportBuilds = false
 }

--- a/features/fixtures/config/bugsnag/custom_build_info.gradle
+++ b/features/fixtures/config/bugsnag/custom_build_info.gradle
@@ -1,16 +1,18 @@
-project.afterEvaluate {
-    project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.uploadJvmMappings = false
+apply plugin: 'com.bugsnag.android.gradle'
 
-    project.bugsnag.builderName = "Mark Twain"
-    project.bugsnag.sourceControl.provider = "bitbucket"
-    project.bugsnag.sourceControl.repository = "https://example.com/bar/foo.git"
-    project.bugsnag.sourceControl.revision = "fab8721"
+bugsnag {
+    endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    uploadJvmMappings = false
+
+    builderName = "Mark Twain"
+    sourceControl.provider = "bitbucket"
+    sourceControl.repository = "https://example.com/bar/foo.git"
+    sourceControl.revision = "fab8721"
 
     def map = new HashMap()
     map.put("MyKey", "MyValue")
     map.put("os_version", "BeOS")
-    project.bugsnag.metadata = map
+    metadata = map
 
 }

--- a/features/fixtures/config/bugsnag/disabled_bugsnag.gradle
+++ b/features/fixtures/config/bugsnag/disabled_bugsnag.gradle
@@ -3,5 +3,5 @@ apply plugin: 'com.bugsnag.android.gradle'
 bugsnag {
     endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
     releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    reportBuilds = false
+    enabled = false
 }

--- a/features/fixtures/config/bugsnag/disabled_build_type.gradle
+++ b/features/fixtures/config/bugsnag/disabled_build_type.gradle
@@ -1,9 +1,11 @@
-project.afterEvaluate {
-    project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+apply plugin: 'com.bugsnag.android.gradle'
+
+bugsnag {
+    endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
 
     // disable bugsnag plugin for 'release' buildType
-    project.bugsnag.variantFilter { variant ->
+    variantFilter { variant ->
         if (variant.name.toLowerCase().contains("release")) {
             enabled = false
         }

--- a/features/fixtures/config/bugsnag/disabled_product_flavor.gradle
+++ b/features/fixtures/config/bugsnag/disabled_product_flavor.gradle
@@ -1,9 +1,11 @@
-project.afterEvaluate {
-    project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+apply plugin: 'com.bugsnag.android.gradle'
+
+bugsnag {
+    endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
 
     // disable bugsnag plugin for 'foo' productFlavor
-    project.bugsnag.variantFilter { variant ->
+    variantFilter { variant ->
         if (variant.name.toLowerCase().contains("foo")) {
             enabled = false
         }

--- a/features/fixtures/config/bugsnag/empty_api_key.gradle
+++ b/features/fixtures/config/bugsnag/empty_api_key.gradle
@@ -6,7 +6,9 @@ android {
     }
 }
 
-project.afterEvaluate {
-    project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+apply plugin: 'com.bugsnag.android.gradle'
+
+bugsnag {
+    endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
 }

--- a/features/fixtures/config/bugsnag/overwrite_enabled.gradle
+++ b/features/fixtures/config/bugsnag/overwrite_enabled.gradle
@@ -1,6 +1,8 @@
-project.afterEvaluate {
-    project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.reportBuilds = false
-    project.bugsnag.overwrite = true
+apply plugin: 'com.bugsnag.android.gradle'
+
+bugsnag {
+    endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    reportBuilds = false
+    overwrite = true
 }

--- a/features/fixtures/config/bugsnag/standard.gradle
+++ b/features/fixtures/config/bugsnag/standard.gradle
@@ -1,4 +1,6 @@
-project.afterEvaluate {
-    project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+apply plugin: 'com.bugsnag.android.gradle'
+
+bugsnag {
+    endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
 }

--- a/features/fixtures/config/bugsnag/upload_debug_enabled.gradle
+++ b/features/fixtures/config/bugsnag/upload_debug_enabled.gradle
@@ -1,5 +1,7 @@
-project.afterEvaluate {
-    project.bugsnag.endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
-    project.bugsnag.uploadDebugBuildMappings = true
+apply plugin: 'com.bugsnag.android.gradle'
+
+bugsnag {
+    endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"
+    uploadDebugBuildMappings = true
 }

--- a/features/fixtures/config/bugsnag/wrong_endpoint.gradle
+++ b/features/fixtures/config/bugsnag/wrong_endpoint.gradle
@@ -1,4 +1,6 @@
-project.afterEvaluate {
-    project.bugsnag.endpoint = "http://localhost:12345"
-    project.bugsnag.releasesEndpoint = "http://localhost:12345"
+apply plugin: 'com.bugsnag.android.gradle'
+
+bugsnag {
+    endpoint = "http://localhost:12345"
+    releasesEndpoint = "http://localhost:12345"
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -83,6 +83,9 @@ class BugsnagPlugin : Plugin<Project> {
             if (BugsnagManifestUuidTaskV2.isApplicable()) {
                 check(android is CommonExtension<*, *, *, *, *, *, *, *>)
                 android.onVariants {
+                    if (!bugsnag.enabled.get()) {
+                        return@onVariants
+                    }
                     val variant = VariantFilterImpl(name)
                     if (!isVariantEnabled(bugsnag, variant)) {
                         return@onVariants
@@ -108,6 +111,9 @@ class BugsnagPlugin : Plugin<Project> {
             }
 
             project.afterEvaluate {
+                if (!bugsnag.enabled.get()) {
+                    return@afterEvaluate
+                }
                 android.applicationVariants.configureEach { variant ->
                     val filterImpl = VariantFilterImpl(variant.name)
                     if (!isVariantEnabled(bugsnag, filterImpl)) {


### PR DESCRIPTION
## Goal

The `bugsnag.enabled` flag controls whether the plugin should add tasks or not. If it is set to `false` then the bugsnag gradle plugin should have no impact on a build script. The user can set the value to false via bugsnag's plugin extension, which can be configured after the bugsnag plugin.

The plugin now uses `project.pluginManager.withPlugin` to configure tasks when the Android Gradle Plugin is added. As AGP can be added before the bugsnag plugin, this means the configuration can occur immediately - before the user's plugin extension has been configured. Adding additional checks on `bugsnag.enabled` within `project.afterEvaluate` and `android.onVariants` prevents the plugin from adding any tasks by reading the value after a user has had a chance to set it.

## Changeset

- Checked the value of `bugsnag.enabled` in both `android.onVariants` and `project.afterEvaluate` and stopped if the value is false
- Added E2E test to cover this scenario
- Tested on example app using AGP 4.2.0-alpha04 and confirmed that no bugsnag tasks ran
- Updated all test fixtures so that the bugsnag plugin extension is configured immediately after the plugin is applied, rather than [after the project is evaluated](https://github.com/bobvanderlinden/probot-auto-merge), as this is what we document users should do

