### PR TITLE
Remove previous files from intermediate build directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## TBD
 
+* Remove previous files from intermediate build directory
+  [#318](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/318)
+
 * Automatically search for NDK shared object files in unity projects
   [#316](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/316)
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.gradle
 import com.android.build.gradle.api.ApkVariantOutput
 import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.NDK_SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.GradleVersions
+import com.bugsnag.android.gradle.internal.clearDir
 import com.bugsnag.android.gradle.internal.includesAbi
 import com.bugsnag.android.gradle.internal.mapProperty
 import com.bugsnag.android.gradle.internal.register
@@ -95,6 +96,8 @@ sealed class BugsnagGenerateNdkSoMappingTask(
 
     private fun processFiles(files: Collection<File>) {
         logger.info("Bugsnag: Found shared object files for upload: $files")
+        val outputDir = intermediateOutputDir.get().asFile
+        outputDir.clearDir()
 
         files.forEach { sharedObjectFile ->
             val arch = sharedObjectFile.parentFile.name
@@ -102,7 +105,7 @@ sealed class BugsnagGenerateNdkSoMappingTask(
                 sharedObjectFile,
                 requireNotNull(Abi.findByName(arch)),
                 objDumpPaths.get(),
-                intermediateOutputDir.get().asFile
+                outputDir
             )
             val outputFile = SharedObjectMappingFileFactory.generateSoMappingFile(project, params)
             if (outputFile != null) {

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
@@ -88,6 +88,7 @@ sealed class BugsnagGenerateNdkSoMappingTask(
             searchDirectory.walkTopDown()
                 .onEnter { archDir -> variantOutput.includesAbi(archDir.name) }
                 .filter { file -> file.extension == "so" }
+                .filter { !IGNORED_SO_FILES.contains(it.name) }
                 .toSet()
         } else {
             emptySet()
@@ -115,6 +116,13 @@ sealed class BugsnagGenerateNdkSoMappingTask(
     }
 
     companion object {
+
+        /**
+         * SO files which should be ignored by the NDK upload task. These are Unity
+         * library SO files and are handled by the Unity upload task.
+         */
+        internal val IGNORED_SO_FILES = listOf("libunity.so", "libil2cpp.so", "libmain.so")
+
         internal fun register(
             project: Project,
             name: String,

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.ApkVariantOutput
 import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.UNITY_SO_MAPPING_DIR
+import com.bugsnag.android.gradle.internal.clearDir
 import com.bugsnag.android.gradle.internal.includesAbi
 import com.bugsnag.android.gradle.internal.mapProperty
 import com.bugsnag.android.gradle.internal.register
@@ -69,6 +70,10 @@ internal open class BugsnagGenerateUnitySoMappingTask @Inject constructor(
         // search the internal Gradle build + exported Gradle build locations
         val symbolArchives = getUnitySymbolArchives(rootProjectDir)
         val copyDir = unitySharedObjectDir.asFile.get()
+        val outputDir = intermediateOutputDir.asFile.get()
+        copyDir.clearDir()
+        outputDir.clearDir()
+
         val sharedObjectFiles = copySoFilesFromBuildDir(copyDir).toMutableList()
 
         if (symbolArchives.isEmpty() && sharedObjectFiles.isEmpty()) {

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
@@ -137,6 +137,14 @@ internal fun ProviderFactory.systemPropertyCompat(
     }
 }
 
+/**
+ * Clears a directory of any files it contains.
+ */
+internal fun File.clearDir() {
+    deleteRecursively()
+    mkdir()
+}
+
 /* Borrowed helper functions from the Gradle Kotlin DSL. */
 
 /**


### PR DESCRIPTION
## Goal

Removes previous files from an intermediate build directory, which could cause erroneous uploads if a SO file had been moved on the filesystem. Additionally this changeset prevents `libunity.so`, `libil2cpp.so`, and `libmain.so` from being 

## Changeset

The gradle plugin copies SO files to an intermediate build directory to take advantage of gradle's task caching.

If a build occured, an SO file was removed/renamed in the project, and then another build occurred, the removed/renamed SO file incorrectly remains in the build directory and is uploaded. The fix for this is to clear out the directory when running the task, which is done for both the Unity/NDK generation tasks.

Additionally, the `BugsnagGenerateNdkSoMappingTask` tries to generate NDK mapping files for `libunity/libmain/libil2cpp`, which have been ignored to avoid spamming the build log with the following warning:

>Bugsnag: Skipping upload of empty/invalid mapping file: intermediates/bugsnag/soMappings/ndk/armeabi-v7a/libunity.so.gz

## Testing

Manually verified that no warning is present in the build log, and that only the relevant files are copied to the intermediate directory on a build that uses cache.