### PR TITLE
Support mapping upload from Android Gradle Plugin through a proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 * Fix task ordering for upload task on AGP 3.5
   [#300](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/300)
+  
+* Support mapping upload from Android Gradle Plugin through a proxy
+  [#298](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/298)
 
 ## 5.0.2 (2020-09-10)
 

--- a/features/proxy.feature
+++ b/features/proxy.feature
@@ -1,0 +1,88 @@
+Feature: Plugin sends requests when a proxy is set
+# note: default JVM behaviour ignores localhost for proxy traffic, these scenarios need to
+# override this. see https://docs.oracle.com/javase/8/docs/api/java/net/doc-files/net-properties.html#proxies
+
+Scenario: Basic HTTP proxy
+    When I start an http proxy
+    And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
+    And I build "default_app" using the "standard" bugsnag config
+    And I wait to receive 2 requests
+    Then the proxy handled a request for "localhost:9339"
+
+    And 1 requests are valid for the build API and match the following:
+      | appVersionCode | appVersion | buildTool      | sourceControl.provider | sourceControl.repository                                     |
+      | 1              | 1.0        | gradle-android | github                 | https://github.com/bugsnag/bugsnag-android-gradle-plugin.git |
+
+    And 1 requests are valid for the android mapping API and match the following:
+      | versionCode | versionName | appId                       | overwrite |
+      | 1           | 1.0         | com.bugsnag.android.example | null      |
+
+Scenario: Authenticated HTTP proxy with creds
+    When I start an authenticated http proxy
+    And I set the fixture JVM arguments to "-Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=9000 -Dhttp.proxyUser=user -Dhttp.proxyPassword=password -Dhttp.nonProxyHosts="
+    And I build "default_app" using the "standard" bugsnag config
+    And I wait to receive 2 requests
+    Then the proxy handled a request for "localhost:9339"
+
+    And 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      | sourceControl.provider | sourceControl.repository                                     |
+        | 1              | 1.0        | gradle-android | github                 | https://github.com/bugsnag/bugsnag-android-gradle-plugin.git |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | versionCode | versionName | appId                       | overwrite |
+        | 1           | 1.0         | com.bugsnag.android.example | null      |
+
+Scenario: Authenticated HTTP proxy without creds
+    When I start an authenticated http proxy
+    And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
+    And I build "default_app" using the "standard" bugsnag config
+    Then I wait for 5 seconds
+    And I should receive no requests
+
+@skip_agp4_0_or_higher
+Scenario: NDK request for basic HTTP proxy AGP < 4
+    When I start an http proxy
+    And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
+    When I build the NDK app
+    And I wait to receive 6 requests
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 4 requests are valid for the android NDK mapping API and match the following:
+        | arch        |
+        | arm64-v8a   |
+        | armeabi-v7a |
+        | x86         |
+        | x86_64      |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | appId                      |
+        | com.bugsnag.android.ndkapp |
+
+@requires_agp4_0_or_higher
+Scenario: NDK request for basic HTTP proxy AGP >= 4
+    When I start an http proxy
+    And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
+    When I build the NDK app
+    And I wait to receive 10 requests
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 8 requests are valid for the android NDK mapping API and match the following:
+        | arch        |
+        | arm64-v8a   |
+        | arm64-v8a   |
+        | armeabi-v7a |
+        | armeabi-v7a |
+        | x86         |
+        | x86         |
+        | x86_64      |
+        | x86_64      |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | appId                      |
+        | com.bugsnag.android.ndkapp |

--- a/features/scripts/build_ndk_app.sh
+++ b/features/scripts/build_ndk_app.sh
@@ -4,4 +4,4 @@ set -e
 # Build test app
 cd $NDK_FIXTURE_DIR
 echo "Test fixture used: $NDK_FIXTURE_DIR, AGP=$AGP_VERSION, Gradle=$GRADLE_WRAPPER_VERSION"
-./gradlew :app:clean :app:assemble -x lint --stacktrace
+./gradlew :app:clean :app:assemble -x lint --stacktrace $CUSTOM_JVM_ARGS

--- a/features/scripts/build_project_module.sh
+++ b/features/scripts/build_project_module.sh
@@ -13,4 +13,4 @@ trap resetGitConfig EXIT
 
 cd $APP_FIXTURE_DIR
 echo "Test fixture used: $APP_FIXTURE_DIR, AGP=$AGP_VERSION, Gradle=$GRADLE_WRAPPER_VERSION"
-./gradlew :module:clean :module:assemble -x lint --stacktrace
+./gradlew :module:clean :module:assemble -x lint --stacktrace $CUSTOM_JVM_ARGS

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -44,6 +44,12 @@ steps %Q{
 }
 end
 
+When("I set the fixture JVM arguments to {string}") do |jvm_args|
+steps %Q{
+  When I set environment variable "CUSTOM_JVM_ARGS" to "#{jvm_args}"
+}
+end
+
 When("I build the failing {string} using the {string} bugsnag config") do |module_config, bugsnag_config|
   Runner.environment["MODULE_CONFIG"] = module_config
   Runner.environment["BUGSNAG_CONFIG"] = bugsnag_config

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -8,14 +8,10 @@ import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.bugsnag.android.gradle.BugsnagInstallJniLibsTask.Companion.resolveBugsnagArtifacts
 import com.bugsnag.android.gradle.internal.BugsnagHttpClientHelper
-import com.bugsnag.android.gradle.internal.BuildServiceBugsnagHttpClientHelper
-import com.bugsnag.android.gradle.internal.GradleVersions
-import com.bugsnag.android.gradle.internal.LegacyBugsnagHttpClientHelper
 import com.bugsnag.android.gradle.internal.UploadRequestClient
 import com.bugsnag.android.gradle.internal.hasDexguardPlugin
 import com.bugsnag.android.gradle.internal.newUploadRequestClientProvider
 import com.bugsnag.android.gradle.internal.register
-import com.bugsnag.android.gradle.internal.versionNumber
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
@@ -58,20 +54,10 @@ class BugsnagPlugin : Plugin<Project> {
                 return@withPlugin
             }
 
-            val canUseBuildService = project.gradle.versionNumber() >= GradleVersions.VERSION_6_1
-            val httpClientHelperProvider = if (canUseBuildService) {
-                project.gradle.sharedServices.registerIfAbsent("bugsnagHttpClientHelper",
-                    BuildServiceBugsnagHttpClientHelper::class.java
-                ) { spec ->
-                    // Provide some parameters
-                    spec.parameters.timeoutMillis.set(bugsnag.requestTimeoutMs)
-                    spec.parameters.retryCount.set(bugsnag.retryCount)
-                }
-            } else {
-                // Reuse instance
-                val client = LegacyBugsnagHttpClientHelper(bugsnag.requestTimeoutMs)
-                project.provider { client }
-            }
+            val httpClientHelperProvider = BugsnagHttpClientHelper.create(
+                project,
+                bugsnag
+            )
 
             val releasesUploadClientProvider = newUploadRequestClientProvider(project, "releases")
             val proguardUploadClientProvider = newUploadRequestClientProvider(project, "proguard")
@@ -231,7 +217,8 @@ class BugsnagPlugin : Plugin<Project> {
                 manifestInfoFileProvider,
                 releasesUploadClientProvider,
                 mappingFilesProvider,
-                symbolFileTaskProvider != null
+                symbolFileTaskProvider != null,
+                httpClientHelperProvider
             )
 
             val releaseAutoUpload = bugsnag.reportBuilds.get()
@@ -371,7 +358,8 @@ class BugsnagPlugin : Plugin<Project> {
         manifestInfoFileProvider: Provider<RegularFile>,
         releasesUploadClientProvider: Provider<out UploadRequestClient>,
         mappingFilesProvider: Provider<FileCollection>?,
-        checkSearchDirectories: Boolean
+        checkSearchDirectories: Boolean,
+        httpClientHelperProvider: Provider<out BugsnagHttpClientHelper>
     ): TaskProvider<out BugsnagReleasesTask> {
         val outputName = taskNameForOutput(output)
         val taskName = "bugsnagRelease${outputName}Task"
@@ -379,6 +367,7 @@ class BugsnagPlugin : Plugin<Project> {
         val requestOutputFile = project.layout.buildDirectory.file(path)
         return BugsnagReleasesTask.register(project, taskName) {
             this.requestOutputFile.set(requestOutputFile)
+            httpClientHelper.set(httpClientHelperProvider)
             retryCount.set(bugsnag.retryCount)
             timeoutMillis.set(bugsnag.requestTimeoutMs)
             failOnUploadError.set(bugsnag.failOnUploadError)

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
@@ -1,14 +1,23 @@
 package com.bugsnag.android.gradle.internal
 
+import com.bugsnag.android.gradle.BugsnagPluginExtension
 import com.bugsnag.android.gradle.internal.BuildServiceBugsnagHttpClientHelper.Params
+import okhttp3.Authenticator
 import okhttp3.OkHttpClient
+import org.gradle.api.Project
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
+import java.net.InetSocketAddress
+import java.net.PasswordAuthentication
+import java.net.Proxy
 import java.time.Duration
 
-/** A simple API for providing a shared [OkHttpClient] instance for shared use in upload tasks. */
+/**
+ * A simple API for providing a shared [OkHttpClient] instance for shared use in upload tasks. This
+ * also handles common shared configuration such as timeouts, proxies, etc.
+ */
 interface BugsnagHttpClientHelper : AutoCloseable {
     val okHttpClient: OkHttpClient
 
@@ -17,15 +26,35 @@ interface BugsnagHttpClientHelper : AutoCloseable {
         okHttpClient.connectionPool.evictAll()
         okHttpClient.cache?.close()
     }
+
+    companion object {
+        fun create(
+            project: Project,
+            bugsnag: BugsnagPluginExtension
+        ): Provider<out BugsnagHttpClientHelper> {
+            val canUseBuildService = project.gradle.versionNumber() >= GradleVersions.VERSION_6_1
+            return if (canUseBuildService) {
+                project.gradle.sharedServices.registerIfAbsent("bugsnagHttpClientHelper",
+                    BuildServiceBugsnagHttpClientHelper::class.java
+                ) { spec ->
+                    // Provide some parameters
+                    spec.parameters.timeoutMillis.set(bugsnag.requestTimeoutMs)
+                }
+            } else {
+                // Reuse instance
+                val client = LegacyBugsnagHttpClientHelper(bugsnag.requestTimeoutMs)
+                project.provider { client }
+            }
+        }
+    }
 }
 
 /** A [BuildService] implementation of [BugsnagHttpClientHelper]. */
-abstract class BuildServiceBugsnagHttpClientHelper
+internal abstract class BuildServiceBugsnagHttpClientHelper
     : BuildService<Params>, BugsnagHttpClientHelper {
 
     interface Params : BuildServiceParameters {
         val timeoutMillis: Property<Long>
-        val retryCount: Property<Int>
     }
 
     override val okHttpClient: OkHttpClient by lazy {
@@ -40,14 +69,38 @@ class LegacyBugsnagHttpClientHelper(
     override val okHttpClient: OkHttpClient by lazy { newClient(timeoutMillis.get()) }
 }
 
+internal class ProxyAuthenticator(val user: String, val pass: String) : java.net.Authenticator() {
+    override fun getPasswordAuthentication() = PasswordAuthentication(user, pass.toCharArray())
+}
+
 internal fun newClient(timeoutMillis: Long): OkHttpClient {
     val timeoutDuration = Duration.ofMillis(timeoutMillis)
-    return OkHttpClient.Builder()
+    val builder = OkHttpClient.Builder()
         .readTimeout(timeoutDuration)
         .writeTimeout(timeoutDuration)
         .connectTimeout(timeoutDuration)
         .callTimeout(Duration.ZERO)
-        .build()
+    configureHttpProxySettings(builder)
+    return builder.build()
+}
+
+private fun configureHttpProxySettings(builder: OkHttpClient.Builder) {
+    val host: String? = System.getProperty("http.proxyHost")
+    val port: String? = System.getProperty("http.proxyPort")
+
+    if (host != null && port != null) { // set the proxy host/port if set
+        val socketAddress = InetSocketAddress("localhost", port.toInt())
+        val proxy = Proxy(Proxy.Type.HTTP, socketAddress)
+        builder.proxy(proxy)
+    }
+
+    val user: String? = System.getProperty("http.proxyUser")
+    val pass: String? = System.getProperty("http.proxyPassword")
+
+    if (user != null && pass != null) { // set the default authenticator if credentials set
+        java.net.Authenticator.setDefault(ProxyAuthenticator("user", "password"))
+        builder.proxyAuthenticator(Authenticator.JAVA_NET_AUTHENTICATOR)
+    }
 }
 
 internal fun runRequestWithRetries(maxRetries: Int, request: () -> String): String {

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
@@ -89,7 +89,7 @@ private fun configureHttpProxySettings(builder: OkHttpClient.Builder) {
     val port: String? = System.getProperty("http.proxyPort")
 
     if (host != null && port != null) { // set the proxy host/port if set
-        val socketAddress = InetSocketAddress("localhost", port.toInt())
+        val socketAddress = InetSocketAddress(host, port.toInt())
         val proxy = Proxy(Proxy.Type.HTTP, socketAddress)
         builder.proxy(proxy)
     }
@@ -98,7 +98,7 @@ private fun configureHttpProxySettings(builder: OkHttpClient.Builder) {
     val pass: String? = System.getProperty("http.proxyPassword")
 
     if (user != null && pass != null) { // set the default authenticator if credentials set
-        java.net.Authenticator.setDefault(ProxyAuthenticator("user", "password"))
+        java.net.Authenticator.setDefault(ProxyAuthenticator(user, password))
         builder.proxyAuthenticator(Authenticator.JAVA_NET_AUTHENTICATOR)
     }
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagHttpClientHelper.kt
@@ -98,7 +98,7 @@ private fun configureHttpProxySettings(builder: OkHttpClient.Builder) {
     val pass: String? = System.getProperty("http.proxyPassword")
 
     if (user != null && pass != null) { // set the default authenticator if credentials set
-        java.net.Authenticator.setDefault(ProxyAuthenticator(user, password))
+        java.net.Authenticator.setDefault(ProxyAuthenticator(user, pass))
         builder.proxyAuthenticator(Authenticator.JAVA_NET_AUTHENTICATOR)
     }
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
@@ -19,6 +19,8 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
@@ -109,8 +111,20 @@ internal fun AppExtension.hasMultipleOutputs(): Boolean {
 /**
  * Returns true if the DexGuard plugin has been applied to the project
  */
-fun Project.hasDexguardPlugin(): Boolean {
+internal fun Project.hasDexguardPlugin(): Boolean {
     return pluginManager.hasPlugin("dexguard")
+}
+
+/** Returns a String provider for a system property. */
+internal fun ProviderFactory.systemPropertyCompat(
+    name: String,
+    gradleVersion: VersionNumber?
+): Provider<String> {
+    return if (gradleVersion != null && gradleVersion >= GradleVersions.VERSION_6_1) {
+        systemProperty(name)
+    } else {
+        provider { System.getProperty(name) }
+    }
 }
 
 /* Borrowed helper functions from the Gradle Kotlin DSL. */
@@ -125,7 +139,7 @@ fun Project.hasDexguardPlugin(): Boolean {
  * @see [ObjectFactory.newInstance]
  */
 @Suppress("SpreadOperator")
-inline fun <reified T : Any> ObjectFactory.newInstance(vararg parameters: Any): T =
+internal inline fun <reified T : Any> ObjectFactory.newInstance(vararg parameters: Any): T =
     newInstance(T::class.javaObjectType, *parameters)
 
 /**


### PR DESCRIPTION
## Goal

Adds support for uploading mapping files with the plugin through a proxy.

This changeset is based off #275 and will add automated test coverage.

## Changeset

- Altered `BugsnagHttpClientHelper` to read the [JVM networking properties](https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html) when creating a new HTTP client
- If `proxyHost/proxyPort` are set, construct a new `Proxy` and set it on `OkHttpClient.Builder#proxy`
- If `proxyUser/proxyPass` are set, create an authenticator and set it on `OkHttpClient.Builder#proxyAuthenticator`

## Tests

Adds E2E scenarios that the plugin can route requests through a local HTTP proxy, with and without credentials.

The test fixture has supplied the proxy information through JVM arguments, rather than in the `gradle.properties`, as this simplifies testing and is functionally equivalent.