### PR TITLE
Support proxies via OkHttp

### DIFF
--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -8,14 +8,10 @@ import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.bugsnag.android.gradle.BugsnagInstallJniLibsTask.Companion.resolveBugsnagArtifacts
 import com.bugsnag.android.gradle.internal.BugsnagHttpClientHelper
-import com.bugsnag.android.gradle.internal.BuildServiceBugsnagHttpClientHelper
-import com.bugsnag.android.gradle.internal.GradleVersions
-import com.bugsnag.android.gradle.internal.LegacyBugsnagHttpClientHelper
 import com.bugsnag.android.gradle.internal.UploadRequestClient
 import com.bugsnag.android.gradle.internal.hasDexguardPlugin
 import com.bugsnag.android.gradle.internal.newUploadRequestClientProvider
 import com.bugsnag.android.gradle.internal.register
-import com.bugsnag.android.gradle.internal.versionNumber
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
@@ -58,20 +54,10 @@ class BugsnagPlugin : Plugin<Project> {
                 return@withPlugin
             }
 
-            val canUseBuildService = project.gradle.versionNumber() >= GradleVersions.VERSION_6_1
-            val httpClientHelperProvider = if (canUseBuildService) {
-                project.gradle.sharedServices.registerIfAbsent("bugsnagHttpClientHelper",
-                    BuildServiceBugsnagHttpClientHelper::class.java
-                ) { spec ->
-                    // Provide some parameters
-                    spec.parameters.timeoutMillis.set(bugsnag.requestTimeoutMs)
-                    spec.parameters.retryCount.set(bugsnag.retryCount)
-                }
-            } else {
-                // Reuse instance
-                val client = LegacyBugsnagHttpClientHelper(bugsnag.requestTimeoutMs, bugsnag.retryCount)
-                project.provider { client }
-            }
+            val httpClientHelperProvider = BugsnagHttpClientHelper.create(
+                project,
+                bugsnag
+            )
 
             val releasesUploadClientProvider = newUploadRequestClientProvider(project, "releases")
             val proguardUploadClientProvider = newUploadRequestClientProvider(project, "proguard")
