### PR TITLE
Reword log messages that implied duplicate uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## TBD
 
+* Reword log messages that implied duplicate uploads
+  [#296](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/296)
+
 * Only set mappingFilesProvider on release task if obfuscation enabled
   [#292](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/292)
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
@@ -144,7 +144,7 @@ sealed class BugsnagReleasesTask(
         val payload = generateJsonPayload(manifestInfo)
 
         val response = uploadRequestClient.get().makeRequestIfNeeded(manifestInfo, payload.hashCode()) {
-            logger.lifecycle("Bugsnag: Attempting upload to Releases API")
+            logger.lifecycle("Bugsnag: Uploading to Releases API")
             val response = try {
                 deliverPayload(payload, manifestInfo)
             } catch (exc: Throwable) {
@@ -156,7 +156,6 @@ sealed class BugsnagReleasesTask(
             response
         }
         requestOutputFile.asFile.get().writeText(response)
-        logger.lifecycle("Bugsnag: Releases request complete")
     }
 
     private fun deliverPayload(

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadNdkTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadNdkTask.kt
@@ -230,14 +230,11 @@ sealed class BugsnagUploadNdkTask(
         }
 
         val request = BugsnagMultiPartUploadRequest.from(this)
-        logger.lifecycle("Bugsnag: Attempting to upload shared object mapping " +
-            "file for $sharedObjectName-$arch from $mappingFile")
-
         val manifestInfo = parseManifestInfo()
         val mappingFileHash = mappingFile.md5HashCode()
         val response = uploadRequestClient.get().makeRequestIfNeeded(manifestInfo, mappingFileHash) {
-            logger.lifecycle("Bugsnag: Attempting to upload shared object mapping " +
-                "file for $sharedObjectName-$arch from $mappingFile")
+            logger.lifecycle("Bugsnag: Uploading SO mapping file for " +
+                "$sharedObjectName ($arch) from $mappingFile")
             request.uploadMultipartEntity(parseManifestInfo(), retryCount.get()) { builder ->
                 builder.addFormDataPart("soSymbolFile", mappingFile.name, mappingFile.asRequestBody())
 
@@ -251,7 +248,6 @@ sealed class BugsnagUploadNdkTask(
             }
         }
         requestOutputFile.asFile.get().writeText(response)
-        logger.lifecycle("Bugsnag: shared object mapping file complete for $mappingFile")
     }
 
     /**

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadProguardTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadProguardTask.kt
@@ -102,14 +102,12 @@ sealed class BugsnagUploadProguardTask @Inject constructor(
         val request = BugsnagMultiPartUploadRequest.from(this)
         val mappingFileHash = mappingFile.md5HashCode()
         val response = uploadRequestClient.get().makeRequestIfNeeded(manifestInfo, mappingFileHash) {
-            logger.lifecycle("Bugsnag: Attempting to upload JVM mapping file: $mappingFile")
             request.uploadMultipartEntity(manifestInfo, retryCount.get()) { builder ->
+                logger.lifecycle("Bugsnag: Uploading JVM mapping file from: $mappingFile")
                 builder.addFormDataPart("proguard", mappingFile.name, mappingFile.asRequestBody())
-
             }
         }
         requestOutputFile.asFile.get().writeText(response)
-        logger.lifecycle("Bugsnag: JVM mapping file complete for $mappingFile")
     }
 
     companion object {


### PR DESCRIPTION
## Goal

Rewords the log messages around uploads as the previous messaging suggests that duplicate uploads were happening, as reported in #274. The new messaging looks like this:

> Task :app:uploadBugsnagNdkReleaseMapping
Starting ndk upload
Processing shared object files
Bugsnag: Uploading SO mapping file for libnative-lib.so (arm64-v8a) from /Users/jamielynch/repos/bugsnag-android-gradle-plugin/features/fixtures/ndkapp/app/build/intermediates/bugsnag/arm64-v8a.gz
Bugsnag: Uploading SO mapping file for libnative-lib.so (armeabi-v7a) from /Users/jamielynch/repos/bugsnag-android-gradle-plugin/features/fixtures/ndkapp/app/build/intermediates/bugsnag/armeabi-v7a.gz
Bugsnag: Uploading SO mapping file for libnative-lib.so (x86) from /Users/jamielynch/repos/bugsnag-android-gradle-plugin/features/fixtures/ndkapp/app/build/intermediates/bugsnag/x86.gz
Bugsnag: Uploading SO mapping file for libnative-lib.so (x86_64) from /Users/jamielynch/repos/bugsnag-android-gradle-plugin/features/fixtures/ndkapp/app/build/intermediates/bugsnag/x86_64.g

> Task :app:bugsnagReleaseReleaseTask
Bugsnag: Uploading to Releases API

> Task :app:uploadBugsnagReleaseMapping
Bugsnag: Uploading JVM mapping file from: /Users/jamielynch/repos/bugsnag-android-gradle-plugin/features/fixtures/ndkapp/app/build/outputs/mapping/release/mapping.txt