### PR TITLE
JNI install task should always takes place if NDK build enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* JNI install task should always takes place if NDK build enabled
+  [#323](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/323)
+
 ## 5.2.0 (2020-09-22)
 
 * Support mapping upload from Android Gradle Plugin through a proxy

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -115,7 +115,7 @@ class BugsnagPlugin : Plugin<Project> {
                         ndkUploadClientProvider
                     )
                 }
-                registerNdkLibInstallTask(project, bugsnag, android)
+                registerNdkLibInstallTask(project)
             }
         }
     }
@@ -126,11 +126,7 @@ class BugsnagPlugin : Plugin<Project> {
         return variant.variantEnabled ?: true
     }
 
-    private fun registerNdkLibInstallTask(
-        project: Project,
-        bugsnag: BugsnagPluginExtension,
-        android: AppExtension
-    ) {
+    private fun registerNdkLibInstallTask(project: Project) {
         val ndkTasks = project.tasks.withType(ExternalNativeBuildTask::class.java)
         val cleanTasks = ndkTasks.filter { it.name.contains(CLEAN_TASK) }.toSet()
         val buildTasks = ndkTasks.filter { !it.name.contains(CLEAN_TASK) }.toSet()
@@ -141,13 +137,8 @@ class BugsnagPlugin : Plugin<Project> {
                 val files = resolveBugsnagArtifacts(project)
                 bugsnagArtifacts.from(files)
             }
-
-            if (isNdkUploadEnabled(bugsnag, android)) {
-                ndkSetupTask.configure {
-                    it.mustRunAfter(cleanTasks)
-                }
-                buildTasks.forEach { it.dependsOn(ndkSetupTask) }
-            }
+            ndkSetupTask.configure { it.mustRunAfter(cleanTasks) }
+            buildTasks.forEach { it.dependsOn(ndkSetupTask) }
         }
     }
 


### PR DESCRIPTION
## Goal

In v4 of the plugin the `BugsnagInstallJniLibsTask` always ran if the NDK build was active, as users may need to copy bugsnag's SO files to their build directory so that they can link against them. v5 introduced a bug where this was gated behind the `uploadNdkMappings` flag - this changeset corrects this change so that the user's project is always able to link against the 

## Testing

Manually verified in an example app that the task runs regardless of the value of `uploadNdkMappings`. E2E tests were not considered practical as there aren't any existing steps to address this, and the functionality of copying SO files will soon be superseded by improvements to AGP's support for external native dependencies (PLAT-3171)