### PR TITLE
Fix task ordering for upload task on AGP 3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Fix task ordering for upload task on AGP 3.5
+  [#300](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/300)
+
 ## 5.0.2 (2020-09-10)
 
 * Reword log messages that implied duplicate uploads

--- a/features/abi_apk_splits.feature
+++ b/features/abi_apk_splits.feature
@@ -34,7 +34,6 @@ Scenario: ABI Splits automatic upload disabled
     Then I should receive no requests
 
 @skip_agp4_1_or_higher
-@skip_agp3_5
 Scenario: ABI Splits manual upload of build API
     When I build the "Armeabi-release" variantOutput for "abi_splits" using the "all_disabled" bugsnag config
     And I wait to receive a request

--- a/features/app_bundle.feature
+++ b/features/app_bundle.feature
@@ -1,7 +1,5 @@
 Feature: Generating Android app bundles
 
-# See [PLAT-5038]
-@skip_agp3_5
 Scenario: Single-module default app bundles successfully
     When I bundle "default_app" using the "standard" bugsnag config
     And I wait to receive 2 requests
@@ -14,8 +12,6 @@ Scenario: Single-module default app bundles successfully
       | versionCode | versionName | appId                       | overwrite |
       | 1           | 1.0         | com.bugsnag.android.example | null      |
 
-# See [PLAT-5038]
-@skip_agp3_5
 Scenario: Bundling multiple flavors automatically
     When I bundle "flavors" using the "standard" bugsnag config
     And I wait to receive 4 requests
@@ -30,8 +26,6 @@ Scenario: Bundling multiple flavors automatically
       | 1           | 1.0         | com.bugsnag.android.example.foo |
       | 1           | 1.0         | com.bugsnag.android.example.bar |
 
-# See [PLAT-5038]
-@skip_agp3_5
 Scenario: Bundling single flavor
     When I bundle the "Foo" variantOutput for "flavors" using the "standard" bugsnag config
     And I wait to receive 2 requests
@@ -44,8 +38,6 @@ Scenario: Bundling single flavor
       | versionCode | versionName | appId                           |
       | 1           | 1.0         | com.bugsnag.android.example.foo |
 
-# See [PLAT-5038]
-@skip_agp3_5
 Scenario: Auto upload disabled
     When I bundle "default_app" using the "all_disabled" bugsnag config
     And I wait for 3 seconds

--- a/features/density_abi_splits.feature
+++ b/features/density_abi_splits.feature
@@ -44,7 +44,6 @@ Scenario: Density ABI Splits automatic upload disabled
     Then I should receive no requests
 
 @skip_agp4_1_or_higher
-@skip_agp3_5
 Scenario: Density ABI Splits manual upload of build API
     When I build the "XxxhdpiArmeabi-release" variantOutput for "density_abi_splits" using the "all_disabled" bugsnag config
     And I wait to receive a request

--- a/features/density_splits.feature
+++ b/features/density_splits.feature
@@ -32,7 +32,6 @@ Scenario: Density Splits automatic upload disabled
     Then I should receive no requests
 
 @skip_agp4_1_or_higher
-@skip_agp3_5
 Scenario: Density Splits manual upload of build API
     When I build the "Hdpi-release" variantOutput for "density_splits" using the "all_disabled" bugsnag config
     And I wait to receive a request

--- a/features/flavor_apk_splits.feature
+++ b/features/flavor_apk_splits.feature
@@ -30,7 +30,6 @@ Scenario: Flavor Density Split automatic upload disabled
     Then I should receive no requests
 
 @skip_agp4_1_or_higher
-@skip_agp3_5
 Scenario: Flavor Density Split manual upload of build API
     When I build the "Bar-xxhdpi-release" variantOutput for "flavor_apk_splits" using the "all_disabled" bugsnag config
     And I wait to receive a request

--- a/features/flavors.feature
+++ b/features/flavors.feature
@@ -19,7 +19,6 @@ Scenario: Flavors automatic upload disabled
     And I wait for 5 seconds
     Then I should receive no requests
 
-@skip_agp3_5
 Scenario: Flavors manual upload of build API
     When I build the "Foo-release" variantOutput for "flavors" using the "all_disabled" bugsnag config
     And I wait to receive 1 requests

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -29,14 +29,6 @@ Before('@skip_agp4_1_or_higher') do |scenario|
   skip_this_scenario if is_above_or_equal_to_target(410)
 end
 
-Before('@skip_agp3_5') do |scenario|
-  skip_this_scenario if equals_target(350)
-end
-
-Before('@skip_agp3_6') do |scenario|
-  skip_this_scenario if equals_target(360)
-end
-
 def equals_target(target)
   version = ENV["AGP_VERSION"].slice(0, 5)
   version = version.gsub(".", "")

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -235,14 +235,16 @@ class BugsnagPlugin : Plugin<Project> {
             )
 
             if (shouldUploadMappings(output, bugsnag)) {
-                if (bugsnag.reportBuilds.get()) {
-                    variant.register(project, releaseUploadTask)
+                val releaseAutoUpload = bugsnag.reportBuilds.get()
+                variant.register(project, releaseUploadTask, releaseAutoUpload)
+
+                if (symbolFileTaskProvider != null) {
+                    val ndkAutoUpload = isNdkUploadEnabled(bugsnag, android)
+                    variant.register(project, symbolFileTaskProvider, ndkAutoUpload)
                 }
-                if (symbolFileTaskProvider != null && isNdkUploadEnabled(bugsnag, android)) {
-                    variant.register(project, symbolFileTaskProvider)
-                }
-                if (proguardTaskProvider != null && bugsnag.uploadJvmMappings.get()) {
-                    variant.register(project, proguardTaskProvider)
+                if (proguardTaskProvider != null) {
+                    val jvmAutoUpload = bugsnag.uploadJvmMappings.get()
+                    variant.register(project, proguardTaskProvider, jvmAutoUpload)
                 }
             }
         }

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
@@ -2,13 +2,11 @@
 package com.bugsnag.android.gradle.internal
 
 import com.android.build.gradle.AppExtension
+import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.BaseVariant
 // TODO use the new replacement when min AGP version is 4.0
 import com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
-import com.android.build.gradle.internal.api.ApplicationVariantImpl
-import com.android.build.gradle.internal.scope.TaskContainer as AgpTaskContainer
-import com.android.build.gradle.internal.scope.MutableTaskContainer
 import okio.HashingSink
 import okio.blackholeSink
 import okio.buffer
@@ -64,76 +62,30 @@ internal fun <T: Task> TaskProvider<out T>.dependsOn(vararg tasks: TaskProvider<
 }
 
 /** An alternative to [BaseVariant.register] that accepts a [TaskProvider] input. */
-internal fun BaseVariant.register(project: Project, provider: TaskProvider<out Task>) {
-    val success = when {
-        AgpVersions.CURRENT >= AgpVersions.VERSION_4_0 -> {
-            registerAgp4(provider)
-        }
-        AgpVersions.CURRENT >= AgpVersions.VERSION_3_4 -> {
-            registerAgp3(provider)
-        }
-        else -> false
-    }
-
-    if (!success) {
-        registerManual(project, provider)
-    }
-}
-
-@Suppress("TooGenericExceptionCaught")
-private fun BaseVariant.registerAgp4(provider: TaskProvider<out Task>): Boolean {
-    return try {
-        // This is of type ComponentPropertiesImpl
-        val componentProperties = javaClass.getField("componentProperties")
-            .apply { isAccessible = true }
-            .get(this)
-        val taskContainer = componentProperties.javaClass.getMethod("getTaskContainer")
-            .apply { isAccessible = true }
-            .invoke(componentProperties) as AgpTaskContainer
-        taskContainer.register(provider)
-        true
-    } catch (t: Throwable) {
-        false
-    }
-}
-
-@Suppress("TooGenericExceptionCaught")
-private fun BaseVariant.registerAgp3(provider: TaskProvider<out Task>): Boolean {
-    return try {
-        if (this is ApplicationVariantImpl) {
-            variantData.taskContainer.register(provider)
-        }
-        true
-    } catch (t: Throwable) {
-        false
-    }
-}
-
-private fun AgpTaskContainer.register(provider: TaskProvider<out Task>) {
-    assembleTask.dependsOn(provider)
-    bundleLibraryTask?.dependsOn(provider)
-    if (this is MutableTaskContainer) {
-        bundleTask?.dependsOn(provider)
-    }
-}
-
-private fun BaseVariant.registerManual(project: Project, provider: TaskProvider<out Task>) {
-    assembleProvider.dependsOn(provider)
-    val bundleName = "bundle" + assembleProvider.name.removePrefix("assemble")
-    project.tasks.matching { it.name == bundleName }
-        .configureEach {
-            it.dependsOn(provider)
-        }
-
-    if (AgpVersions.CURRENT.major == AgpVersions.VERSION_3_5.major
-        && AgpVersions.CURRENT.minor == AgpVersions.VERSION_3_5.minor) {
-        // workaround - AGP 3.5.0 executes upload tasks before the package tasks
-        // so we need to manually specify that it must run after the package task
-        // this stops config avoidance for AGP 3.5.0 only
-        project.tasks.matching { it.name.contains("package") }
-            .configureEach { packageTask ->
-                provider.get().mustRunAfter(packageTask)
+internal fun ApkVariant.register(project: Project, provider: TaskProvider<out Task>, autoRunTask: Boolean) {
+    if (autoRunTask) {
+        assembleProvider.dependsOn(provider)
+        val bundleName = "bundle" + assembleProvider.name.removePrefix("assemble")
+        project.tasks.matching { it.name == bundleName }
+            .configureEach { task ->
+                task.dependsOn(provider)
             }
+    }
+
+    provider.configure { task ->
+        // the upload task should always execute after the package task,
+        // but should only run automatically when specified
+        if (autoRunTask) {
+            task.dependsOn(packageApplicationProvider)
+        }
+        task.mustRunAfter(packageApplicationProvider)
+    }
+    packageApplicationProvider.configure {
+        // triggers configuration of the bugsnag upload task so that it runs
+        // automatically when an assemble/bundle task is invoked
+        if (autoRunTask) {
+            provider.get()
+        }
     }
 }
 


### PR DESCRIPTION
## Goal

Fixes the task ordering for the bugsnag upload tasks to enforce that it [must run after](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:ordering_tasks) the package task which produces the APK/AAB. This dependency was not explicitly specified and resulted in the JVM upload task failing with the following exception:

>java.lang.IllegalStateException: Expected file collection to contain exactly one file, however, it contains no files.

This was caused by the fact that the JVM upload task on AGP 3.5 executed before the package task, and so the mapping file was not present. Explicitly adding a task ordering fixes this issue.

## Changeset

- When registering a task in `BugsnagPlugin` pass whether the task has been configured to run automatically to `variant.register()`
- Remove `registerAgp3/registerAgp4` methods as these do not have any function and appear to throw an exception on all tested AGP versions, resulting in a default fallback to `registerManual`
- Wrap existing `registerManual` task dependencies in the `autoRunTask` flag, and configure the upload task to run automatically if required. This follows a similar approach to that taken in #294 

## Testing

Enabled skipped E2E scenarios for AGP 3.5.