### PR TITLE
Fix task dependencies and order for BugsnagManifestUuidTask in AGP <4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Only set mappingFilesProvider on release task if obfuscation enabled
   [#292](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/292)
 
+* Fix task dependencies and order for BugsnagManifestUuidTask in AGP <4.1.0
+  [#294](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/294)
+
 ## 5.0.1 (2020-08-26)
 
 * Retry request by constructing new OkHttp request

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -279,7 +279,7 @@ class BugsnagPlugin : Plugin<Project> {
 
             // Enforces correct task ordering. The manifest can only be edited inbetween
             // when the merged manifest is generated (processManifestProvider) and when
-            // the merged manifest is copied for use in packaging the artefact (processResourcesProvider).
+            // the merged manifest is copied for use in packaging the artifact (processResourcesProvider).
             // This ensures BugsnagManifestUuidTask runs at the correct time for both tasks.
             //
             // https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:ordering_tasks

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -271,6 +271,17 @@ class BugsnagPlugin : Plugin<Project> {
                 it.variant = variant
                 it.manifestInfoProvider.set(manifestInfoOutputFile)
                 it.dependsOn(output.processManifestProvider)
+                it.mustRunAfter(output.processManifestProvider)
+            }
+
+            // Enforces correct task ordering. The manifest can only be edited inbetween
+            // when the merged manifest is generated (processManifestProvider) and when
+            // the merged manifest is copied for use in packaging the artefact (processResourcesProvider).
+            // This ensures BugsnagManifestUuidTask runs at the correct time for both tasks.
+            //
+            // https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:ordering_tasks
+            output.processResourcesProvider.configure {
+                it.mustRunAfter(manifestTask)
             }
             output.processManifestProvider.configure {
                 // Trigger eager configuration of the manifest task. This creates the task


### PR DESCRIPTION
## Goal

The `BugsnagManifestUuidTask` is used to write a UUID as a `meta-data` element to the AndroidManifest for AGP < 4.1.0. This changeset resolves two bugs in the task's configuration:

1. The `BugsnagManifestUuidTask` configure action mutates a task other than itself, which causes #287 
2. The `BugsnagManifestUuidTask` can run after the `processResources` task, which causes the UUID to be written to the manifest input file _after_ it has been copied to the APK/App bundle

These bugs are by their nature non-deterministic which partly explains why they were not observed during UAT of v5.

## Changeset

The PR is split into two commits which each fix an individual issue. Both issues are restricted to AGP < 4.1.0, as later versions of AGP offer the superior `android.onVariants` API which gets rid of a lot of complexity associated with editing the manifest.

### Configure action mutates a task other than itself

The plugin registers the `BugsnagManifestUuidTask` to support [task configuration avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:how_does_it_work). This avoids adding the UUID task to a Gradle build when it is not necessary - for example, if a user is running unit tests the task is not required at all.

[The guidelines](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:task_configuration_avoidance_general) suggest that when a task is configured, it should not mutate other tasks inside its configuration action. This guideline is broken by the plugin by adding a dependency on the `processManifest` task. The majority of the time this doesn't appear to have any consequence, but when running in a debug build via Android Studio, this results in the indeterminate behaviour seen in #287. 

The fix for this is to add a task dependency between `BugsnagManifestUuidTask` and `processManifest`, and additionally to enforce that `BugsnagManifestUuidTask` must run after `processManifest`. Because configuration avoidance requires for a [task to be looked up](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:how_do_i_reference_a_task), a configure action has been added for `processManifest` which calls `get()` on the `BugsnagManifestUuidTask` and triggers its creation.

This approach is more performant than the original suggestion of simply calling `get()` in the plugin, because the UUID task should only be created when the `processManifest` task is executing - and in this scenario the bugsnag plugin should always manipulate the manifest.

This was tested by running the example app against a local artefact and confirming that running from AS does not fail the build.

### BugsnagManifestUuidTask can run after the processResources task

In a typical Android build the `processManifest` task produces a merged `AndroidManifest.xml`, and the `processResources` task copies this manifest to a location where it can be packaged into an APK/App Bundle artefact.

The bugsnag plugin adds a `BugsnagManifestUuidTask` task which writes a UUID into the `AndroidManifest.xml`. This needs to run after `processManifest` so that the `AndroidManifest.xml` file exists, and before the `processResources` task so that the updated file is copied to the APK.

The plugin correctly adds a [task ordering](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:ordering_tasks) so that `BugsnagManifestUuidTask` runs after `processManifest`, but does not do the equivalent for `processResources`. In a clean build where every task is rerun this results in the correct task ordering:

<img width="296" alt="clean-build" src="https://user-images.githubusercontent.com/11800640/92485082-68b7cb80-f1e2-11ea-888b-2ba79fef352f.png">

However, if a build makes use of [up-to-date checks](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks) this can alter the order in which tasks are run so that `processResources` occurs before `BugsnagManifestUuidTask`. This causes a manifest without a build UUID to be copied to the final APK:

<img width="348" alt="up-to-date" src="https://user-images.githubusercontent.com/11800640/92485090-69e8f880-f1e2-11ea-8cb7-2a2802eeb6e8.png">

The fix for this is to configure `processResources` so that it must run after the `BugsnagManifestUuidTask`. This has been verified in the Android example app by running `./gradlew assembleRelease --rerun-tasks && ./gradlew assembleRelease` before and after the change, then checking whether the AndroidManifest contains the build UUID in Android Studio's [APK analyzer](https://developer.android.com/studio/build/apk-analyzer).

## Testing

These bugs have laid bare a few gaps in our automated test coverage. I would suggest we investigate adding additional test infastructure as part of future work:

1. Adding a step to mazerunner which extracts the APK/App Bundle archive and inspects whether the binary encoded `AndroidManifest.xml` contains the correct build UUID. We should consider adding this to most of the existing scenarios.
2. Adding some steps to mazerunner which build the APK/App Bundle using a build cache. Currently all builds happen from a clean slate which can miss problems with task ordering.