### PR TITLE
Remove undocumented uploadDebugBuildMappings flag in favour of variantFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Remove undocumented uploadDebugBuildMappings flag in favour of variantFilter
+  [#290](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/290)
+
 ## 5.0.1 (2020-08-26)
 
 * Retry request by constructing new OkHttp request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD
+## 5.1.0 (2020-09-07)
 
 * Remove undocumented uploadDebugBuildMappings flag in favour of variantFilter
   [#290](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/290)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -13,7 +13,8 @@ dependencies {
 ```
 
 You should add a variant filter to disable the plugin for the debug buildType, and any other build variants
-which do not require deobfuscation. This improves the plugin's build performance:
+that do not require deobfuscated stacktraces in Bugsnag. This will improve your project's build performance and can be 
+achieved by adding the following to your module-level build.gradle:
 
 ```groovy
 bugsnag {

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -12,6 +12,21 @@ dependencies {
 }
 ```
 
+You should add a variant filter to disable the plugin for the debug buildType, and any other build variants
+which do not require deobfuscation. This improves the plugin's build performance:
+
+```groovy
+bugsnag {
+    variantFilter { variant ->
+        // disables plugin for all variants of the 'debug' buildType
+        def name = variant.name.toLowerCase()
+        if (name.contains("debug")) {
+            enabled = false
+        }
+    }
+}
+```
+
 ### Minimum requirements
 
 The plugin now requires a Gradle wrapper >= 5.1.1, Android Gradle Plugin >= 3.4.0, and JDK >= 8.

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -67,6 +67,13 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
+        variantFilter { variant ->
+            // disables plugin for all variants of the 'debug' buildType
+            def name = variant.name.toLowerCase()
+            if (name.contains("debug")) {
+                enabled = false
+            }
+        }
         uploadNdkMappings = true
         endpoint = "http://localhost:${System.env.MOCK_API_PORT}"
         releasesEndpoint = "http://localhost:${System.env.MOCK_API_PORT}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.bugsnag
-version = 5.0.1
+version = 5.1.0
 
 ANDROID_MIN_SDK_VERSION=14
 ANDROID_TARGET_SDK_VERSION=29

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -234,16 +234,14 @@ class BugsnagPlugin : Plugin<Project> {
                 symbolFileTaskProvider != null
             )
 
-            if (shouldUploadMappings(output, bugsnag)) {
-                if (bugsnag.reportBuilds.get()) {
-                    variant.register(project, releaseUploadTask)
-                }
-                if (symbolFileTaskProvider != null && isNdkUploadEnabled(bugsnag, android)) {
-                    variant.register(project, symbolFileTaskProvider)
-                }
-                if (proguardTaskProvider != null && bugsnag.uploadJvmMappings.get()) {
-                    variant.register(project, proguardTaskProvider)
-                }
+            if (bugsnag.reportBuilds.get()) {
+                variant.register(project, releaseUploadTask)
+            }
+            if (symbolFileTaskProvider != null && isNdkUploadEnabled(bugsnag, android)) {
+                variant.register(project, symbolFileTaskProvider)
+            }
+            if (proguardTaskProvider != null && bugsnag.uploadJvmMappings.get()) {
+                variant.register(project, proguardTaskProvider)
             }
         }
     }
@@ -381,14 +379,6 @@ class BugsnagPlugin : Plugin<Project> {
             }
             configureMetadata()
         }
-    }
-
-    private fun shouldUploadMappings(
-        output: ApkVariantOutput,
-        bugsnag: BugsnagPluginExtension
-    ): Boolean {
-        return !output.name.toLowerCase().endsWith(
-            "debug") || bugsnag.uploadDebugBuildMappings.get()
     }
 
     private fun isNdkUploadEnabled(bugsnag: BugsnagPluginExtension,

--- a/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
@@ -39,7 +39,6 @@ class PluginExtensionTest {
             assertEquals(60000, requestTimeoutMs.get())
             assertEquals(0, retryCount.get())
             assertEquals(emptyList<File>(), sharedObjectPaths.get())
-            assertFalse(uploadDebugBuildMappings.get())
             assertTrue(uploadJvmMappings.get())
             assertNull(uploadNdkMappings.orNull)
             assertNull(sourceControl.repository.orNull)


### PR DESCRIPTION
## Goal

Removes the undocumented `uploadDebugBuildMappings` flag in favour of `variantFilter`. This has the effect of adding tasks to any build variant which has either NDK symbols or JVM minification enabled. Therefore the bugsnag plugin will create tasks by default for the `debug` buildType if the NDK is in use, or if JVM minification is enabled.

As part of the upgrade to v5 it was recommended to use the `variantFilter` API to disable the plugin for the debug build type and any other variants which do not require deobfuscation. This API should be used in place of `uploadDebugBuildMappings`:

```
bugsnag {
    variantFilter { variant ->
        // disables plugin for all variants of the 'debug' buildType
        def name = variant.name.toLowerCase()
        if (name.contains("debug")) {
            enabled = false
        }
    }
}
```