### PR TITLE
 Only upload mapping files once per variant

### DIFF
--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -216,6 +216,8 @@ class BugsnagPlugin : Plugin<Project> {
                         )
                         existingProguardTaskProvider = registered
                     }
+
+                    // Guaranteed to be initialized if we reach here
                     existingProguardTaskProvider
                 }
                 else -> null


### PR DESCRIPTION
## Goal

This is a proposal solution for #274, and works by only registering the mapping file upload at most one time. This is useful as these mapping files are identical per variant, and can save quite a bit of time in uploads for apps with large mapping files and/or multiple ABIs/densities

## Design

See above

## Changeset

See title

## Tests

I can look at updating the maze tests if y'all are ok with this proposal