### PR TITLE
Specify millisecond timeout correctly for entire request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Deduplicate unnecessary upload requests for APK splits
 
 Switch to OkHttp for networking
 [#247](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/247)
+[#268](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/268)
 
 Specify shared object files as input for ndk task
 [#243](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/243)

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.gradle
 import com.bugsnag.android.gradle.internal.GradleVersions
 import com.bugsnag.android.gradle.internal.UploadRequestClient
 import com.bugsnag.android.gradle.internal.mapProperty
+import com.bugsnag.android.gradle.internal.newClient
 import com.bugsnag.android.gradle.internal.property
 import com.bugsnag.android.gradle.internal.register
 import com.bugsnag.android.gradle.internal.versionNumber
@@ -160,8 +161,8 @@ sealed class BugsnagReleasesTask(
         payload: ReleasePayload,
         manifestInfo: AndroidManifestInfo
     ): String {
-        val timeoutDuration = Duration.ofMillis(timeoutMillis.get())
-        val bugsnagService = createService(timeoutDuration)
+        val okHttpClient = newClient(timeoutMillis.get())
+        val bugsnagService = createService(okHttpClient)
 
         val response = try {
             bugsnagService.upload(
@@ -308,15 +309,6 @@ sealed class BugsnagReleasesTask(
                 }
             }
             return null
-        }
-
-        private fun createService(
-            timeoutDuration: Duration
-        ): BugsnagReleasesService {
-            return createService(OkHttpClient.Builder()
-                .connectTimeout(timeoutDuration)
-                .callTimeout(timeoutDuration)
-                .build())
         }
 
         internal fun createService(

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
@@ -35,10 +35,12 @@ class LegacyBugsnagHttpClientHelper(timeoutMillis: Provider<Long>) : BugsnagHttp
     override val okHttpClient: OkHttpClient by lazy { newClient(timeoutMillis.get()) }
 }
 
-private fun newClient(timeoutMillis: Long): OkHttpClient {
+internal fun newClient(timeoutMillis: Long): OkHttpClient {
     val timeoutDuration = Duration.ofMillis(timeoutMillis)
     return OkHttpClient.Builder()
-        .connectTimeout(timeoutDuration)
+        .readTimeout(Duration.ZERO)
+        .writeTimeout(Duration.ZERO)
+        .connectTimeout(Duration.ZERO)
         .callTimeout(timeoutDuration)
         .build()
 }


### PR DESCRIPTION
## Goal

#247 switches the internal HTTP library to OkHttp to avoid using the deprecated Apache client. This caused a bug where the `requestTimeoutMs` property on the plugin would not be respected due to OkHttp setting a [default timeout of 10s on writes](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/write-timeout/).

This changeset alters the timeout so that it applies to the [request as a whole](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/call-timeout/) and resets any default timeouts to 0 (indefinite). This has been verified in an example app by setting the `requestTimeoutMs` to 15000ms and running each type of upload task against a non-responsive local server. After 15s it was confirmed that the task failed due to the timeout.
