### PR TITLE
Create additional E2E scenarios for Unity SO file upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## TBD
 
+* Create additional E2E scenarios for Unity SO file upload
+  [#314](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/314)
+
 * Generate shared object mapping files for libunity and libil2cpp
   [#312](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/312)
 

--- a/features/fixtures/unity_2018/example/build.gradle
+++ b/features/fixtures/unity_2018/example/build.gradle
@@ -57,9 +57,13 @@ android {
         minSdkVersion 16
         targetSdkVersion 29
         applicationId 'com.bugsnag.example'
-        ndk {
-            abiFilters 'armeabi-v7a', 'x86'
+
+        if ("true" != System.env.UNITY_ABI_SPLITS) {
+            ndk {
+                abiFilters 'armeabi-v7a', 'x86'
+            }
         }
+
         versionCode 1
         versionName '1.0'
     }
@@ -101,6 +105,30 @@ android {
         }
         abi {
             enableSplit = true
+        }
+    }
+
+    // conditionally enable ABI splits
+    if ("true" == System.env.UNITY_ABI_SPLITS) {
+        splits {
+            abi {
+                reset()
+                include("armeabi-v7a", "x86_64")
+                universalApk false
+                enable true
+            }
+        }
+    }
+
+    // conditionally enable flavor splits
+    if ("true" == System.env.UNITY_FLAVORS) {
+        flavorDimensions "regular"
+
+        productFlavors {
+            foo {
+            }
+            bar {
+            }
         }
     }
 }

--- a/features/fixtures/unity_2019/launcher/build.gradle
+++ b/features/fixtures/unity_2019/launcher/build.gradle
@@ -75,5 +75,9 @@ if (!System.env.UPDATING_GRADLEW) {
     bugsnag {
         endpoint = "http://localhost:9339"
         releasesEndpoint = "http://localhost:9339"
+
+        if ("false" == System.env.UNITY_SO_UPLOAD) {
+            uploadNdkUnityLibraryMappings = false
+        }
     }
 }

--- a/features/scripts/build_unity_2018_abi_splits.sh
+++ b/features/scripts/build_unity_2018_abi_splits.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+cd features/fixtures/unity_2018/example
+./gradlew clean uploadBugsnagUnityArmeabi-v7a-releaseMapping --stacktrace

--- a/features/scripts/build_unity_2018_flavors.sh
+++ b/features/scripts/build_unity_2018_flavors.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+cd features/fixtures/unity_2018/example
+./gradlew clean assembleFooRelease --stacktrace

--- a/features/scripts/bundle_unity_2019.sh
+++ b/features/scripts/bundle_unity_2019.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+cd features/fixtures/unity_2019
+./gradlew clean bundleRelease --stacktrace

--- a/features/unity.feature
+++ b/features/unity.feature
@@ -1,6 +1,6 @@
 Feature: Exported Unity project uploads mapping files
 
-Scenario: Unity 2018 exported gradle project uploads JVM/release information
+Scenario: Unity 2018 exported gradle project uploads JVM/release/Unity information
     When I run the script "features/scripts/build_unity_2018.sh" synchronously
     And I wait to receive 6 requests
 
@@ -19,7 +19,7 @@ Scenario: Unity 2018 exported gradle project uploads JVM/release information
         | x86         | /\S+/       | libil2cpp.sym    |
         | x86         | /\S+/       | libunity.sym.so  |
 
-Scenario: Unity 2019 exported gradle project uploads JVM/release information
+Scenario: Unity 2019 exported gradle project uploads JVM/release/Unity information
     When I run the script "features/scripts/build_unity_2019.sh" synchronously
     And I wait to receive 4 requests
 
@@ -35,4 +35,65 @@ Scenario: Unity 2019 exported gradle project uploads JVM/release information
     And 2 requests are valid for the android unity NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
         | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
+        | armeabi-v7a | /\S+/       | libunity.sym.so  |
+
+Scenario: Shared object files not uploaded when uploadNdkUnityLibraryMappings set to false
+    When I set environment variable "UNITY_SO_UPLOAD" to "false"
+    And I run the script "features/scripts/build_unity_2019.sh" synchronously
+    And I wait to receive 2 requests
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | versionCode | versionName | appId               |
+        | 1           | 1.0         | com.bugsnag.example |
+
+Scenario: Bundling a Unity project uploads JVM/release/Unity information
+    When I run the script "features/scripts/bundle_unity_2019.sh" synchronously
+    And I wait to receive 4 requests
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | versionCode | versionName | appId               |
+        | 1           | 1.0         | com.bugsnag.example |
+
+# Unity 2019 doesn't contain symbols for x86
+    And 2 requests are valid for the android unity NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
+        | armeabi-v7a | /\S+/       | libunity.sym.so  |
+
+Scenario: Building a Unity product flavor uploads Unity SO files
+    When I set environment variable "UNITY_FLAVORS" to "true"
+    When I run the script "features/scripts/build_unity_2018_flavors.sh" synchronously
+    And I wait to receive 6 requests
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | versionCode | versionName | appId               |
+        | 1           | 1.0         | com.bugsnag.example |
+
+    And 4 requests are valid for the android unity NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | armeabi-v7a | /\S+/       | libil2cpp.sym    |
+        | armeabi-v7a | /\S+/       | libunity.sym.so  |
+        | x86         | /\S+/       | libil2cpp.sym    |
+        | x86         | /\S+/       | libunity.sym.so  |
+
+Scenario: Building a Unity product flavor uploads Unity SO files
+    When I set environment variable "UNITY_ABI_SPLITS" to "true"
+    When I run the script "features/scripts/build_unity_2018_abi_splits.sh" synchronously
+    And I wait to receive 2 requests
+
+    And 2 requests are valid for the android unity NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | armeabi-v7a | /\S+/       | libil2cpp.sym    |
         | armeabi-v7a | /\S+/       | libunity.sym.so  |

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
@@ -1,8 +1,10 @@
 @file:Suppress("MatchingDeclarationName", "TooManyFunctions") // This file contains multiple top-level members
 package com.bugsnag.android.gradle.internal
 
+import com.android.build.VariantOutput
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.ApkVariant
+import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.BaseVariant
 // TODO use the new replacement when min AGP version is 4.0
@@ -111,6 +113,14 @@ internal fun AppExtension.hasMultipleOutputs(): Boolean {
  */
 fun Project.hasDexguardPlugin(): Boolean {
     return pluginManager.hasPlugin("dexguard")
+}
+
+/**
+ * Returns true if an APK variant output includes SO files for the given ABI.
+ */
+internal fun ApkVariantOutput.includesAbi(abi: String): Boolean {
+    val splitArch = getFilter(VariantOutput.FilterType.ABI)
+    return splitArch == null || abi == splitArch
 }
 
 /* Borrowed helper functions from the Gradle Kotlin DSL. */


### PR DESCRIPTION
## Goal

Adds additional E2E mazerunner scenarios that test Unity SO file upload.

## Changeset

- Altered `BugsnagGenerateUnitySoMappingTask` so that for APK splits mapping files are only generated for the supported ABI
- Added scenario to verify that setting `uploadNdkUnityLibraryMappings` to false disables the Unity SO upload task
- Added scenario that verifies uploads occur when an App Bundle is generated
- Added scenario that tests uploads in a fixture with product flavors
- Added scenario that tests uploads in a fixture using APK splits, where the Unity upload task is invoked manually

