### PR TITLE
Support Unity builds using internal Gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Generate shared object mapping files for libunity and libil2cpp
   [#312](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/312)
   [#313](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/313)
+  [#315](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/315)
 
 * Register unity shared object generation and upload tasks
   [#311](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/311)

--- a/src/test/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTaskTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTaskTest.kt
@@ -5,7 +5,6 @@ import com.bugsnag.android.gradle.BugsnagGenerateUnitySoMappingTask.Companion.is
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.util.zip.ZipEntry
 
 class BugsnagGenerateUnitySoMappingTaskTest {
 
@@ -22,13 +21,14 @@ class BugsnagGenerateUnitySoMappingTaskTest {
 
     @Test
     fun testIsUnitySharedObjectFile() {
-        assertFalse(isUnitySharedObjectFile(ZipEntry("")))
-        assertFalse(isUnitySharedObjectFile(ZipEntry("foo")))
-        assertFalse(isUnitySharedObjectFile(ZipEntry("armeabi-v7a")))
-        assertFalse(isUnitySharedObjectFile(ZipEntry("x86")))
-        assertFalse(isUnitySharedObjectFile(ZipEntry("libsomethingelse.sym")))
-        assertTrue(isUnitySharedObjectFile(ZipEntry("libil2cpp.sym")))
-        assertTrue(isUnitySharedObjectFile(ZipEntry("libunity.sym.so")))
-        assertTrue(isUnitySharedObjectFile(ZipEntry("unity_2019-1.0-v1.symbols/armeabi-v7a/libil2cpp.sym.so")))
+        assertFalse(isUnitySharedObjectFile(""))
+        assertFalse(isUnitySharedObjectFile("foo"))
+        assertFalse(isUnitySharedObjectFile("armeabi-v7a"))
+        assertFalse(isUnitySharedObjectFile("x86"))
+        assertFalse(isUnitySharedObjectFile("libsomethingelse.sym"))
+        assertFalse(isUnitySharedObjectFile("libunity.so"))
+        assertTrue(isUnitySharedObjectFile("libil2cpp.sym"))
+        assertTrue(isUnitySharedObjectFile("libunity.sym.so"))
+        assertTrue(isUnitySharedObjectFile("unity_2019-1.0-v1.symbols/armeabi-v7a/libil2cpp.sym.so"))
     }
 }


### PR DESCRIPTION
## Goal

It's possible to build a Unity project either by exporting symbols to an archive, which is supported, or by using [Unity's internal Gradle build](https://docs.unity3d.com/Manual/android-gradle-overview.html). This changeset adds support for uploading Unity SO mapping files for the second use case.

## Changeset

- Searched the `Temp/StagingArea/symbols` directory for `libunity/libil2cpp` SO files
- Generated SO mapping files using the symbols in the `Temp/StagingArea/symbols` directory

## Testing

Manually tested on a Unity 2018 and 2019 example project and confirmed that a SO mapping file was generated in the appropriate build directory. Due to the nature of the change E2E tests were not seen as feasible on CI for now and manual testing was agreed as part of the design.