### PR TITLE
Generate shared object mapping files for libunity and libil2cpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## TBD
 
+* Generate shared object mapping files for libunity and libil2cpp
+  [#312](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/312)
+
 * Register unity shared object generation and upload tasks
   [#311](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/311)
 

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -7,6 +7,7 @@
     <ID>MagicNumber:BugsnagReleasesTask.kt$BugsnagReleasesTask$200</ID>
     <ID>MaxLineLength:BugsnagManifestUuidTask.kt$BugsnagManifestUuidTask$private</ID>
     <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ @Suppress("SENSELESS_COMPARISON") internal fun isUnityLibraryUploadEnabled(bugsnag: BugsnagPluginExtension, android: AppExtension): Boolean</ID>
+    <ID>ReturnCount:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$ fun generateSoMappingFile(project: Project, params: Params): File?</ID>
     <ID>SpreadOperator:BugsnagReleasesTask.kt$BugsnagReleasesTask$(*cmd)</ID>
     <ID>TooGenericExceptionCaught:BugsnagHttpClientHelper.kt$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:BugsnagManifestUuidTask.kt$BugsnagManifestUuidTask$exc: Throwable</ID>

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -87,7 +87,7 @@ end
 
 Then('{int} requests are valid for the android unity NDK mapping API and match the following:') do |request_count, data_table|
   requests = get_android_unity_ndk_mapping_requests
-  assert_equal(request_count, requests.length, 'Wrong number of NDK mapping API requests')
+  assert_equal(request_count, requests.length, 'Wrong number of android unity NDK mapping API requests')
   RequestSetAssertions.assert_requests_match requests, data_table
 
   requests.each do |request|
@@ -120,7 +120,7 @@ end
 
 def valid_android_unity_ndk_mapping_api?(request_body)
   valid_mapping_api?(request_body)
-  assert_not_nil(request_body['soSymbolTable'])
+  assert_not_nil(request_body['soSymbolTableFile'])
 end
 
 def valid_mapping_api?(request_body)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -66,7 +66,7 @@ end
 
 def get_android_unity_ndk_mapping_requests
   Server.stored_requests.reject do |request|
-    value = read_key_path(request[:body], 'soSymbolTable')
+    value = read_key_path(request[:body], 'soSymbolTableFile')
     value.nil?
   end
 end

--- a/features/unity.feature
+++ b/features/unity.feature
@@ -2,24 +2,37 @@ Feature: Exported Unity project uploads mapping files
 
 Scenario: Unity 2018 exported gradle project uploads JVM/release information
     When I run the script "features/scripts/build_unity_2018.sh" synchronously
-    And I wait to receive 2 requests
+    And I wait to receive 6 requests
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
       | 1              | 1.0        | gradle-android |
 
     And 1 requests are valid for the android mapping API and match the following:
-      | versionCode | versionName | appId                       |
+      | versionCode | versionName | appId               |
       | 1           | 1.0         | com.bugsnag.example |
+
+    And 4 requests are valid for the android unity NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | armeabi-v7a | /\S+/       | libil2cpp.sym    |
+        | armeabi-v7a | /\S+/       | libunity.sym.so  |
+        | x86         | /\S+/       | libil2cpp.sym    |
+        | x86         | /\S+/       | libunity.sym.so  |
 
 Scenario: Unity 2019 exported gradle project uploads JVM/release information
     When I run the script "features/scripts/build_unity_2019.sh" synchronously
-    And I wait to receive 2 requests
+    And I wait to receive 4 requests
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
       | 1              | 1.0        | gradle-android |
 
     And 1 requests are valid for the android mapping API and match the following:
-      | versionCode | versionName | appId                       |
+      | versionCode | versionName | appId               |
       | 1           | 1.0         | com.bugsnag.example |
+
+    # Unity 2019 doesn't contain symbols for x86
+    And 2 requests are valid for the android unity NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
+        | armeabi-v7a | /\S+/       | libunity.sym.so  |

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
@@ -4,6 +4,9 @@ import com.android.build.gradle.api.ApkVariantOutput
 import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.UNITY_SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.mapProperty
 import com.bugsnag.android.gradle.internal.register
+import okio.buffer
+import okio.sink
+import okio.source
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
@@ -12,6 +15,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
@@ -19,6 +23,9 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity.NONE
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
 import javax.inject.Inject
 
 /**
@@ -48,19 +55,135 @@ internal open class BugsnagGenerateUnitySoMappingTask @Inject constructor(
     val intermediateOutputDir: DirectoryProperty = objects.directoryProperty()
         .convention(projectLayout.buildDirectory.dir(UNITY_SO_MAPPING_DIR))
 
+    @get:OutputDirectory
+    val unitySharedObjectDir: DirectoryProperty = objects.directoryProperty()
+        .convention(projectLayout.buildDirectory.dir(UNITY_SO_COPY_DIR))
+
+    @get:InputDirectory
+    val rootProjectDir: DirectoryProperty = objects.directoryProperty()
+
     @TaskAction
     fun generateMappingFiles() {
         logger.lifecycle("Generating Unity mapping files")
-        // TODO generate mapping file here
+
+        // TODO search Unity internal build too
+        val symbolArchives = getUnitySymbolArchives(rootProjectDir)
+        logger.info("Found symbol archives: $symbolArchives")
+
+        if (symbolArchives.isEmpty()) {
+            logger.warn("Bugsnag did not find symbols.zip which is required to fully symbolicate " +
+                "Unity stackframes. Please ensure that symbols.zip generation is enabled in build " +
+                "settings and that it hasn't been removed from the filesystem. See " +
+                "https://docs.unity3d.com/ScriptReference/EditorUserBuildSettings" +
+                "-androidCreateSymbolsZip.html")
+        }
+
+        symbolArchives.forEach { archive ->
+            val copyDir = unitySharedObjectDir.asFile.get()
+            copyDir.mkdirs()
+            val zipFile = ZipFile(archive)
+            val entries = zipFile.entries()
+
+            // extract SO files from archive and generate mapping files for each
+            entries.asSequence()
+                .filter(::isUnitySharedObjectFile)
+                .map { zipEntry ->
+                    extractSoFileFromArchive(zipEntry, copyDir, zipFile)
+                }
+                .forEach { sharedObjectFile ->
+                    generateUnitySoMappingFile(sharedObjectFile)
+                }
+        }
+
+        // TODO check ABI and avoid unnecessary generation
+    }
+
+    private fun generateUnitySoMappingFile(sharedObjectFile: File) {
+        val arch = sharedObjectFile.parentFile.name
+        val params = SharedObjectMappingFileFactory.Params(
+            sharedObjectFile,
+            requireNotNull(Abi.findByName(arch)),
+            objDumpPaths.get(),
+            intermediateOutputDir.get().asFile,
+            SharedObjectMappingFileFactory.SharedObjectType.UNITY
+        )
+        SharedObjectMappingFileFactory.generateSoMappingFile(project, params)
+    }
+
+    private fun extractSoFileFromArchive(
+        entry: ZipEntry,
+        copyDir: File,
+        zipFile: ZipFile
+    ): File {
+        val entryFile = File(entry.name)
+        val sharedObjectName = entryFile.name
+        val arch = entryFile.parentFile.name
+        val archDir = File(copyDir, arch)
+        archDir.mkdir()
+        val dst = File(archDir, sharedObjectName)
+        logger.lifecycle("Copying zip entry $entry to $dst")
+
+        // copy entry to intermediate dir
+        zipFile.getInputStream(entry).use { sharedObjectStream ->
+            val source = sharedObjectStream.source().buffer()
+            val sink = dst.sink()
+            source.readAll(sink)
+        }
+        return dst
+    }
+
+    /**
+     * The directory below the exported symbols. When Unity exports a project to an Android Gradle project
+     * the symbols are exported as an archive in the same directory.
+     *
+     * Unity 2018 exports to <output-dir>/<project-name>/<rootProjectDir>, whereas Unity 2019 exports
+     * to <output-dir>/<rootProjectDir>. As there's no way of distinguishing the two via Gradle
+     * both locations are searched.
+     */
+    private fun getUnitySymbolArchives(rootProjectDir: DirectoryProperty): List<File> {
+        val unity2019ProjectDir = rootProjectDir.get().asFile
+        val unity2018ProjectDir = unity2019ProjectDir.parentFile
+        val files = mutableListOf<File>()
+        files.addAll(getUnitySymbolArchive(unity2019ProjectDir))
+        files.addAll(getUnitySymbolArchive(unity2018ProjectDir))
+        return files
+    }
+
+    private fun getUnitySymbolArchive(projectDir: File): List<File> {
+        val exportDir = projectDir.parentFile
+
+        return exportDir.listFiles()?.filter { file ->
+            val name = file.name
+            val projectName = projectDir.name
+            isUnitySymbolsArchive(name, projectName)
+        } ?: emptyList()
     }
 
     companion object {
+
+        /**
+         * Intermediate path where libunity and other Unity SO files are copied
+         * after being extracted from the Gzip archive
+         */
+        private const val UNITY_SO_COPY_DIR = "intermediates/bugsnag/unitySoFiles"
+
         internal fun register(
             project: Project,
             name: String,
             configurationAction: BugsnagGenerateUnitySoMappingTask.() -> Unit
         ): TaskProvider<out BugsnagGenerateUnitySoMappingTask> {
             return project.tasks.register(name, configurationAction)
+        }
+
+        internal fun isUnitySymbolsArchive(name: String, projectName: String): Boolean {
+            return name.endsWith("symbols.zip") && name.startsWith(projectName)
+        }
+
+        internal fun isUnitySharedObjectFile(entry: ZipEntry): Boolean {
+            val name = entry.name
+            val extensionMatch = name.endsWith(".sym.so") || name.endsWith(".sym")
+            val nameMatch = name.contains("libunity") || name.contains("libil2cpp")
+            return extensionMatch && nameMatch
         }
     }
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
@@ -68,7 +68,6 @@ internal open class BugsnagGenerateUnitySoMappingTask @Inject constructor(
 
         // TODO search Unity internal build too
         val symbolArchives = getUnitySymbolArchives(rootProjectDir)
-        logger.info("Found symbol archives: $symbolArchives")
 
         if (symbolArchives.isEmpty()) {
             logger.warn("Bugsnag did not find symbols.zip which is required to fully symbolicate " +
@@ -76,6 +75,8 @@ internal open class BugsnagGenerateUnitySoMappingTask @Inject constructor(
                 "settings and that it hasn't been removed from the filesystem. See " +
                 "https://docs.unity3d.com/ScriptReference/EditorUserBuildSettings" +
                 "-androidCreateSymbolsZip.html")
+        } else {
+            logger.info("Found symbol archives: $symbolArchives")
         }
 
         symbolArchives.forEach { archive ->

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -413,7 +413,7 @@ class BugsnagPlugin : Plugin<Project> {
             variantOutput = output
             objDumpPaths.set(bugsnag.objdumpPaths)
             manifestInfoFile.set(manifestInfoFileProvider)
-            // TODO update me
+            rootProjectDir.set(project.rootProject.projectDir)
         }
     }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadSharedObjectTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadSharedObjectTask.kt
@@ -1,6 +1,5 @@
 package com.bugsnag.android.gradle
 
-import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.UNITY_SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.BugsnagHttpClientHelper
 import com.bugsnag.android.gradle.internal.UploadRequestClient
 import com.bugsnag.android.gradle.internal.md5HashCode
@@ -10,7 +9,6 @@ import okhttp3.RequestBody.Companion.asRequestBody
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -30,8 +28,7 @@ import javax.inject.Inject
  * Task that uploads shared object mapping files to Bugsnag.
  */
 internal open class BugsnagUploadSharedObjectTask @Inject constructor(
-    objects: ObjectFactory,
-    projectLayout: ProjectLayout
+    objects: ObjectFactory
 ) : DefaultTask(), AndroidManifestInfoReceiver, BugsnagFileUploadTask {
 
     enum class UploadType(private val path: String, val uploadKey: String) {
@@ -78,7 +75,6 @@ internal open class BugsnagUploadSharedObjectTask @Inject constructor(
 
     @get:InputDirectory
     val intermediateOutputDir: DirectoryProperty = objects.directoryProperty()
-        .convention(projectLayout.buildDirectory.dir(UNITY_SO_MAPPING_DIR))
 
     @get:Input
     override val failOnUploadError: Property<Boolean> = objects.property()

--- a/src/test/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTaskTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTaskTest.kt
@@ -1,0 +1,34 @@
+package com.bugsnag.android.gradle
+
+import com.bugsnag.android.gradle.BugsnagGenerateUnitySoMappingTask.Companion.isUnitySharedObjectFile
+import com.bugsnag.android.gradle.BugsnagGenerateUnitySoMappingTask.Companion.isUnitySymbolsArchive
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.zip.ZipEntry
+
+class BugsnagGenerateUnitySoMappingTaskTest {
+
+    @Test
+    fun testIsUnitySymbolsArchive() {
+        assertFalse(isUnitySymbolsArchive("", ""))
+        assertFalse(isUnitySymbolsArchive("foo", "bar"))
+        assertTrue(isUnitySymbolsArchive("symbols.zip", ""))
+        assertFalse(isUnitySymbolsArchive("symbols.zip", "example-project"))
+        assertFalse(isUnitySymbolsArchive("another-project-symbols.zip", "example-project"))
+        assertFalse(isUnitySymbolsArchive("another-project.zip", "example-project"))
+        assertTrue(isUnitySymbolsArchive("example-project-symbols.zip", "example-project"))
+    }
+
+    @Test
+    fun testIsUnitySharedObjectFile() {
+        assertFalse(isUnitySharedObjectFile(ZipEntry("")))
+        assertFalse(isUnitySharedObjectFile(ZipEntry("foo")))
+        assertFalse(isUnitySharedObjectFile(ZipEntry("armeabi-v7a")))
+        assertFalse(isUnitySharedObjectFile(ZipEntry("x86")))
+        assertFalse(isUnitySharedObjectFile(ZipEntry("libsomethingelse.sym")))
+        assertTrue(isUnitySharedObjectFile(ZipEntry("libil2cpp.sym")))
+        assertTrue(isUnitySharedObjectFile(ZipEntry("libunity.sym.so")))
+        assertTrue(isUnitySharedObjectFile(ZipEntry("unity_2019-1.0-v1.symbols/armeabi-v7a/libil2cpp.sym.so")))
+    }
+}


### PR DESCRIPTION
## Goal

Makes `BugsnagGenerateUnitySoMappingTask` generate a shared object mapping file for the `libunity` and `libil2cpp` SO files.

## Changeset

- `BugsnagGenerateUnitySoMappingTask` searches one directory above the project's root directory for Unity symbols. In an [exported Unity project](https://docs.unity3d.com/Manual/android-gradle-overview.html#building-or-exporting-a-gradle-project) the `libunity/libil2cpp` symbols are output in a gzip archive in this directory. (For Unity 2018 this is two directories above due to a different Gradle project structure)
- Searched the gzip archive for `libunity/libil2cpp` entries and copied them to `intermediates/bugsnag/unitySoFiles/<abi>/<so-file>`
- If no gzip archive is found, log a warning
- Added `SharedObjectType` to `SharedObjectMappingFileFactory`, which alters the objdump command used to generate mapping files
- Used `objdump --sym <so file>` to generate SO mapping files for Unity

### Future changes

Several changes are planned as part of this ticket but haven't been included in this PR for ease of review:

- Using grep to reduce SO mapping file size
- Filtering unnecessary archives by ABI
- Searching `Temp/StagingArea/libs` when using Unity's internal build system

## Testing

Added unit tests that verify methods which check whether an SO file/gzip entry are from Unity. Updated existing E2E tests to verify that a SO mapping file is uploaded for each available ABI of `libunity` and `libil2cpp`.