@@ -231,7 +217,8 @@ class BugsnagPlugin : Plugin<Project> {
                 manifestInfoFileProvider,
                 releasesUploadClientProvider,
                 mappingFilesProvider,
-                symbolFileTaskProvider != null
+                symbolFileTaskProvider != null,
+                httpClientHelperProvider
             )
 
             if (shouldUploadMappings(output, bugsnag)) {
@@ -350,7 +337,8 @@ class BugsnagPlugin : Plugin<Project> {
         manifestInfoFileProvider: Provider<RegularFile>,
         releasesUploadClientProvider: Provider<out UploadRequestClient>,
         mappingFilesProvider: Provider<FileCollection>?,
-        checkSearchDirectories: Boolean
+        checkSearchDirectories: Boolean,
+        httpClientHelperProvider: Provider<out BugsnagHttpClientHelper>
     ): TaskProvider<out BugsnagReleasesTask> {
         val outputName = taskNameForOutput(output)
         val taskName = "bugsnagRelease${outputName}Task"
@@ -358,6 +346,7 @@ class BugsnagPlugin : Plugin<Project> {
         val requestOutputFile = project.layout.buildDirectory.file(path)
         return BugsnagReleasesTask.register(project, taskName) {
             this.requestOutputFile.set(requestOutputFile)
+            httpClientHelper.set(httpClientHelperProvider)
             retryCount.set(bugsnag.retryCount)
             timeoutMillis.set(bugsnag.requestTimeoutMs)
             failOnUploadError.set(bugsnag.failOnUploadError)

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
@@ -34,6 +34,7 @@ import org.gradle.process.ExecOperations
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
 import org.gradle.process.internal.ExecException
+import org.gradle.util.VersionNumber
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -270,12 +271,15 @@ sealed class BugsnagReleasesTask(
     }
 
     internal fun configureMetadata() {
-        gradleVersion.orNull?.let(gradleVersion::set)
+        val gradleVersionNumber = gradleVersion.orNull?.let {
+            gradleVersion.set(it)
+            VersionNumber.parse(it)
+        }
         gitVersion.set(providerFactory.provider { runCmd(VCS_COMMAND, "--version") } )
-        osArch.set(providerFactory.systemPropertyCompat(MK_OS_ARCH) )
-        osName.set(providerFactory.systemPropertyCompat(MK_OS_NAME) )
-        osVersion.set(providerFactory.systemPropertyCompat(MK_OS_VERSION) )
-        javaVersion.set(providerFactory.systemPropertyCompat(MK_JAVA_VERSION))
+        osArch.set(providerFactory.systemPropertyCompat(MK_OS_ARCH, gradleVersionNumber) )
+        osName.set(providerFactory.systemPropertyCompat(MK_OS_NAME, gradleVersionNumber) )
+        osVersion.set(providerFactory.systemPropertyCompat(MK_OS_VERSION, gradleVersionNumber) )
+        javaVersion.set(providerFactory.systemPropertyCompat(MK_JAVA_VERSION, gradleVersionNumber))
     }
 
     companion object {

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
@@ -19,7 +19,6 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
@@ -326,22 +325,17 @@ sealed class BugsnagReleasesTask(
         internal fun register(
             project: Project,
             name: String,
-            clientHelperProvider: Provider<out BugsnagHttpClientHelper>,
             configurationAction: BugsnagReleasesTask.() -> Unit
         ): TaskProvider<out BugsnagReleasesTask> {
-            val delegatingProvider: BugsnagReleasesTask.() -> Unit = {
-                httpClientHelper.set(clientHelperProvider)
-                configurationAction()
-            }
             return when {
               project.gradle.versionNumber() >= GradleVersions.VERSION_6 -> {
-                  project.tasks.register<BugsnagReleasesTaskGradle6Plus>(name, delegatingProvider)
+                  project.tasks.register<BugsnagReleasesTaskGradle6Plus>(name, configurationAction)
               }
               project.gradle.versionNumber() >= GradleVersions.VERSION_5_3 -> {
-                  project.tasks.register<BugsnagReleasesTaskGradle53Plus>(name, delegatingProvider)
+                  project.tasks.register<BugsnagReleasesTaskGradle53Plus>(name, configurationAction)
               }
               else -> {
-                  project.tasks.register<BugsnagReleasesTaskLegacy>(name, delegatingProvider)
+                  project.tasks.register<BugsnagReleasesTaskLegacy>(name, configurationAction)
               }
             }
         }

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
@@ -42,10 +42,12 @@ interface BugsnagHttpClientHelper : AutoCloseable {
             project: Project,
             bugsnag: BugsnagPluginExtension
         ): Provider<out BugsnagHttpClientHelper> {
-            val proxyHost = project.providers.systemPropertyCompat(KEY_PROXY_HOST)
-            val proxyPort = project.providers.systemPropertyCompat(KEY_PROXY_PORT)
-            val proxyUsername = project.providers.systemPropertyCompat(KEY_PROXY_USER)
-            val proxyPassword = project.providers.systemPropertyCompat(KEY_PROXY_PASSWORD)
+            val gradleVersion = project.gradle.versionNumber()
+            val providers = project.providers
+            val proxyHost = providers.systemPropertyCompat(KEY_PROXY_HOST, gradleVersion)
+            val proxyPort = providers.systemPropertyCompat(KEY_PROXY_PORT, gradleVersion)
+            val proxyUsername = providers.systemPropertyCompat(KEY_PROXY_USER, gradleVersion)
+            val proxyPassword = providers.systemPropertyCompat(KEY_PROXY_PASSWORD, gradleVersion)
 
             val canUseBuildService = project.gradle.versionNumber() >= GradleVersions.VERSION_6_1
             return if (canUseBuildService) {

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
@@ -39,7 +39,6 @@ interface BugsnagHttpClientHelper : AutoCloseable {
 
     companion object {
         fun create(
-            canUseBuildService: Boolean,
             project: Project,
             bugsnag: BugsnagPluginExtension
         ): Provider<out BugsnagHttpClientHelper> {
@@ -48,6 +47,7 @@ interface BugsnagHttpClientHelper : AutoCloseable {
             val proxyUsername = project.providers.systemPropertyCompat(KEY_PROXY_USER)
             val proxyPassword = project.providers.systemPropertyCompat(KEY_PROXY_PASSWORD)
 
+            val canUseBuildService = project.gradle.versionNumber() >= GradleVersions.VERSION_6_1
             return if (canUseBuildService) {
                 project.gradle.sharedServices.registerIfAbsent("bugsnagHttpClientHelper",
                     BuildServiceBugsnagHttpClientHelper::class.java

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
@@ -122,6 +122,7 @@ internal class LegacyBugsnagHttpClientHelper(
     }
 }
 
+@Suppress("LongParameterList")
 private fun newClient(
     timeoutMillis: Long,
     retryCount: Int,

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
@@ -11,7 +11,6 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
-import java.net.ProxySelector
 import java.time.Duration
 
 /**
@@ -96,7 +95,6 @@ private fun newClient(
         .connectTimeout(Duration.ZERO)
         .callTimeout(timeoutDuration)
         .addInterceptor(interceptor)
-        .proxySelector(ProxySelector.getDefault())
         .proxyAuthenticator(Authenticator.JAVA_NET_AUTHENTICATOR)
         .build()
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
@@ -164,9 +164,12 @@ internal fun Project.hasDexguardPlugin(): Boolean {
 }
 
 /** Returns a String provider for a system property. */
-internal fun ProviderFactory.systemPropertyCompat(name: String): Provider<String> {
-    return if (gradle.versionNumber() >= GradleVersions.VERSION_6_1) {
-        providers.systemProperty(name)
+internal fun ProviderFactory.systemPropertyCompat(
+    name: String,
+    gradleVersion: VersionNumber?
+): Provider<String> {
+    return if (gradleVersion != null && gradleVersion >= GradleVersions.VERSION_6_1) {
+        systemProperty(name)
     } else {
         provider { System.getProperty(name) }
     }

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
@@ -21,6 +21,8 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
@@ -157,8 +159,17 @@ internal fun AppExtension.hasMultipleOutputs(): Boolean {
 /**
  * Returns true if the DexGuard plugin has been applied to the project
  */
-fun Project.hasDexguardPlugin(): Boolean {
+internal fun Project.hasDexguardPlugin(): Boolean {
     return pluginManager.hasPlugin("dexguard")
+}
+
+/** Returns a String provider for a system property. */
+internal fun ProviderFactory.systemPropertyCompat(name: String): Provider<String> {
+    return if (gradle.versionNumber() >= GradleVersions.VERSION_6_1) {
+        providers.systemProperty(name)
+    } else {
+        provider { System.getProperty(name) }
+    }
 }
 
 /* Borrowed helper functions from the Gradle Kotlin DSL. */
@@ -173,7 +184,7 @@ fun Project.hasDexguardPlugin(): Boolean {
  * @see [ObjectFactory.newInstance]
  */
 @Suppress("SpreadOperator")
-inline fun <reified T : Any> ObjectFactory.newInstance(vararg parameters: Any): T =
+internal inline fun <reified T : Any> ObjectFactory.newInstance(vararg parameters: Any): T =
     newInstance(T::class.javaObjectType, *parameters)
 
 /**


### PR DESCRIPTION
Re-publish of #270 

Continuation of #200 but implemented in the new OkHttp stack. This also opportunistically fixes the BugsnagReleasesTask not using the same shared client