### PR TITLE
Register unity shared object generation and upload tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## TBD
 
+* Register unity shared object generation and upload tasks
+  [#311](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/311)
+
 * Support Unity shared object files in upload task
   [#307](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/307)
 

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -6,6 +6,7 @@
     <ID>MagicNumber:BugsnagPluginExtension.kt$BugsnagPluginExtension$60000</ID>
     <ID>MagicNumber:BugsnagReleasesTask.kt$BugsnagReleasesTask$200</ID>
     <ID>MaxLineLength:BugsnagManifestUuidTask.kt$BugsnagManifestUuidTask$private</ID>
+    <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ @Suppress("SENSELESS_COMPARISON") internal fun isUnityLibraryUploadEnabled(bugsnag: BugsnagPluginExtension, android: AppExtension): Boolean</ID>
     <ID>SpreadOperator:BugsnagReleasesTask.kt$BugsnagReleasesTask$(*cmd)</ID>
     <ID>TooGenericExceptionCaught:BugsnagHttpClientHelper.kt$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:BugsnagManifestUuidTask.kt$BugsnagManifestUuidTask$exc: Throwable</ID>

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
@@ -2,7 +2,7 @@ package com.bugsnag.android.gradle
 
 import com.android.build.VariantOutput
 import com.android.build.gradle.api.ApkVariantOutput
-import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.SO_MAPPING_DIR
+import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.NDK_SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.GradleVersions
 import com.bugsnag.android.gradle.internal.mapProperty
 import com.bugsnag.android.gradle.internal.register
@@ -28,7 +28,7 @@ import java.io.File
 import javax.inject.Inject
 
 /**
- * Task that generates shared object mapping files for upload to Bugsnag.
+ * Task that generates NDK shared object mapping files for upload to Bugsnag.
  */
 sealed class BugsnagGenerateNdkSoMappingTask(
     objects: ObjectFactory,
@@ -49,7 +49,7 @@ sealed class BugsnagGenerateNdkSoMappingTask(
 
     @get:OutputDirectory
     val intermediateOutputDir: DirectoryProperty = objects.directoryProperty()
-        .convention(projectLayout.buildDirectory.dir(SO_MAPPING_DIR))
+        .convention(projectLayout.buildDirectory.dir(NDK_SO_MAPPING_DIR))
 
     @get:Input
     val objDumpPaths: MapProperty<String, String> = objects.mapProperty()

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
@@ -1,0 +1,66 @@
+package com.bugsnag.android.gradle
+
+import com.android.build.gradle.api.ApkVariantOutput
+import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.UNITY_SO_MAPPING_DIR
+import com.bugsnag.android.gradle.internal.mapProperty
+import com.bugsnag.android.gradle.internal.register
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.NONE
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+import javax.inject.Inject
+
+/**
+ * Task that generates Unity shared object mapping files for upload to Bugsnag.
+ */
+internal open class BugsnagGenerateUnitySoMappingTask @Inject constructor(
+    objects: ObjectFactory,
+    projectLayout: ProjectLayout
+) : DefaultTask(), AndroidManifestInfoReceiver {
+
+    init {
+        group = BugsnagPlugin.GROUP_NAME
+        description = "Generates Unity mapping files for upload to Bugsnag"
+    }
+
+    @get:PathSensitive(NONE)
+    @get:InputFile
+    override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
+
+    @get:Internal
+    internal lateinit var variantOutput: ApkVariantOutput
+
+    @get:Input
+    val objDumpPaths: MapProperty<String, String> = objects.mapProperty()
+
+    @get:OutputDirectory
+    val intermediateOutputDir: DirectoryProperty = objects.directoryProperty()
+        .convention(projectLayout.buildDirectory.dir(UNITY_SO_MAPPING_DIR))
+
+    @TaskAction
+    fun generateMappingFiles() {
+        logger.lifecycle("Generating Unity mapping files")
+        // TODO generate mapping file here
+    }
+
+    companion object {
+        internal fun register(
+            project: Project,
+            name: String,
+            configurationAction: BugsnagGenerateUnitySoMappingTask.() -> Unit
+        ): TaskProvider<out BugsnagGenerateUnitySoMappingTask> {
+            return project.tasks.register(name, configurationAction)
+        }
+    }
+}

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadSharedObjectTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadSharedObjectTask.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android.gradle
 
-import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.SO_MAPPING_DIR
+import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.UNITY_SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.BugsnagHttpClientHelper
 import com.bugsnag.android.gradle.internal.UploadRequestClient
 import com.bugsnag.android.gradle.internal.md5HashCode
@@ -57,7 +57,7 @@ internal open class BugsnagUploadSharedObjectTask @Inject constructor(
 
     init {
         group = BugsnagPlugin.GROUP_NAME
-        description = "Uploads NDK mapping files to Bugsnag"
+        description = "Uploads SO mapping files to Bugsnag"
     }
 
     @get:Internal
@@ -78,7 +78,7 @@ internal open class BugsnagUploadSharedObjectTask @Inject constructor(
 
     @get:InputDirectory
     val intermediateOutputDir: DirectoryProperty = objects.directoryProperty()
-        .convention(projectLayout.buildDirectory.dir(SO_MAPPING_DIR))
+        .convention(projectLayout.buildDirectory.dir(UNITY_SO_MAPPING_DIR))
 
     @get:Input
     override val failOnUploadError: Property<Boolean> = objects.property()

--- a/src/main/kotlin/com/bugsnag/android/gradle/SharedObjectMappingFileFactory.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/SharedObjectMappingFileFactory.kt
@@ -19,7 +19,8 @@ import java.io.Reader
  */
 internal object SharedObjectMappingFileFactory {
 
-    internal const val SO_MAPPING_DIR = "intermediates/bugsnag/soMappings"
+    internal const val NDK_SO_MAPPING_DIR = "intermediates/bugsnag/soMappings/ndk"
+    internal const val UNITY_SO_MAPPING_DIR = "intermediates/bugsnag/soMappings/unity"
 
     internal data class Params(
         val sharedObject: File,


### PR DESCRIPTION
## Goal

Registers Gradle tasks for generating SO mapping files from `libunity.so` and uploading the SO file. Note that this changeset simply registers the tasks and ensures that they run in a Unity project - the actual generation and verification that symbols are uploaded will take place in separate PRs.

## Changeset

- Changed SO mapping files from being output into the intermediate directory `soMappings` to two separate directories for NDK + Unity
- Added `BugsnagGenerateUnitySoMappingTask`, which mimics `BugsnagGenerateNdkSoMappingTask` but at present performs no action for its task
- Added a `BugsnagGenerateUnitySoMappingTask` and `BugsnagUploadUnityTask` for each build variant when `uploadNdkUnityLibraryMappings` is enabled

## Testing

Ran the Unity test fixtures added in #310 with `VERBOSE=true` to confirm that the tasks were run in Unity projects.