### PR TITLE
Add uploadReactNativeMappings flag to plugin extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Add uploadReactNativeMappings flag to plugin extension
+  [#327](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/327)
+
 ## 5.3.0 (2020-10-15)
 
 * Ensure libil2cpp has correct file extension

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -560,6 +560,14 @@ class BugsnagPlugin : Plugin<Project> {
         return bugsnag.uploadNdkMappings.getOrElse(default)
     }
 
+    internal fun isReactNativeUploadEnabled(
+        project: Project,
+        bugsnag: BugsnagPluginExtension
+    ): Boolean {
+        val hasReact = project.extensions.extraProperties.has("react")
+        return bugsnag.uploadReactNativeMappings.getOrElse(hasReact)
+    }
+
     /**
      * Gets the directories which should be searched for NDK shared objects.
      * By default this is set to an empty list, and paths set by the user

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
@@ -37,6 +37,9 @@ open class BugsnagPluginExtension(objects: ObjectFactory) {
     val uploadNdkUnityLibraryMappings: Property<Boolean> = objects.property<Boolean>()
         .convention(NULL_BOOLEAN)
 
+    val uploadReactNativeMappings: Property<Boolean> = objects.property<Boolean>()
+        .convention(NULL_BOOLEAN)
+
     val reportBuilds: Property<Boolean> = objects.property<Boolean>()
         .convention(true)
 

--- a/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
@@ -43,6 +43,7 @@ class PluginExtensionTest {
             assertTrue(uploadJvmMappings.get())
             assertNull(uploadNdkMappings.orNull)
             assertNull(uploadNdkUnityLibraryMappings.orNull)
+            assertNull(uploadReactNativeMappings.orNull)
             assertNull(sourceControl.repository.orNull)
             assertNull(sourceControl.revision.orNull)
             assertNull(sourceControl.provider.orNull)
@@ -53,6 +54,7 @@ class PluginExtensionTest {
         val plugin = proj.plugins.findPlugin(BugsnagPlugin::class.java)!!
         assertFalse(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
         assertFalse(plugin.isNdkUploadEnabled(bugsnag, android))
+        assertFalse(plugin.isReactNativeUploadEnabled(proj, bugsnag))
         assertEquals(emptyList<File>(), plugin.getSharedObjectSearchPaths(proj, bugsnag, android))
     }
 
@@ -78,6 +80,7 @@ class PluginExtensionTest {
             uploadJvmMappings.set(false)
             uploadNdkMappings.set(true)
             uploadNdkUnityLibraryMappings.set(true)
+            uploadReactNativeMappings.set(true)
             metadata.set(mapOf(Pair("test", "a")))
             objdumpPaths.set(mapOf(Pair("armeabi-v7a", "/test/foo")))
             sharedObjectPaths.set(listOf(File("/test/bar")))
@@ -114,6 +117,7 @@ class PluginExtensionTest {
         val plugin = proj.plugins.findPlugin(BugsnagPlugin::class.java)!!
         assertTrue(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
         assertTrue(plugin.isNdkUploadEnabled(bugsnag, android))
+        assertTrue(plugin.isReactNativeUploadEnabled(proj, bugsnag))
         val expected = listOf(
             File("/test/bar"),
             File(proj.projectDir, "src/main/jniLibs"),
@@ -143,6 +147,17 @@ class PluginExtensionTest {
             File(proj.rootDir, "unityLibrary/src/main/jniLibs")
         )
         assertEquals(expected, plugin.getSharedObjectSearchPaths(proj, bugsnag, android))
+    }
+
+    /**
+     * Verifies that the React Native heuristics control whether tasks are created
+     */
+    @Test
+    fun reactNativeUploadHeuristics() {
+        val bugsnag = proj.extensions.getByType(BugsnagPluginExtension::class.java)
+        val plugin = proj.plugins.findPlugin(BugsnagPlugin::class.java)!!
+        proj.extensions.extraProperties.set("react", "some value")
+        assertTrue(plugin.isReactNativeUploadEnabled(proj, bugsnag))
     }
 
     /**


### PR DESCRIPTION
## Goal

Adds the `uploadReactNativeMappings` flag to the plugin extension. This will be used to check whether a project is React Native or not, which will be used to trigger registration of tasks that upload source maps.

## Changeset

- Checked `project.ext.react` as a heuristic to determine whether React Native is in use
- Added `uploadReactNativeMappings` to the plugin extension
- Added tests cases for the different values `uploadReactNativeMappings` can be set to