### PR TITLE
Ensure libil2cpp has correct file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## TBD
 
+* Ensure libil2cpp has correct file extension
+  [#320](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/320)
+
 * Remove previous files from intermediate build directory
   [#318](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/318)
 

--- a/features/unity.feature
+++ b/features/unity.feature
@@ -19,9 +19,9 @@ Scenario: Unity 2018 exported gradle project uploads JVM/release/Unity informati
 
     And 4 requests are valid for the android unity NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
-        | armeabi-v7a | /\S+/       | libil2cpp.sym    |
+        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
         | armeabi-v7a | /\S+/       | libunity.sym.so  |
-        | x86         | /\S+/       | libil2cpp.sym    |
+        | x86         | /\S+/       | libil2cpp.sym.so |
         | x86         | /\S+/       | libunity.sym.so  |
 
 Scenario: Unity 2019 exported gradle project uploads JVM/release/Unity information
@@ -101,9 +101,9 @@ Scenario: Building a Unity product flavor uploads Unity SO files
 
     And 4 requests are valid for the android unity NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
-        | armeabi-v7a | /\S+/       | libil2cpp.sym    |
+        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
         | armeabi-v7a | /\S+/       | libunity.sym.so  |
-        | x86         | /\S+/       | libil2cpp.sym    |
+        | x86         | /\S+/       | libil2cpp.sym.so |
         | x86         | /\S+/       | libunity.sym.so  |
 
 Scenario: Building a Unity product flavor uploads Unity SO files
@@ -113,5 +113,5 @@ Scenario: Building a Unity product flavor uploads Unity SO files
 
     And 2 requests are valid for the android unity NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
-        | armeabi-v7a | /\S+/       | libil2cpp.sym    |
+        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
         | armeabi-v7a | /\S+/       | libunity.sym.so  |

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
@@ -137,7 +137,11 @@ internal open class BugsnagGenerateUnitySoMappingTask @Inject constructor(
     }
 
     private fun copySoFile(sharedObjectFile: File, copyDir: File, src: BufferedSource): File? {
-        val sharedObjectName = sharedObjectFile.name
+        // append .so extension if not already present (required for pipeline symbolication)
+        val sharedObjectName = when (sharedObjectFile.extension) {
+            "so" -> sharedObjectFile.name
+            else -> "${sharedObjectFile.name}.so"
+        }
         val arch = sharedObjectFile.parentFile.name
 
         // avoid generating unnecessary symbols


### PR DESCRIPTION
## Goal

The `libil2cpp.sym` file is currently uploaded without a `.so` extension which prevents the pipeline from symbolicating the frames correctly. This change adds the correct extension to the file if it is missing.

## Testing

Manually verified symbolication in a Unity 2018 example app, updated E2E assertions.