### PR TITLE
[PLAT-4918] Add dependencies to POM file for Bintray upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,42 @@ publishing {
             artifactId "bugsnag-android-gradle-plugin"
             version project.version
         }
+
+        BintrayPublication(MavenPublication) {
+            artifact jar
+            groupId "com.bugsnag"
+            artifactId "bugsnag-android-gradle-plugin"
+            version project.version
+
+            pom.withXml {
+                def dependenciesNode = asNode().getAt('dependencies')[0] ?: asNode().appendNode('dependencies')
+
+                // Iterate over the implementation dependencies and add a <dependency> node for each
+                configurations.implementation.allDependencies.each {
+                    // Ensure dependencies such as fileTree are not included in the pom
+                    if (it.name != 'unspecified') {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                        dependencyNode.appendNode('scope', 'runtime')
+                    }
+                }
+
+                configurations.testImplementation.allDependencies.each {
+                    // Ensure we don't add the same dependency twice
+                    if (it.name != 'unspecified' && !configurations.implementation.allDependencies.contains(it)) {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                        dependencyNode.appendNode('scope', 'test')
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -157,7 +193,7 @@ bintray {
     user = project.hasProperty("bintray_user") ? "$bintray_user" : System.getenv("bintray_user")
     key = project.hasProperty("bintray_api_key") ? "$bintray_api_key" : System.getenv("bintray_api_key")
 
-    publications = ["Publication"]
+    publications = ["BintrayPublication"]
     configurations = ["archives"]
     pkg {
         repo = "maven"


### PR DESCRIPTION
## Goal

The Bintray v5.0.0 upload doesn't work currently because its POM file is missing our dependencies — the plugin we use which works for Maven Central doesn't seem to apply to Bintray (this is what's causing #280)

To specify dependencies for Bintray, we need to add them to the POM file in the Bintray publication