### PR TITLE
Reduce size of Unity SO mapping files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Generate shared object mapping files for libunity and libil2cpp
   [#312](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/312)
+  [#313](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/313)
 
 * Register unity shared object generation and upload tasks
   [#311](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/311)

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -17,5 +17,6 @@
     <ID>TooGenericExceptionCaught:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$e: Exception</ID>
     <ID>TooGenericExceptionCaught:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$ex: Throwable</ID>
     <ID>TooManyFunctions:BugsnagPlugin.kt$BugsnagPlugin$BugsnagPlugin</ID>
+    <ID>TooManyFunctions:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$SharedObjectMappingFileFactory</ID>
   </Whitelist>
 </SmellBaseline>

--- a/src/test/kotlin/com/bugsnag/android/gradle/SharedObjectMappingFileFactoryTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/SharedObjectMappingFileFactoryTest.kt
@@ -1,0 +1,21 @@
+package com.bugsnag.android.gradle
+
+import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.filterUnitySoLines
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SharedObjectMappingFileFactoryTest {
+
+    @Test
+    fun testUnityLineFilter() {
+        assertFalse(filterUnitySoLines(""))
+        assertFalse(filterUnitySoLines("Some useless metadata"))
+        assertTrue(filterUnitySoLines("SYMBOL TABLE:"))
+        assertTrue(filterUnitySoLines(" F "))
+        assertFalse(filterUnitySoLines("SYMBOL TABLE: *UND*"))
+        assertFalse(filterUnitySoLines(" F *UND*"))
+        assertTrue(filterUnitySoLines("0004e618 l     F .text 00000010 __on_dlclose"))
+        assertFalse(filterUnitySoLines("F *UND* 00000000 __system_property_read00000000"))
+    }
+}


### PR DESCRIPTION
## Goal

Reduces the size of Unity SO mapping files by filtering out unnecessary lines from the output. Specifically, this removes anything that is not a section header or function definition. Any symbols which are undefined are removed also.

This only applies to `libunity/libil2cpp` files as NDK SO files use a different format.

## Testing

Added a unit test to verify line filtering logic. I additionally verified that the SO file generated in the plugin matches the checksum of that generated from `objdump --sym <so file> | grep " F \|SYMBOL TABLE:" | grep -v ”*UND*”`, which confirms that only the unnecessary information has been removed.