### PR TITLE
Populate task inputs for BugsnagUploadJsSourceMapTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## TBD
 
+* Populate task inputs for BugsnagUploadJsSourceMapTask
+  [#332](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/332)
+
 * Create BugsnagUploadJsSourceMapTask and register for build variants
   [#330](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/330)
 

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -8,7 +8,7 @@
     <ID>MagicNumber:BugsnagReleasesTask.kt$BugsnagReleasesTask$200</ID>
     <ID>MaxLineLength:BugsnagManifestUuidTask.kt$BugsnagManifestUuidTask$private</ID>
     <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ @Suppress("SENSELESS_COMPARISON") internal fun isUnityLibraryUploadEnabled( bugsnag: BugsnagPluginExtension, android: AppExtension ): Boolean</ID>
-    <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ private fun registerUploadSourceMapTask( project: Project, variant: ApkVariant, output: ApkVariantOutput, manifestInfoFileProvider: Provider&lt;RegularFile&gt; ): TaskProvider&lt;out BugsnagUploadJsSourceMapTask&gt;?</ID>
+    <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ private fun registerUploadSourceMapTask( project: Project, variant: ApkVariant, output: ApkVariantOutput, bugsnag: BugsnagPluginExtension, manifestInfoFileProvider: Provider&lt;RegularFile&gt; ): TaskProvider&lt;out BugsnagUploadJsSourceMapTask&gt;?</ID>
     <ID>ReturnCount:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$ fun generateSoMappingFile(project: Project, params: Params): File?</ID>
     <ID>SpreadOperator:BugsnagReleasesTask.kt$BugsnagReleasesTask$(*cmd)</ID>
     <ID>TooGenericExceptionCaught:BugsnagHttpClientHelper.kt$exc: Throwable</ID>

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -254,6 +254,7 @@ class BugsnagPlugin : Plugin<Project> {
                     project,
                     variant,
                     output,
+                    bugsnag,
                     manifestInfoFileProvider
                 )
                 else -> null
@@ -381,6 +382,7 @@ class BugsnagPlugin : Plugin<Project> {
         project: Project,
         variant: ApkVariant,
         output: ApkVariantOutput,
+        bugsnag: BugsnagPluginExtension,
         manifestInfoFileProvider: Provider<RegularFile>
     ): TaskProvider<out BugsnagUploadJsSourceMapTask>? {
         val outputName = taskNameForOutput(output)
@@ -394,18 +396,26 @@ class BugsnagPlugin : Plugin<Project> {
         val rnTask: Task = project.tasks.findByName(rnTaskName) ?: return null
         val rnSourceMap = BugsnagUploadJsSourceMapTask.findReactNativeTaskArg(rnTask, "--sourcemap-output")
         val rnBundle = BugsnagUploadJsSourceMapTask.findReactNativeTaskArg(rnTask, "--bundle-output")
+        val dev = BugsnagUploadJsSourceMapTask.findReactNativeTaskArg(rnTask, "--dev")
 
-        if (rnSourceMap == null || rnBundle == null) {
+        if (rnSourceMap == null || rnBundle == null || dev == null) {
             project.logger.error("Bugsnag: unable to upload JS sourcemaps. Please enable sourcemap + bundle output.")
             return null
         }
 
-        return project.tasks.register<BugsnagUploadJsSourceMapTask>(taskName) {
+        return BugsnagUploadJsSourceMapTask.register(project, taskName) {
             requestOutputFile.set(requestOutputFileProvider)
             manifestInfoFile.set(manifestInfoFileProvider)
+            bundleJsFileProvider.set(File(rnBundle))
+            sourceMapFileProvider.set(File(rnSourceMap))
+            overwrite.set(bugsnag.overwrite)
+            endpoint.set(bugsnag.endpoint)
+            devEnabled.set(dev)
+            failOnUploadError.set(bugsnag.failOnUploadError)
+
+            val jsProjectRoot = project.rootProject.rootDir.parentFile
+            projectRootFileProvider.from(jsProjectRoot)
             mustRunAfter(rnTask)
-            bundleJsFile.set(File(rnBundle))
-            sourceMapFile.set(File(rnSourceMap))
         }
     }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
@@ -1,17 +1,28 @@
 package com.bugsnag.android.gradle
 
+import com.bugsnag.android.gradle.internal.GradleVersions
+import com.bugsnag.android.gradle.internal.property
+import com.bugsnag.android.gradle.internal.register
+import com.bugsnag.android.gradle.internal.versionNumber
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
 import javax.inject.Inject
 
-open class BugsnagUploadJsSourceMapTask @Inject constructor(
+sealed class BugsnagUploadJsSourceMapTask @Inject constructor(
     objects: ObjectFactory
 ) : DefaultTask(), AndroidManifestInfoReceiver {
 
@@ -25,20 +36,85 @@ open class BugsnagUploadJsSourceMapTask @Inject constructor(
     override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
 
     @get:InputFile
-    val bundleJsFile: RegularFileProperty = objects.fileProperty()
+    val bundleJsFileProvider: RegularFileProperty = objects.fileProperty()
 
     @get:InputFile
-    val sourceMapFile: RegularFileProperty = objects.fileProperty()
+    val sourceMapFileProvider: RegularFileProperty = objects.fileProperty()
 
     @get:OutputFile
     val requestOutputFile: RegularFileProperty = objects.fileProperty()
+
+    @get:InputFiles
+    abstract val projectRootFileProvider: ConfigurableFileCollection
+
+    @get:Input
+    val overwrite: Property<Boolean> = objects.property()
+
+    @get:Input
+    val endpoint: Property<String> = objects.property()
+
+    @get:Input
+    val devEnabled: Property<String> = objects.property()
+
+    @get:Input
+    val failOnUploadError: Property<Boolean> = objects.property()
 
     @TaskAction
     fun uploadJsSourceMap() {
         // Construct a basic request
         val manifestInfo = parseManifestInfo()
-        val cliResult = "success"
-        project.logger.lifecycle("Uploading sourcemap: ${bundleJsFile.get()}, JS bundle: ${bundleJsFile.get()}")
+
+        val builder = ProcessBuilder(
+            "echo", // TODO this is a placeholder until bugsnag-source-maps is ready
+
+            "--api-key",
+            manifestInfo.apiKey,
+
+            "--app-version",
+            manifestInfo.versionName,
+
+            "--app-version-code",
+            manifestInfo.versionCode,
+
+            "--dev",
+            devEnabled.get(),
+
+            "--platform",
+            "android",
+
+            "--source-map",
+            sourceMapFileProvider.asFile.get().absolutePath,
+
+            "--bundle",
+            bundleJsFileProvider.asFile.get().absolutePath,
+
+            "--overwrite",
+            overwrite.get().toString(),
+
+            "--endpoint",
+            endpoint.get(),
+
+            "--project-root",
+            projectRootFileProvider.singleFile.absolutePath
+        )
+        builder.redirectError(ProcessBuilder.Redirect.INHERIT)
+
+        project.logger.lifecycle("Bugsnag: uploading react native sourcemap: ${builder.command()}")
+
+        val process = builder.start()
+        val exitCode = process.waitFor()
+
+        if (exitCode != 0 && failOnUploadError.get()) {
+            throw IllegalStateException(
+                "Bugsnag: source map upload failed, $exitCode." +
+                    "Please ensure that bugsnag-source-maps is installed and source maps are enabled."
+            )
+        }
+
+        val cliResult = when (exitCode) {
+            0 -> "success"
+            else -> "failure"
+        }
         requestOutputFile.asFile.get().writeText(cliResult)
     }
 
@@ -56,5 +132,43 @@ open class BugsnagUploadJsSourceMapTask @Inject constructor(
             }
             return null
         }
+
+        /**
+         * Registers the appropriate subtype to this [project] with the given [name] and
+         * [configurationAction]
+         */
+        internal fun register(
+            project: Project,
+            name: String,
+            configurationAction: BugsnagUploadJsSourceMapTask.() -> Unit
+        ): TaskProvider<out BugsnagUploadJsSourceMapTask> {
+            return when {
+                project.gradle.versionNumber() >= GradleVersions.VERSION_5_3 -> {
+                    project.tasks.register<BugsnagUploadJsSourceMapTaskGradle53Plus>(name, configurationAction)
+                } else -> {
+                    project.tasks.register<BugsnagUploadJsSourceMapTaskLegacy>(name, configurationAction)
+                }
+            }
+        }
     }
+}
+
+/**
+ * Legacy [BugsnagUploadJsSourceMapTask] task that requires using [ProjectLayout.configurableFiles].
+ */
+internal open class BugsnagUploadJsSourceMapTaskLegacy @Inject constructor(
+    objects: ObjectFactory,
+    projectLayout: ProjectLayout
+) : BugsnagUploadJsSourceMapTask(objects) {
+
+    @get:InputFiles
+    override val projectRootFileProvider: ConfigurableFileCollection = projectLayout.configurableFiles()
+}
+
+internal open class BugsnagUploadJsSourceMapTaskGradle53Plus @Inject constructor(
+    objects: ObjectFactory
+) : BugsnagUploadJsSourceMapTask(objects) {
+
+    @get:InputFiles
+    override val projectRootFileProvider: ConfigurableFileCollection = objects.fileCollection()
 }


### PR DESCRIPTION
## Goal

Populates the task inputs for the `BugsnagUploadJsSourceMapTask`. This does not invoke the `bugsnag-source-maps` CLI tool yet so no source maps are generated, but the command line arguments supplied should now be in their final state.

## Changeset

- Added additional task inputs which are part of the command line invocation
- Invoked `echo` using `ProcessBuilder` (this will be replaced with `bugsnag-source-maps`)
- Added a compatibility shim around `ConfigurableFileCollection` which is required to support Gradle 5.1

## Testing

Ran mazerunner scenario on RN 0.60 and 0.63, confirmed that the echo command is logged out for both fixtures:

>[echo, --api-key, TEST_API_KEY, --app-version, 1.0, --app-version-code, 1, --dev, false, --platform, android, --source-map, /bugsnag-android-gradle-plugin/features/fixtures/rn060/android/app/build/generated/sourcemaps/react/release/index.android.bundle.map, --bundle, /bugsnag-android-gradle-plugin/features/fixtures/rn060/android/app/build/generated/assets/react/release/index.android.bundle, --overwrite, false, --endpoint, http://localhost:9339, --project-root, /bugsnag-android-gradle-plugin/features/fixtures/rn060]
