### PR TITLE
Generate shared object mapping files in separate class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## TBD
 
+* Generate shared object mapping files in separate class
+  [#304](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/304)
+
 * Separate generation/upload of shared objects into two tasks
   [#303](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/303)
 

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -7,13 +7,13 @@
     <ID>MagicNumber:BugsnagReleasesTask.kt$BugsnagReleasesTask$200</ID>
     <ID>MaxLineLength:BugsnagManifestUuidTask.kt$BugsnagManifestUuidTask$private</ID>
     <ID>SpreadOperator:BugsnagReleasesTask.kt$BugsnagReleasesTask$(*cmd)</ID>
-    <ID>TooGenericExceptionCaught:BugsnagGenerateNdkSoMappingTask.kt$BugsnagGenerateNdkSoMappingTask$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:BugsnagGenerateNdkSoMappingTask.kt$BugsnagGenerateNdkSoMappingTask$ex: Throwable</ID>
     <ID>TooGenericExceptionCaught:BugsnagHttpClientHelper.kt$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:BugsnagManifestUuidTask.kt$BugsnagManifestUuidTask$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:BugsnagMultiPartUploadRequest.kt$BugsnagMultiPartUploadRequest$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:BugsnagReleasesTask.kt$BugsnagReleasesTask$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:MappingFileProvider.kt$exc: Throwable</ID>
+    <ID>TooGenericExceptionCaught:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$ex: Throwable</ID>
     <ID>TooManyFunctions:BugsnagPlugin.kt$BugsnagPlugin$BugsnagPlugin</ID>
   </Whitelist>
 </SmellBaseline>

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
@@ -1,18 +1,12 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.VariantOutput
-import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.ApkVariantOutput
-import com.bugsnag.android.gradle.Abi.Companion.findByName
+import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.GradleVersions
 import com.bugsnag.android.gradle.internal.mapProperty
 import com.bugsnag.android.gradle.internal.register
 import com.bugsnag.android.gradle.internal.versionNumber
-import okio.buffer
-import okio.gzip
-import okio.sink
-import okio.source
-import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
@@ -31,8 +25,6 @@ import org.gradle.api.tasks.PathSensitivity.NONE
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
-import java.io.InputStream
-import java.io.Reader
 import javax.inject.Inject
 
 /**
@@ -110,132 +102,22 @@ sealed class BugsnagGenerateNdkSoMappingTask(
     private fun processFiles(files: Collection<File>) {
         logger.info("Bugsnag: Found shared object files for upload: $files")
 
-        files.forEach { file ->
-            val arch = file.parentFile.name
-            val outputFile = generateSymbolsForSharedObject(file, arch)
+        files.forEach { sharedObjectFile ->
+            val arch = sharedObjectFile.parentFile.name
+            val params = SharedObjectMappingFileFactory.Params(
+                sharedObjectFile,
+                requireNotNull(Abi.findByName(arch)),
+                objDumpPaths.get(),
+                intermediateOutputDir.get().asFile
+            )
+            val outputFile = SharedObjectMappingFileFactory.generateSoMappingFile(project, params)
             if (outputFile != null) {
                 logger.info("Bugsnag: Created symbol file for $arch at $outputFile")
             }
         }
     }
 
-    /**
-     * Uses objdump to create a symbols file for the given shared object file
-     * @param sharedObject the shared object file
-     * @param arch the arch of the file
-     * @return the output file location, or null on error
-     */
-    private fun generateSymbolsForSharedObject(sharedObject: File, arch: String): File? {
-        // Get the path the version of objdump to use to get symbols
-        val objDumpPath = getObjDumpExecutable(arch)
-        val logger = logger
-        if (objDumpPath != null) {
-            val outReader: Reader? = null
-            try {
-                val rootDir = intermediateOutputDir.asFile.get()
-                val archDir = File(rootDir, arch)
-                archDir.mkdir()
-
-                val outputFile = File(archDir, "${sharedObject.name}.gz")
-                val errorOutputFile = File(archDir, "${sharedObject.name}.error.txt")
-                logger.info("Bugsnag: Creating symbol file for ${sharedObject.name} at $outputFile")
-
-                // Call objdump, redirecting output to the output file
-                val builder = ProcessBuilder(objDumpPath.toString(),
-                    "--dwarf=info", "--dwarf=rawline", sharedObject.toString())
-                builder.redirectError(errorOutputFile)
-                val process = builder.start()
-
-                // Output the file to a zip
-                val stdout = process.inputStream
-                outputZipFile(stdout, outputFile)
-                return if (process.waitFor() == 0) {
-                    outputFile
-                } else {
-                    logger.error("Bugsnag: failed to generate symbols for " + arch + " see "
-                        + errorOutputFile.toString() + " for more details")
-                    null
-                }
-            } catch (e: Exception) {
-                logger.error("Bugsnag: failed to generate symbols for " + arch + " " + e.message, e)
-            } finally {
-                outReader?.close()
-            }
-        } else {
-            logger.error("Bugsnag: Unable to upload NDK symbols: Could not find objdump location for $arch")
-        }
-        return null
-    }
-
-    /**
-     * Gets the path to the objdump executable to use to get symbols from a shared object
-     * @param arch The arch of the shared object
-     * @return The objdump executable, or null if not found
-     */
-    private fun getObjDumpExecutable(arch: String): File? {
-        try {
-            val override = getObjDumpOverride(arch)
-            val objDumpFile: File
-            objDumpFile = override?.let { File(it) } ?: findObjDump(project, arch)
-            check((objDumpFile.exists() && objDumpFile.canExecute())) {
-                "Failed to find executable objdump at $objDumpFile"
-            }
-            return objDumpFile
-        } catch (ex: Throwable) {
-            logger.error("Bugsnag: Error attempting to calculate objdump location: " + ex.message)
-        }
-        return null
-    }
-
-    private fun getObjDumpOverride(arch: String): String? {
-        return objDumpPaths.get()[arch]
-    }
-
     companion object {
-        internal const val SO_MAPPING_DIR = "intermediates/bugsnag/soMappings"
-
-        /**
-         * Outputs the contents of stdout into the gzip file output file
-         *
-         * @param stdout The input stream
-         * @param outputFile The output file
-         */
-        private fun outputZipFile(stdout: InputStream, outputFile: File) {
-            stdout.source().use { source ->
-                outputFile.sink().gzip().buffer().use { gzipSink ->
-                    gzipSink.writeAll(source)
-                }
-            }
-        }
-
-        private fun findObjDump(project: Project, arch: String): File {
-            val abi = findByName(arch)
-            val android = project.extensions.getByType(AppExtension::class.java)
-            val ndkDir = android.ndkDirectory.absolutePath
-            val osName = calculateOsName()
-            checkNotNull(abi) { "Failed to find ABI for $arch" }
-            checkNotNull(osName) { "Failed to calculate OS name" }
-            return calculateObjDumpLocation(ndkDir, abi, osName)
-        }
-
-        @JvmStatic
-        fun calculateObjDumpLocation(ndkDir: String?, abi: Abi, osName: String): File {
-            val executable = if (osName.startsWith("windows")) "objdump.exe" else "objdump"
-            return File("$ndkDir/toolchains/${abi.toolchainPrefix}-4.9/prebuilt/" +
-                "$osName/bin/${abi.objdumpPrefix}-$executable")
-        }
-
-        private fun calculateOsName(): String? {
-            return when {
-                Os.isFamily(Os.FAMILY_MAC) -> "darwin-x86_64"
-                Os.isFamily(Os.FAMILY_UNIX) -> "linux-x86_64"
-                Os.isFamily(Os.FAMILY_WINDOWS) -> {
-                    if ("x86" == System.getProperty("os.arch")) "windows" else "windows-x86_64"
-                }
-                else -> null
-            }
-        }
-
         internal fun register(
             project: Project,
             name: String,

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadNdkTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadNdkTask.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android.gradle
 
-import com.bugsnag.android.gradle.BugsnagGenerateNdkSoMappingTask.Companion.SO_MAPPING_DIR
+import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.BugsnagHttpClientHelper
 import com.bugsnag.android.gradle.internal.UploadRequestClient
 import com.bugsnag.android.gradle.internal.md5HashCode

--- a/src/main/kotlin/com/bugsnag/android/gradle/SharedObjectMappingFileFactory.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/SharedObjectMappingFileFactory.kt
@@ -1,0 +1,147 @@
+package com.bugsnag.android.gradle
+
+import com.android.build.gradle.AppExtension
+import okio.buffer
+import okio.gzip
+import okio.sink
+import okio.source
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.Project
+import java.io.File
+import java.io.InputStream
+import java.io.Reader
+
+/**
+ * Generates a mapping file for the supplied shared object file.
+ *
+ * Currently this only supports NDK SO mapping files but in future this will support
+ * other platforms which require different SO mapping support.
+ */
+internal object SharedObjectMappingFileFactory {
+
+    internal const val SO_MAPPING_DIR = "intermediates/bugsnag/soMappings"
+
+    internal data class Params(
+        val sharedObject: File,
+        val abi: Abi,
+        val objDumpPaths: Map<String, String>,
+        val outputDirectory: File
+    )
+
+    /**
+     * Uses objdump to create a symbols file for the given shared object file.
+     *
+     * @param project the gradle project
+     * @param params the parameters required to generate a SO mapping file
+     * @return the output file location, or null on error
+     */
+    fun generateSoMappingFile(project: Project, params: Params): File? {
+        // Get the path the version of objdump to use to get symbols
+        val arch = params.abi.abiName
+        val objDumpPath = getObjDumpExecutable(project, params.objDumpPaths, arch)
+        val logger = project.logger
+        if (objDumpPath != null) {
+            val outReader: Reader? = null
+            try {
+                val rootDir = params.outputDirectory
+                val archDir = File(rootDir, arch)
+                archDir.mkdir()
+
+                val outputName = params.sharedObject.name
+                val outputFile = File(archDir, "$outputName.gz")
+                val errorOutputFile = File(archDir, "$outputName.error.txt")
+                logger.info("Bugsnag: Creating symbol file for $outputName at $outputFile")
+
+                // Call objdump, redirecting output to the output file
+                val builder = ProcessBuilder(objDumpPath.toString(),
+                    "--dwarf=info", "--dwarf=rawline", params.sharedObject.toString())
+                builder.redirectError(errorOutputFile)
+                val process = builder.start()
+
+                // Output the file to a zip
+                val stdout = process.inputStream
+                outputZipFile(stdout, outputFile)
+                return if (process.waitFor() == 0) {
+                    outputFile
+                } else {
+                    logger.error("Bugsnag: failed to generate symbols for $arch " +
+                        "see $errorOutputFile for more details")
+                    null
+                }
+            } catch (e: Exception) {
+                logger.error("Bugsnag: failed to generate symbols for $arch ${e.message}", e)
+            } finally {
+                outReader?.close()
+            }
+        } else {
+            logger.error("Bugsnag: Unable to upload NDK symbols: Could not find objdump location for $arch")
+        }
+        return null
+    }
+
+    /**
+     * Gets the path to the objdump executable to use to get symbols from a shared object
+     * @param arch The arch of the shared object
+     * @return The objdump executable, or null if not found
+     */
+    private fun getObjDumpExecutable(project: Project, objDumpPaths: Map<String, String>, arch: String): File? {
+        try {
+            val override = getObjDumpOverride(objDumpPaths, arch)
+            val objDumpFile: File
+            objDumpFile = override?.let { File(it) } ?: findObjDump(project, arch)
+            check((objDumpFile.exists() && objDumpFile.canExecute())) {
+                "Failed to find executable objdump at $objDumpFile"
+            }
+            return objDumpFile
+        } catch (ex: Throwable) {
+            project.logger.error("Bugsnag: Error attempting to calculate objdump location: " + ex.message)
+        }
+        return null
+    }
+
+    private fun getObjDumpOverride(objDumpPaths: Map<String, String>, arch: String): String? {
+        return objDumpPaths[arch]
+    }
+
+    /**
+     * Outputs the contents of stdout into the gzip file output file
+     *
+     * @param stdout The input stream
+     * @param outputFile The output file
+     */
+    private fun outputZipFile(stdout: InputStream, outputFile: File) {
+        stdout.source().use { source ->
+            outputFile.sink().gzip().buffer().use { gzipSink ->
+                gzipSink.writeAll(source)
+            }
+        }
+    }
+
+    private fun findObjDump(project: Project, arch: String): File {
+        val abi = Abi.findByName(arch)
+        val android = project.extensions.getByType(AppExtension::class.java)
+        val ndkDir = android.ndkDirectory.absolutePath
+        val osName = calculateOsName()
+        checkNotNull(abi) { "Failed to find ABI for $arch" }
+        checkNotNull(osName) { "Failed to calculate OS name" }
+        return calculateObjDumpLocation(ndkDir, abi, osName)
+    }
+
+    @JvmStatic
+    fun calculateObjDumpLocation(ndkDir: String?, abi: Abi, osName: String): File {
+        val executable = if (osName.startsWith("windows")) "objdump.exe" else "objdump"
+        return File("$ndkDir/toolchains/${abi.toolchainPrefix}-4.9/prebuilt/" +
+            "$osName/bin/${abi.objdumpPrefix}-$executable")
+    }
+
+    private fun calculateOsName(): String? {
+        return when {
+            Os.isFamily(Os.FAMILY_MAC) -> "darwin-x86_64"
+            Os.isFamily(Os.FAMILY_UNIX) -> "linux-x86_64"
+            Os.isFamily(Os.FAMILY_WINDOWS) -> {
+                if ("x86" == System.getProperty("os.arch")) "windows" else "windows-x86_64"
+            }
+            else -> null
+        }
+    }
+}

--- a/src/test/kotlin/com/bugsnag/android/gradle/ObjDumpLocationTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/ObjDumpLocationTest.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android.gradle
 
-import com.bugsnag.android.gradle.BugsnagGenerateNdkSoMappingTask.Companion.calculateObjDumpLocation
+import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.calculateObjDumpLocation
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
## Goal

Refactors the generation of shared object mapping files into a separate factory class.

This creates a new class named `SharedObjectMappingFactory` which generates a mapping file for a given shared object. This will make it easier to create different mapping files for NDK vs Unity SO files, and avoids any new Unity Gradle task needing to rely on code within `BugsnagGenerateNdkSoMappingTask`.

The implementation has remained the same with the exception that a `SharedObjectMappingFileFactory.Params` class has been added, and that the architecture is supplied as `Abi` rather than `String`.

## Testing

Relied on existing E2E test coverage as this does not involve any functional changes.