### PR TITLE
Retry request by constructing new OkHttp request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+Retry request by constructing new OkHttp request
+[#278](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/278)
+
 ## 5.0.0 (2020-08-20)
 
 This release contains **breaking changes**. It contains numerous performance

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -15,6 +15,7 @@
     <ID>TooGenericExceptionCaught:BugsnagUploadNdkTask.kt$BugsnagUploadNdkTask$e: Exception</ID>
     <ID>TooGenericExceptionCaught:BugsnagUploadNdkTask.kt$BugsnagUploadNdkTask$ex: Throwable</ID>
     <ID>TooGenericExceptionCaught:MappingFileProvider.kt$exc: Throwable</ID>
+    <ID>TooGenericExceptionCaught:BugsnagHttpClientHelper.kt$exc: Throwable</ID>
     <ID>TooManyFunctions:BugsnagPlugin.kt$BugsnagPlugin$BugsnagPlugin</ID>
   </Whitelist>
 </SmellBaseline>

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagMultiPartUploadRequest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android.gradle
 
+import com.bugsnag.android.gradle.internal.runRequestWithRetries
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -28,6 +29,7 @@ class BugsnagMultiPartUploadRequest(
 
     fun uploadMultipartEntity(
         manifestInfo: AndroidManifestInfo,
+        retryCount: Int,
         action: (MultipartBody.Builder) -> Unit
     ): String {
         val builder = buildMultipartBody(manifestInfo, overwrite)
@@ -35,7 +37,9 @@ class BugsnagMultiPartUploadRequest(
         val body = builder.build()
 
         return try {
-            uploadToServer(body)!!
+            runRequestWithRetries(retryCount) {
+                uploadToServer(body)!!
+            }
         } catch (exc: Throwable) {
             when {
                 failOnUploadError -> throw exc

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -69,7 +69,7 @@ class BugsnagPlugin : Plugin<Project> {
                 }
             } else {
                 // Reuse instance
-                val client = LegacyBugsnagHttpClientHelper(bugsnag.requestTimeoutMs, bugsnag.retryCount)
+                val client = LegacyBugsnagHttpClientHelper(bugsnag.requestTimeoutMs)
                 project.provider { client }
             }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
@@ -6,6 +6,7 @@ import com.bugsnag.android.gradle.internal.mapProperty
 import com.bugsnag.android.gradle.internal.newClient
 import com.bugsnag.android.gradle.internal.property
 import com.bugsnag.android.gradle.internal.register
+import com.bugsnag.android.gradle.internal.runRequestWithRetries
 import com.bugsnag.android.gradle.internal.versionNumber
 import com.squareup.moshi.JsonClass
 import okhttp3.OkHttpClient
@@ -162,19 +163,21 @@ sealed class BugsnagReleasesTask(
         payload: ReleasePayload,
         manifestInfo: AndroidManifestInfo
     ): String {
-        val okHttpClient = newClient(timeoutMillis.get(), retryCount.get())
+        val okHttpClient = newClient(timeoutMillis.get())
         val bugsnagService = createService(okHttpClient)
 
-        val response = try {
-            bugsnagService.upload(
-                releasesEndpoint.get(),
-                apiKey = manifestInfo.apiKey,
-                payload = payload
-            ).execute()
+        return try {
+            runRequestWithRetries(retryCount.get()) {
+                val response = bugsnagService.upload(
+                    releasesEndpoint.get(),
+                    apiKey = manifestInfo.apiKey,
+                    payload = payload
+                )
+                readRequestResponse(response.execute())
+            }
         } catch (e: IOException) {
             throw IllegalStateException("Request to Bugsnag Releases API failed, aborting build.", e)
         }
-        return readRequestResponse(response)
     }
 
     private fun readRequestResponse(response: Response<String>): String {

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadNdkTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadNdkTask.kt
@@ -238,7 +238,7 @@ sealed class BugsnagUploadNdkTask(
         val response = uploadRequestClient.get().makeRequestIfNeeded(manifestInfo, mappingFileHash) {
             logger.lifecycle("Bugsnag: Attempting to upload shared object mapping " +
                 "file for $sharedObjectName-$arch from $mappingFile")
-            request.uploadMultipartEntity(parseManifestInfo()) { builder ->
+            request.uploadMultipartEntity(parseManifestInfo(), retryCount.get()) { builder ->
                 builder.addFormDataPart("soSymbolFile", mappingFile.name, mappingFile.asRequestBody())
 
                 if (arch != null) {

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadProguardTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadProguardTask.kt
@@ -103,7 +103,7 @@ sealed class BugsnagUploadProguardTask @Inject constructor(
         val mappingFileHash = mappingFile.md5HashCode()
         val response = uploadRequestClient.get().makeRequestIfNeeded(manifestInfo, mappingFileHash) {
             logger.lifecycle("Bugsnag: Attempting to upload JVM mapping file: $mappingFile")
-            request.uploadMultipartEntity(manifestInfo) { builder ->
+            request.uploadMultipartEntity(manifestInfo, retryCount.get()) { builder ->
                 builder.addFormDataPart("proguard", mappingFile.name, mappingFile.asRequestBody())
 
             }

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
@@ -58,7 +58,6 @@ internal fun runRequestWithRetries(maxRetries: Int, request: () -> String): Stri
             return request()
         } catch (exc: Throwable) {
             cause = exc
-            exc.printStackTrace(System.out)
         }
         attempts++
     } while (attempts < maxRetries)

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
@@ -1,9 +1,7 @@
 package com.bugsnag.android.gradle.internal
 
 import com.bugsnag.android.gradle.internal.BuildServiceBugsnagHttpClientHelper.Params
-import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import okhttp3.Response
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
@@ -31,49 +29,38 @@ abstract class BuildServiceBugsnagHttpClientHelper
     }
 
     override val okHttpClient: OkHttpClient by lazy {
-        newClient(parameters.timeoutMillis.get(), parameters.retryCount.get())
+        newClient(parameters.timeoutMillis.get())
     }
 }
 
 /** A simple instance-based [BugsnagHttpClientHelper] for use on Gradle <6.1. */
 class LegacyBugsnagHttpClientHelper(
-    timeoutMillis: Provider<Long>,
-    retryCount: Provider<Int>
+    timeoutMillis: Provider<Long>
 ) : BugsnagHttpClientHelper {
-    override val okHttpClient: OkHttpClient by lazy { newClient(timeoutMillis.get(), retryCount.get()) }
+    override val okHttpClient: OkHttpClient by lazy { newClient(timeoutMillis.get()) }
 }
 
-internal fun newClient(
-    timeoutMillis: Long,
-    retryCount: Int
-): OkHttpClient {
+internal fun newClient(timeoutMillis: Long): OkHttpClient {
     val timeoutDuration = Duration.ofMillis(timeoutMillis)
-    val interceptor = retryInterceptor(retryCount)
     return OkHttpClient.Builder()
         .readTimeout(Duration.ZERO)
         .writeTimeout(Duration.ZERO)
         .connectTimeout(Duration.ZERO)
         .callTimeout(timeoutDuration)
-        .addInterceptor(interceptor)
         .build()
 }
 
-internal fun retryInterceptor(maxRetries: Int): Interceptor {
-    return object : Interceptor {
-        override fun intercept(chain: Interceptor.Chain): Response {
-            var attempts = 0
-            var cause: Throwable?
-            do {
-                try {
-                    val request = chain.request()
-                    return chain.proceed(request)
-                } catch (exc: Throwable) {
-                    cause = exc
-                }
-                attempts++
-            } while (attempts < maxRetries)
-            throw IllegalStateException("Bugsnag request failed to complete", cause)
+internal fun runRequestWithRetries(maxRetries: Int, request: () -> String): String {
+    var attempts = 0
+    var cause: Throwable?
+    do {
+        try {
+            return request()
+        } catch (exc: Throwable) {
+            cause = exc
+            exc.printStackTrace(System.out)
         }
-    }
+        attempts++
+    } while (attempts < maxRetries)
+    throw IllegalStateException("Bugsnag request failed to complete", cause)
 }
-

--- a/src/test/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelperKtTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelperKtTest.kt
@@ -1,0 +1,44 @@
+package com.bugsnag.android.gradle.internal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+
+class BugsnagHttpClientHelperKtTest {
+
+    @Test
+
+    fun testRunRequestWithRetries() {
+        var attempts = 0
+
+        try {
+            runRequestWithRetries(5) {
+                attempts++
+                throw RuntimeException()
+            }
+            fail("Expected exception to be thrown after max retries reached")
+        } catch (exc: Throwable) {
+            assertEquals(5, attempts)
+        }
+    }
+
+    @Test
+    fun testRunRequestNoFailure() {
+        var attempts = 0
+        runRequestWithRetries(5) {
+            attempts++
+            ""
+        }
+        assertEquals(1, attempts)
+    }
+
+    @Test
+    fun testRunRequestZeroRetries() {
+        var attempts = 0
+        runRequestWithRetries(0) {
+            attempts++
+            ""
+        }
+        assertEquals(1, attempts)
+    }
+}


### PR DESCRIPTION
## Goal

#269 used an [OkHttp interceptor](https://square.github.io/okhttp/interceptors/) to retry the request. However, because the same request was retried for each recount and after the first attempt the request was [marked as cancelled](https://github.com/square/okhttp/blob/0cc3aefa8ee328409bc6797e501308ba0b3c5e17/okhttp/src/main/kotlin/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt#L72) OkHttp would always fail subsequent requests immediately. This changeset addresses this issue.

## Changeset

- Refactored retry logic to construct a new OkHttp request each time
- Added unit test to verify that `runRequestWithRetries` retries a set number of times if an exception is thrown, then throws an exception if no attempts are successful

## Tests

Added unit tests and also verified with log statements that the retry was invoked each time. Additionally the plugin was run in an example app against a local server that verified a request was sent for each attempt:

`while true ; do nc -l 1234; echo "\nRestarting netcat"; done`
