### PR TITLE
Only set mappingFilesProvider on release task if obfuscation enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Only set mappingFilesProvider on release task if obfuscation enabled
+  [#292](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/292)
+
 ## 5.0.1 (2020-08-26)
 
 * Retry request by constructing new OkHttp request

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -185,7 +185,7 @@ class BugsnagPlugin : Plugin<Project> {
             check(output is ApkVariantOutput) {
                 "Expected variant output to be ApkVariantOutput but found ${output.javaClass}"
             }
-            val jvmMinificationEnabled = variant.buildType.isMinifyEnabled || project.hasDexguardPlugin()
+            val jvmMinificationEnabled = project.isJvmMinificationEnabled(variant)
             val ndkEnabled = isNdkUploadEnabled(bugsnag,
                 project.extensions.getByType(AppExtension::class.java))
 
@@ -247,6 +247,9 @@ class BugsnagPlugin : Plugin<Project> {
             }
         }
     }
+
+    private fun Project.isJvmMinificationEnabled(variant: ApkVariant) =
+        variant.buildType.isMinifyEnabled || hasDexguardPlugin()
 
     private fun registerManifestUuidTask(
         project: Project,
@@ -370,8 +373,11 @@ class BugsnagPlugin : Plugin<Project> {
             gradleVersion.set(project.gradle.gradleVersion)
             manifestInfoFile.set(manifestInfoFileProvider)
             uploadRequestClient.set(releasesUploadClientProvider)
-            mappingFilesProvider?.let {
-                jvmMappingFileProperty.from(it)
+
+            if (project.isJvmMinificationEnabled(variant)) {
+                mappingFilesProvider?.let {
+                    jvmMappingFileProperty.from(it)
+                }
             }
             if (checkSearchDirectories) {
                 variant.externalNativeBuildProviders.forEach { task ->


### PR DESCRIPTION
## Goal

The `BugsnagReleaseTask` takes the JVM mapping file as a task input. This is used to invalidate the task's caching - if the mapping file has changed, then the code has also changed so new release information needs to be sent to Bugsnag.

If the NDK and release uploads are enabled but JVM minification is disabled, then no mapping file will exist. This means that the value of `jvmMappingFileProperty ` will not exist, which will cause Gradle to throw an invalid user data exception on AGP 4.1.0/Gradle 6.6, because task inputs should be a valid file.

The `jvmMappingFileProperty` is already marked as `@Optional` to try and avoid this scenario. This changeset fixes the issue by only setting the property value if obfuscation is enabled, as Gradle will not attempt to validate the property in this case.

## Testing

Verified changes manually by running the `ndk_app_agp400` scenarios on a6ec99235e8732fb5c7f3ff52aa4cc2e4a8e4617 with and without the changes.