### PR TITLE
Support Unity shared object files in upload task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## TBD
 
+* Support Unity shared object files in upload task
+  [#307](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/307)
+
 * Generate shared object mapping files in separate class
   [#304](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/304)
 

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -85,8 +85,8 @@ Then('{int} requests are valid for the android NDK mapping API and match the fol
   end
 end
 
-Then('{int} requests are valid for the android Unity NDK mapping API and match the following:') do |request_count, data_table|
-  requests = get_android_ndk_mapping_requests
+Then('{int} requests are valid for the android unity NDK mapping API and match the following:') do |request_count, data_table|
+  requests = get_android_unity_ndk_mapping_requests
   assert_equal(request_count, requests.length, 'Wrong number of NDK mapping API requests')
   RequestSetAssertions.assert_requests_match requests, data_table
 
@@ -118,7 +118,7 @@ def valid_android_ndk_mapping_api?(request_body)
   assert_not_nil(request_body['soSymbolFile'])
 end
 
-def valid_android_ndk_mapping_api?(request_body)
+def valid_android_unity_ndk_mapping_api?(request_body)
   valid_mapping_api?(request_body)
   assert_not_nil(request_body['soSymbolTable'])
 end

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -59,18 +59,40 @@ Then('{int} requests are valid for the build API and match the following:') do |
   requests = get_build_requests
   assert_equal(request_count, requests.length, 'Wrong number of build API requests')
   RequestSetAssertions.assert_requests_match requests, data_table
+
+  requests.each do |request|
+    valid_build_api?(request[:body])
+  end
 end
 
 Then('{int} requests are valid for the android mapping API and match the following:') do |request_count, data_table|
   requests = get_android_mapping_requests
   assert_equal(request_count, requests.length, 'Wrong number of mapping API requests')
   RequestSetAssertions.assert_requests_match requests, data_table
+
+  requests.each do |request|
+    valid_android_mapping_api?(request[:body])
+  end
 end
 
 Then('{int} requests are valid for the android NDK mapping API and match the following:') do |request_count, data_table|
   requests = get_android_ndk_mapping_requests
   assert_equal(request_count, requests.length, 'Wrong number of NDK mapping API requests')
   RequestSetAssertions.assert_requests_match requests, data_table
+
+  requests.each do |request|
+    valid_android_ndk_mapping_api?(request[:body])
+  end
+end
+
+Then('{int} requests are valid for the android Unity NDK mapping API and match the following:') do |request_count, data_table|
+  requests = get_android_ndk_mapping_requests
+  assert_equal(request_count, requests.length, 'Wrong number of NDK mapping API requests')
+  RequestSetAssertions.assert_requests_match requests, data_table
+
+  requests.each do |request|
+    valid_android_unity_ndk_mapping_api?(request[:body])
+  end
 end
 
 def valid_build_api?(request_body)
@@ -87,18 +109,22 @@ def valid_build_api?(request_body)
 end
 
 def valid_android_mapping_api?(request_body)
-  assert_equal($api_key, request_body['apiKey'])
+  valid_mapping_api?(request_body)
   assert_not_nil(request_body['proguard'])
-  assert_not_nil(request_body['appId'])
-  assert_not_nil(request_body['versionCode'])
-  assert_not_nil(request_body['buildUUID'])
-  assert_not_nil(request_body['versionName'])
 end
 
-# TODO can avoid duplication
 def valid_android_ndk_mapping_api?(request_body)
-  assert_equal($api_key, request_body['apiKey'])
+  valid_mapping_api?(request_body)
   assert_not_nil(request_body['soSymbolFile'])
+end
+
+def valid_android_ndk_mapping_api?(request_body)
+  valid_mapping_api?(request_body)
+  assert_not_nil(request_body['soSymbolTable'])
+end
+
+def valid_mapping_api?(request_body)
+  assert_equal($api_key, request_body['apiKey'])
   assert_not_nil(request_body['appId'])
   assert_not_nil(request_body['versionCode'])
   assert_not_nil(request_body['buildUUID'])

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -62,4 +62,11 @@ def get_android_ndk_mapping_requests
   end
 end
 
+def get_android_unity_ndk_mapping_requests
+  Server.stored_requests.reject do |request|
+    value = read_key_path(request[:body], 'soSymbolTable')
+    value.nil?
+  end
+end
+
 $api_key = "TEST_API_KEY"

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagMultiPartUploadRequest.kt
@@ -81,12 +81,13 @@ class BugsnagMultiPartUploadRequest(
         }
 
         internal fun <T> from(
-            task: T
+            task: T,
+            endpoint: String = task.endpoint.get()
         ): BugsnagMultiPartUploadRequest where T : DefaultTask, T: BugsnagFileUploadTask {
             return BugsnagMultiPartUploadRequest(
                 failOnUploadError = task.failOnUploadError.get(),
                 overwrite = task.overwrite.get(),
-                endpoint = task.endpoint.get(),
+                endpoint = endpoint,
                 okHttpClient = task.httpClientHelper.get().okHttpClient
             )
         }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -375,13 +375,13 @@ class BugsnagPlugin : Plugin<Project> {
         manifestInfoFileProvider: Provider<RegularFile>,
         ndkUploadClientProvider: Provider<out UploadRequestClient>,
         generateTaskProvider: TaskProvider<out BugsnagGenerateNdkSoMappingTask>
-    ): TaskProvider<out BugsnagUploadNdkTask> {
+    ): TaskProvider<out BugsnagUploadSharedObjectTask> {
         // Create a Bugsnag task to upload NDK mapping file(s)
         val outputName = taskNameForOutput(output)
         val taskName = "uploadBugsnagNdk${outputName}Mapping"
         val path = "intermediates/bugsnag/requests/ndkFor${outputName}.json"
         val requestOutputFile = project.layout.buildDirectory.file(path)
-        return BugsnagUploadNdkTask.register(project, taskName) {
+        return BugsnagUploadSharedObjectTask.register(project, taskName) {
             // upload task requires SO mapping generation to occur first
             this.dependsOn(generateTaskProvider)
             this.requestOutputFile.set(requestOutputFile)
@@ -389,6 +389,7 @@ class BugsnagPlugin : Plugin<Project> {
             httpClientHelper.set(httpClientHelperProvider)
             manifestInfoFile.set(manifestInfoFileProvider)
             uploadRequestClient.set(ndkUploadClientProvider)
+            uploadType.set(BugsnagUploadSharedObjectTask.UploadType.NDK)
             configureWith(bugsnag)
         }
     }


### PR DESCRIPTION
## Goal

Supports uploading shared object mapping files generated from `libunity.so` in the upload task. Note that this does not generate the files themselves and only alters the upload task so that they are sent to the correct endpoint.

## Changeset

- Renamed `BugsnagUploadNdkTask` to `BugsnagUploadSharedObjectTask` as this will be capable of uploading both Unity/NDK SO mapping files
- Added `UploadType` which alters the endpoint/payload of the shared upload request. If the SO file is from the NDK, it will be sent to `/so-symbol` with a key of `soSymbolFile`; otherwise it will be sent to `so-symbol-table` with a key of `soSymbolTable`

## Testing

- Fixed existing mazerunner assertions so that they check whether the payload body of a build/mapping/NDK mapping request is valid
- Added `requests are valid for the android Unity NDK mapping API and match the following:` step which will be used by Unity SO requests once the plugin is capable of generating these mapping files