### PR TITLE
Create BugsnagUploadJsSourceMapTask and register for build variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## TBD
 
+* Create BugsnagUploadJsSourceMapTask and register for build variants
+  [#330](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/330)
+
 * Add uploadReactNativeMappings flag to plugin extension
   [#327](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/327)
 

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -3,10 +3,12 @@
   <Blacklist></Blacklist>
   <Whitelist>
     <ID>ComplexCondition:AndroidManifestParser.kt$AndroidManifestParser$apiKey == null || "" == apiKey || versionCode == null || buildUUID == null || versionName == null || applicationId == null</ID>
+    <ID>ComplexCondition:BugsnagPlugin.kt$BugsnagPlugin$!jvmMinificationEnabled &amp;&amp; !ndkEnabled &amp;&amp; !unityEnabled &amp;&amp; !reactNativeEnabled</ID>
     <ID>MagicNumber:BugsnagPluginExtension.kt$BugsnagPluginExtension$60000</ID>
     <ID>MagicNumber:BugsnagReleasesTask.kt$BugsnagReleasesTask$200</ID>
     <ID>MaxLineLength:BugsnagManifestUuidTask.kt$BugsnagManifestUuidTask$private</ID>
     <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ @Suppress("SENSELESS_COMPARISON") internal fun isUnityLibraryUploadEnabled( bugsnag: BugsnagPluginExtension, android: AppExtension ): Boolean</ID>
+    <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ private fun registerUploadSourceMapTask( project: Project, variant: ApkVariant, output: ApkVariantOutput, manifestInfoFileProvider: Provider&lt;RegularFile&gt; ): TaskProvider&lt;out BugsnagUploadJsSourceMapTask&gt;?</ID>
     <ID>ReturnCount:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$ fun generateSoMappingFile(project: Project, params: Params): File?</ID>
     <ID>SpreadOperator:BugsnagReleasesTask.kt$BugsnagReleasesTask$(*cmd)</ID>
     <ID>TooGenericExceptionCaught:BugsnagHttpClientHelper.kt$exc: Throwable</ID>

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -385,7 +385,7 @@ class BugsnagPlugin : Plugin<Project> {
     ): TaskProvider<out BugsnagUploadJsSourceMapTask>? {
         val outputName = taskNameForOutput(output)
         val taskName = "uploadBugsnag${outputName}SourceMaps"
-        val path = "intermediates/bugsnag/requests/sourceMapFor${outputName}"
+        val path = "intermediates/bugsnag/requests/sourceMapFor$outputName"
         val requestOutputFileProvider = project.layout.buildDirectory.file(path)
 
         // lookup the react-native task by its name

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -176,9 +176,11 @@ class BugsnagPlugin : Plugin<Project> {
             val jvmMinificationEnabled = project.isJvmMinificationEnabled(variant)
             val ndkEnabled = isNdkUploadEnabled(bugsnag, android)
             val unityEnabled = isUnityLibraryUploadEnabled(bugsnag, android)
+            // TODO check variant extras for RN defined tasks as well
+            val reactNativeEnabled = isReactNativeUploadEnabled(project, bugsnag)
 
             // skip tasks for variant if JVM/NDK/Unity minification not enabled
-            if (!jvmMinificationEnabled && !ndkEnabled && !unityEnabled) {
+            if (!jvmMinificationEnabled && !ndkEnabled && !unityEnabled && !reactNativeEnabled) {
                 return@configureEach
             }
 
@@ -248,6 +250,16 @@ class BugsnagPlugin : Plugin<Project> {
                 else -> null
             }
 
+            val uploadSourceMapProvider = when {
+                reactNativeEnabled -> registerUploadSourceMapTask(
+                    project,
+                    variant,
+                    output,
+                    manifestInfoFileProvider
+                )
+                else -> null
+            }
+
             val releaseUploadTask = registerReleasesUploadTask(
                 project,
                 variant,
@@ -274,6 +286,9 @@ class BugsnagPlugin : Plugin<Project> {
             if (proguardTaskProvider != null) {
                 val jvmAutoUpload = bugsnag.uploadJvmMappings.get()
                 variant.register(project, proguardTaskProvider, jvmAutoUpload)
+            }
+            if (uploadSourceMapProvider != null) {
+                variant.register(project, uploadSourceMapProvider, reactNativeEnabled)
             }
         }
     }
@@ -357,6 +372,31 @@ class BugsnagPlugin : Plugin<Project> {
                 mappingFileProperty.from(it)
             }
             configureWith(bugsnag)
+        }
+    }
+
+    /**
+     * Creates a bugsnag task to upload JS source maps
+     */
+    private fun registerUploadSourceMapTask(
+        project: Project,
+        variant: ApkVariant,
+        output: ApkVariantOutput,
+        manifestInfoFileProvider: Provider<RegularFile>
+    ): TaskProvider<out BugsnagUploadJsSourceMapTask> {
+        val outputName = taskNameForOutput(output)
+        val taskName = "uploadBugsnag${outputName}SourceMaps"
+        val path = "intermediates/bugsnag/requests/sourceMapFor${outputName}"
+        val requestOutputFileProvider = project.layout.buildDirectory.file(path)
+
+//        variant.
+
+        return project.tasks.register<BugsnagUploadJsSourceMapTask>(taskName) {
+            requestOutputFile.set(requestOutputFileProvider)
+            manifestInfoFile.set(manifestInfoFileProvider)
+            // TODO set properties from variant
+//            bundleJsFile.set()
+//            sourceMapFile.set()
         }
     }
 
@@ -572,7 +612,8 @@ class BugsnagPlugin : Plugin<Project> {
         project: Project,
         bugsnag: BugsnagPluginExtension
     ): Boolean {
-        val hasReact = project.extensions.extraProperties.has("react")
+        val props = project.extensions.extraProperties
+        val hasReact = props.has("react")
         return bugsnag.uploadReactNativeMappings.getOrElse(hasReact)
     }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -176,7 +176,6 @@ class BugsnagPlugin : Plugin<Project> {
             val jvmMinificationEnabled = project.isJvmMinificationEnabled(variant)
             val ndkEnabled = isNdkUploadEnabled(bugsnag, android)
             val unityEnabled = isUnityLibraryUploadEnabled(bugsnag, android)
-            // TODO check variant extras for RN defined tasks as well
             val reactNativeEnabled = isReactNativeUploadEnabled(project, bugsnag)
 
             // skip tasks for variant if JVM/NDK/Unity minification not enabled
@@ -383,20 +382,30 @@ class BugsnagPlugin : Plugin<Project> {
         variant: ApkVariant,
         output: ApkVariantOutput,
         manifestInfoFileProvider: Provider<RegularFile>
-    ): TaskProvider<out BugsnagUploadJsSourceMapTask> {
+    ): TaskProvider<out BugsnagUploadJsSourceMapTask>? {
         val outputName = taskNameForOutput(output)
         val taskName = "uploadBugsnag${outputName}SourceMaps"
         val path = "intermediates/bugsnag/requests/sourceMapFor${outputName}"
         val requestOutputFileProvider = project.layout.buildDirectory.file(path)
 
-//        variant.
+        // lookup the react-native task by its name
+        // https://github.com/facebook/react-native/blob/master/react.gradle#L132
+        val rnTaskName = "bundle${variant.name.capitalize()}JsAndAssets"
+        val rnTask: Task = project.tasks.findByName(rnTaskName) ?: return null
+        val rnSourceMap = BugsnagUploadJsSourceMapTask.findReactNativeTaskArg(rnTask, "--sourcemap-output")
+        val rnBundle = BugsnagUploadJsSourceMapTask.findReactNativeTaskArg(rnTask, "--bundle-output")
+
+        if (rnSourceMap == null || rnBundle == null) {
+            project.logger.error("Bugsnag: unable to upload JS sourcemaps. Please enable sourcemap + bundle output.")
+            return null
+        }
 
         return project.tasks.register<BugsnagUploadJsSourceMapTask>(taskName) {
             requestOutputFile.set(requestOutputFileProvider)
             manifestInfoFile.set(manifestInfoFileProvider)
-            // TODO set properties from variant
-//            bundleJsFile.set()
-//            sourceMapFile.set()
+            mustRunAfter(rnTask)
+            bundleJsFile.set(File(rnBundle))
+            sourceMapFile.set(File(rnSourceMap))
         }
     }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
@@ -1,0 +1,43 @@
+package com.bugsnag.android.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
+
+open class BugsnagUploadJsSourceMapTask @Inject constructor(
+    objects: ObjectFactory
+) : DefaultTask(), AndroidManifestInfoReceiver {
+
+    init {
+        group = BugsnagPlugin.GROUP_NAME
+        description = "Uploads JS source maps to Bugsnag"
+    }
+
+    @get:PathSensitive(PathSensitivity.NONE)
+    @get:InputFile
+    override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
+
+    @get:InputFile
+    val bundleJsFile: RegularFileProperty = objects.fileProperty()
+
+    @get:InputFile
+    val sourceMapFile: RegularFileProperty = objects.fileProperty()
+
+    @get:OutputFile
+    val requestOutputFile: RegularFileProperty = objects.fileProperty()
+
+    @TaskAction
+    fun uploadJsSourceMap() {
+        // Construct a basic request
+        val manifestInfo = parseManifestInfo()
+        val cliResult = "success"
+        project.logger.lifecycle("Uploading sourcemap: $bundleJsFile, JS bundle: $bundleJsFile")
+        requestOutputFile.asFile.get().writeText(cliResult)
+    }
+}

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.gradle
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.Task
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.InputFile
@@ -37,7 +38,23 @@ open class BugsnagUploadJsSourceMapTask @Inject constructor(
         // Construct a basic request
         val manifestInfo = parseManifestInfo()
         val cliResult = "success"
-        project.logger.lifecycle("Uploading sourcemap: $bundleJsFile, JS bundle: $bundleJsFile")
+        project.logger.lifecycle("Uploading sourcemap: ${bundleJsFile.get()}, JS bundle: ${bundleJsFile.get()}")
         requestOutputFile.asFile.get().writeText(cliResult)
+    }
+
+    companion object {
+
+        /**
+         * Introspects the command line arguments for the React Native Exec task
+         * and returns the value of the argument which matches the given key.
+         */
+        fun findReactNativeTaskArg(task: Task, key: String): String? {
+            val args = task.property("args") as List<*>
+            val index = args.indexOf(key)
+            if (index != -1 && index < args.size) {
+                return args[index + 1] as String?
+            }
+            return null
+        }
     }
 }


### PR DESCRIPTION
## Goal

Creates the `BugsnagUploadJsSourceMapTask` task and registers it to run against any build variants which have a RN bundleJsAssets task created. This task does not do anything functionally yet but is setup with the correct task inputs/outputs to upload sourcemaps to bugsnag - this will be added in a future PR.

## Changeset

- Registered `BugsnagUploadJsSourceMapTask` on each build variant that has a [`bundleJsAssets` task](https://github.com/facebook/react-native/blob/master/react.gradle#L132) defined and `uploadReactNativeMappings` set to true
- Set the [task inputs](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks) as the JS bundle file, sourcemap file, and the parsed AndroidManifest. The task output (success/failure) is recorded in an intermediate file
- Introspected the command line arguments of the `bundleJsAssets` [Exec task](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.Exec.html) to retrieve the sourcemap/bundle files

## Testing

Ran the react native E2E scenario. While this does not yet verify that sourcemaps were uploaded, it does check that JVM mapping files are uploaded, and logs out the sourcemap/bundle file, proving that the task has run