### PR TITLE
Improve build performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,6 @@ version = 5.3.0
 ANDROID_MIN_SDK_VERSION=14
 ANDROID_TARGET_SDK_VERSION=29
 ANDROID_COMPILE_SDK_VERSION=29
+
+org.gradle.jvmargs=-Xmx4096m
+org.gradle.parallel=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Goal

Improves the project's build speed by following the [Gradle guide](https://guides.gradle.org/performance/) which has already been implemented on the Android repo. This includes:

- Bumping the Gradle wrapper from 6.6 to 6.7
- Increasing the max memory available to the build
- Enabling parallelization of build tasks

