### PR TITLE
Avoid creating debug tasks unless uploadDebugBuildMappings flag enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Avoid creating debug tasks unless uploadDebugBuildMappings flag enabled
+  [#288](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/288)
+
 ## 5.0.1 (2020-08-26)
 
 * Retry request by constructing new OkHttp request

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -190,7 +190,7 @@ class BugsnagPlugin : Plugin<Project> {
                 project.extensions.getByType(AppExtension::class.java))
 
             // skip tasks for variant if JVM/NDK minification not enabled
-            if (!jvmMinificationEnabled && !ndkEnabled) {
+            if ((!jvmMinificationEnabled && !ndkEnabled) || !shouldUploadMappings(output, bugsnag)) {
                 return@configureEach
             }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -189,7 +189,8 @@ class BugsnagPlugin : Plugin<Project> {
             val ndkEnabled = isNdkUploadEnabled(bugsnag,
                 project.extensions.getByType(AppExtension::class.java))
 
-            // skip tasks for variant if JVM/NDK minification not enabled
+            // skip tasks for variant if JVM/NDK minification not enabled, or if
+            // uploadDebugBuildMappings is false on the debug buildType
             if ((!jvmMinificationEnabled && !ndkEnabled) || !shouldUploadMappings(output, bugsnag)) {
                 return@configureEach
             }


### PR DESCRIPTION
## Goal

Avoids creating any tasks for the debug buildType unless the `uploadDebugBuildMappings` flag is enabled. This fixes #287 by avoiding unnecessary creation of the UUID task for the debug buildType.

Note that if proguard is enabled on the debug buildType the issue will remain if the user sets `uploadDebugBuildMappings` to true. This is deemed a very unlikely case that only affects AGP < 4.1.0 so has been left as-is for now, as the fix of calling `.get()` when registering the `BugsnagManifestUuidTask` would negatively impact performance. This approach has been tested however so could be used if absolutely required.

## Testing

Relied on existing E2E test coverage, additionally verified that running from Android Studio worked in example apps using AGP 3.6.0 and AGP 4.1.0.