### PR TITLE
Add uploadNdkUnityLibraryMappings flag to bugsnag extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Separate generation/upload of shared objects into two tasks
   [#303](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/303)
+  
+* Add uploadNdkUnityLibraryMappings flag to bugsnag extension
+  [#306](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/306)
 
 ## 5.1.0 (2020-09-17)
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -438,7 +438,18 @@ class BugsnagPlugin : Plugin<Project> {
         }
     }
 
-    private fun isNdkUploadEnabled(bugsnag: BugsnagPluginExtension,
+    /**
+     * Determines whether SO mapping files should be generated for the
+     * libunity.so file in Unity projects.
+     */
+    internal fun isUnityLibraryUploadEnabled(bugsnag: BugsnagPluginExtension,
+                                             android: AppExtension): Boolean {
+        val default = android.aaptOptions.noCompress.contains(".unity3d")
+        return bugsnag.uploadNdkUnityLibraryMappings.getOrElse(default)
+    }
+
+
+    internal fun isNdkUploadEnabled(bugsnag: BugsnagPluginExtension,
         android: AppExtension): Boolean {
         val usesCmake = android.externalNativeBuild.cmake.path != null
         val usesNdkBuild = android.externalNativeBuild.ndkBuild.path != null

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
@@ -34,6 +34,9 @@ open class BugsnagPluginExtension(objects: ObjectFactory) {
     val uploadNdkMappings: Property<Boolean> = objects.property<Boolean>()
         .convention(NULL_BOOLEAN)
 
+    val uploadNdkUnityLibraryMappings: Property<Boolean> = objects.property<Boolean>()
+        .convention(NULL_BOOLEAN)
+
     val reportBuilds: Property<Boolean> = objects.property<Boolean>()
         .convention(true)
 

--- a/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android.gradle
 
+import com.android.build.gradle.AppExtension
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Assert.assertEquals
@@ -41,9 +42,94 @@ class PluginExtensionTest {
             assertEquals(emptyList<File>(), sharedObjectPaths.get())
             assertTrue(uploadJvmMappings.get())
             assertNull(uploadNdkMappings.orNull)
+            assertNull(uploadNdkUnityLibraryMappings.orNull)
             assertNull(sourceControl.repository.orNull)
             assertNull(sourceControl.revision.orNull)
             assertNull(sourceControl.provider.orNull)
         }
+
+        // ndk/unity upload defaults to false
+        val android = proj.extensions.findByType(AppExtension::class.java)!!
+        val plugin = proj.plugins.findPlugin(BugsnagPlugin::class.java)!!
+        assertFalse(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
+        assertFalse(plugin.isNdkUploadEnabled(bugsnag, android))
+    }
+
+    /**
+     * Verifies that the default extension values can be overridden
+     */
+    @Test
+    fun overrideExtensionValues() {
+        val bugsnag = proj.extensions.getByType(BugsnagPluginExtension::class.java)
+
+        // override default values
+        with(bugsnag) {
+            builderName.set("Joe Bloggs")
+            enabled.set(false)
+            failOnUploadError.set(false)
+            overwrite.set(true)
+            reportBuilds.set(false)
+            projectRoot.set("/users/foo")
+            endpoint.set("http://localhost:1234")
+            releasesEndpoint.set("http://localhost:5678")
+            retryCount.set(2)
+            requestTimeoutMs.set(10000)
+            uploadJvmMappings.set(false)
+            uploadNdkMappings.set(true)
+            uploadNdkUnityLibraryMappings.set(true)
+            metadata.set(mapOf(Pair("test", "a")))
+            objdumpPaths.set(mapOf(Pair("armeabi-v7a", "/test/foo")))
+            sharedObjectPaths.set(listOf(File("/test/bar")))
+
+            sourceControl.repository.set("https://github.com")
+            sourceControl.revision.set("d0e98fc")
+            sourceControl.provider.set("github")
+        }
+
+        with(bugsnag) {
+            assertEquals("Joe Bloggs", builderName.get())
+            assertFalse(enabled.get())
+            assertFalse(failOnUploadError.get())
+            assertTrue(overwrite.get())
+            assertFalse(reportBuilds.get())
+            assertEquals("/users/foo", projectRoot.get())
+            assertEquals("http://localhost:1234", endpoint.get())
+            assertEquals("http://localhost:5678", releasesEndpoint.get())
+            assertEquals(2, retryCount.get())
+            assertEquals(10000, requestTimeoutMs.get())
+            assertFalse(uploadJvmMappings.get())
+            assertTrue(uploadNdkMappings.get())
+            assertTrue(uploadNdkUnityLibraryMappings.get())
+            assertEquals(mapOf(Pair("test", "a")), metadata.get())
+            assertEquals(mapOf(Pair("armeabi-v7a", "/test/foo")), objdumpPaths.get())
+            assertEquals(listOf(File("/test/bar")), sharedObjectPaths.get())
+            assertEquals("https://github.com", sourceControl.repository.get())
+            assertEquals("d0e98fc", sourceControl.revision.get())
+            assertEquals("github", sourceControl.provider.get())
+        }
+
+        // ndk/unity upload overridden to true
+        val android = proj.extensions.findByType(AppExtension::class.java)!!
+        val plugin = proj.plugins.findPlugin(BugsnagPlugin::class.java)!!
+        assertTrue(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
+        assertTrue(plugin.isNdkUploadEnabled(bugsnag, android))
+    }
+
+    /**
+     * Verifies that the NDK/Unity heuristics control whether tasks are created
+     */
+    @Test
+    fun uploadHeuristics() {
+        val bugsnag = proj.extensions.getByType(BugsnagPluginExtension::class.java)
+        val android = proj.extensions.findByType(AppExtension::class.java)!!
+        val plugin = proj.plugins.findPlugin(BugsnagPlugin::class.java)!!
+
+        // used to check
+        android.aaptOptions.noCompress.add(".unity3d")
+        android.externalNativeBuild.cmake.path = File("/users/sdk/cmake")
+
+        // ndk/unity upload overridden to true
+        assertTrue(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
+        assertTrue(plugin.isNdkUploadEnabled(bugsnag, android))
     }
 }


### PR DESCRIPTION
## Goal

Adds the `uploadNdkUnityLibraryMappings` flag to the bugsnag plugin extension.

By default this value is null and the plugin will use the presence of `unity.3d` in the `android.aaptOptions.noCompress` collection as evidence that the project is Unity. If a user supplies a property value this will be preferred instead.

## Testing

Added unit tests to verify that the heuristic works correctly. Additional test coverage for overwriting the other properties on the bugsnag plugin extension was also added.