### PR TITLE
Add E2E test scenarios for JS source map upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - ls $ANDROID_HOME
 
 install:
-  - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+  - curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
   - sudo apt-get install -y nodejs
 
 before_cache:

--- a/features/fixtures/rn060/android/app/build.gradle
+++ b/features/fixtures/rn060/android/app/build.gradle
@@ -132,8 +132,8 @@ android {
         applicationId "com.bugsnag.android.rnapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 5
+        versionName "2.45.beta"
     }
     splits {
         abi {

--- a/features/fixtures/rn060/android/app/build.gradle
+++ b/features/fixtures/rn060/android/app/build.gradle
@@ -229,8 +229,8 @@ if (!System.env.UPDATING_GRADLEW) {
         endpoint = "http://localhost:9339"
         releasesEndpoint = "http://localhost:9339"
 
-        if (System.env.UPLOAD_RN_MAPPINGS == false) {
-            bugsnag.uploadReactNativeMappings = false
+        if (System.env.UPLOAD_RN_MAPPINGS == "false") {
+            uploadReactNativeMappings = false
         }
     }
 }

--- a/features/fixtures/rn060/android/app/build.gradle
+++ b/features/fixtures/rn060/android/app/build.gradle
@@ -77,7 +77,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "index.js",
-    enableHermes: false,  // clean and rebuild if changing
+    enableHermes: System.env.RN_ENABLE_HERMES != null,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
@@ -163,6 +163,18 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+    if (System.env.USE_RN_FLAVORS) {
+        flavorDimensions "regular"
+
+        productFlavors {
+            foo {
+                applicationIdSuffix ".foo"
+            }
+            bar {
+                applicationIdSuffix ".bar"
+            }
+        }
+    }
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->
@@ -216,5 +228,9 @@ if (!System.env.UPDATING_GRADLEW) {
     bugsnag {
         endpoint = "http://localhost:9339"
         releasesEndpoint = "http://localhost:9339"
+
+        if (System.env.UPLOAD_RN_MAPPINGS == false) {
+            bugsnag.uploadReactNativeMappings = false
+        }
     }
 }

--- a/features/fixtures/rn060/android/app/build.gradle
+++ b/features/fixtures/rn060/android/app/build.gradle
@@ -77,7 +77,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "index.js",
-    enableHermes: System.env.RN_ENABLE_HERMES != null,  // clean and rebuild if changing
+    enableHermes: System.env.RN_ENABLE_HERMES == true,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/features/fixtures/rn060/package.json
+++ b/features/fixtures/rn060/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/runtime": "^7.12.1",
+    "@bugsnag/source-maps": "^1.0.0-alpha.0",
     "@react-native-community/eslint-config": "^2.0.0",
     "babel-jest": "^26.6.0",
     "eslint": "^7.11.0",

--- a/features/fixtures/rn061/android/app/build.gradle
+++ b/features/fixtures/rn061/android/app/build.gradle
@@ -132,8 +132,8 @@ android {
         applicationId "com.bugsnag.android.rnapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 5
+        versionName "2.45.beta"
     }
     splits {
         abi {

--- a/features/fixtures/rn061/android/app/build.gradle
+++ b/features/fixtures/rn061/android/app/build.gradle
@@ -77,7 +77,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "index.js",
-    enableHermes: false,  // clean and rebuild if changing
+    enableHermes: System.env.RN_ENABLE_HERMES != null,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
@@ -163,6 +163,18 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+    if (System.env.USE_RN_FLAVORS) {
+        flavorDimensions "regular"
+
+        productFlavors {
+            foo {
+                applicationIdSuffix ".foo"
+            }
+            bar {
+                applicationIdSuffix ".bar"
+            }
+        }
+    }
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->
@@ -207,5 +219,9 @@ if (!System.env.UPDATING_GRADLEW) {
     bugsnag {
         endpoint = "http://localhost:9339"
         releasesEndpoint = "http://localhost:9339"
+
+        if (System.env.UPLOAD_RN_MAPPINGS == false) {
+            bugsnag.uploadReactNativeMappings = false
+        }
     }
 }

--- a/features/fixtures/rn061/android/app/build.gradle
+++ b/features/fixtures/rn061/android/app/build.gradle
@@ -220,8 +220,8 @@ if (!System.env.UPDATING_GRADLEW) {
         endpoint = "http://localhost:9339"
         releasesEndpoint = "http://localhost:9339"
 
-        if (System.env.UPLOAD_RN_MAPPINGS == false) {
-            bugsnag.uploadReactNativeMappings = false
+        if (System.env.UPLOAD_RN_MAPPINGS == "false") {
+            uploadReactNativeMappings = false
         }
     }
 }

--- a/features/fixtures/rn061/android/app/build.gradle
+++ b/features/fixtures/rn061/android/app/build.gradle
@@ -77,7 +77,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "index.js",
-    enableHermes: System.env.RN_ENABLE_HERMES != null,  // clean and rebuild if changing
+    enableHermes: System.env.RN_ENABLE_HERMES == true,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/features/fixtures/rn061/package.json
+++ b/features/fixtures/rn061/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/runtime": "^7.12.1",
+    "@bugsnag/source-maps": "^1.0.0-alpha.0",
     "@react-native-community/eslint-config": "^2.0.0",
     "babel-jest": "^26.6.0",
     "eslint": "^7.11.0",

--- a/features/fixtures/rn062/android/app/build.gradle
+++ b/features/fixtures/rn062/android/app/build.gradle
@@ -78,7 +78,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: false,  // clean and rebuild if changing
+    enableHermes: System.env.RN_ENABLE_HERMES != null,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
@@ -164,6 +164,18 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+    if (System.env.USE_RN_FLAVORS) {
+        flavorDimensions "regular"
+
+        productFlavors {
+            foo {
+                applicationIdSuffix ".foo"
+            }
+            bar {
+                applicationIdSuffix ".bar"
+            }
+        }
+    }
 
     packagingOptions {
         pickFirst "lib/armeabi-v7a/libc++_shared.so"
@@ -231,5 +243,9 @@ if (!System.env.UPDATING_GRADLEW) {
     bugsnag {
         endpoint = "http://localhost:9339"
         releasesEndpoint = "http://localhost:9339"
+
+        if (System.env.UPLOAD_RN_MAPPINGS == false) {
+            bugsnag.uploadReactNativeMappings = false
+        }
     }
 }

--- a/features/fixtures/rn062/android/app/build.gradle
+++ b/features/fixtures/rn062/android/app/build.gradle
@@ -78,7 +78,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: System.env.RN_ENABLE_HERMES != null,  // clean and rebuild if changing
+    enableHermes: System.env.RN_ENABLE_HERMES == true,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/features/fixtures/rn062/android/app/build.gradle
+++ b/features/fixtures/rn062/android/app/build.gradle
@@ -133,8 +133,8 @@ android {
         applicationId "com.bugsnag.android.rnapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 5
+        versionName "2.45.beta"
     }
     splits {
         abi {

--- a/features/fixtures/rn062/android/app/build.gradle
+++ b/features/fixtures/rn062/android/app/build.gradle
@@ -244,8 +244,8 @@ if (!System.env.UPDATING_GRADLEW) {
         endpoint = "http://localhost:9339"
         releasesEndpoint = "http://localhost:9339"
 
-        if (System.env.UPLOAD_RN_MAPPINGS == false) {
-            bugsnag.uploadReactNativeMappings = false
+        if (System.env.UPLOAD_RN_MAPPINGS == "false") {
+            uploadReactNativeMappings = false
         }
     }
 }

--- a/features/fixtures/rn062/package.json
+++ b/features/fixtures/rn062/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/runtime": "^7.12.1",
+    "@bugsnag/source-maps": "^1.0.0-alpha.0",
     "@react-native-community/eslint-config": "^2.0.0",
     "babel-jest": "^26.6.0",
     "eslint": "^7.11.0",

--- a/features/fixtures/rn063/android/app/build.gradle
+++ b/features/fixtures/rn063/android/app/build.gradle
@@ -132,8 +132,8 @@ android {
         applicationId "com.bugsnag.android.rnapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 5
+        versionName "2.45.beta"
     }
     splits {
         abi {

--- a/features/fixtures/rn063/android/app/build.gradle
+++ b/features/fixtures/rn063/android/app/build.gradle
@@ -77,7 +77,7 @@ import com.android.build.OutputFile
  * ]
  */
 project.ext.react = [
-    enableHermes: System.env.RN_ENABLE_HERMES != null // clean and rebuild if changing
+    enableHermes: System.env.RN_ENABLE_HERMES == true // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/features/fixtures/rn063/android/app/build.gradle
+++ b/features/fixtures/rn063/android/app/build.gradle
@@ -237,8 +237,9 @@ if (!System.env.UPDATING_GRADLEW) {
     bugsnag {
         endpoint = "http://localhost:9339"
         releasesEndpoint = "http://localhost:9339"
-    }
-    if (System.env.UPLOAD_RN_MAPPINGS == false) {
-        bugsnag.uploadReactNativeMappings = false
+
+        if (System.env.UPLOAD_RN_MAPPINGS == "false") {
+            uploadReactNativeMappings = false
+        }
     }
 }

--- a/features/fixtures/rn063/android/app/build.gradle
+++ b/features/fixtures/rn063/android/app/build.gradle
@@ -76,9 +76,8 @@ import com.android.build.OutputFile
  *   extraPackagerArgs: []
  * ]
  */
-
 project.ext.react = [
-    enableHermes: false,  // clean and rebuild if changing
+    enableHermes: System.env.RN_ENABLE_HERMES != null // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
@@ -165,7 +164,20 @@ android {
         }
     }
 
-    // applicationVariants are e.g. debug, release
+    if (System.env.USE_RN_FLAVORS) {
+        flavorDimensions "regular"
+
+        productFlavors {
+            foo {
+                applicationIdSuffix ".foo"
+            }
+            bar {
+                applicationIdSuffix ".bar"
+            }
+        }
+    }
+
+        // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->
             // For each separate APK per architecture, set a unique version code as described here:
@@ -225,5 +237,8 @@ if (!System.env.UPDATING_GRADLEW) {
     bugsnag {
         endpoint = "http://localhost:9339"
         releasesEndpoint = "http://localhost:9339"
+    }
+    if (System.env.UPLOAD_RN_MAPPINGS == false) {
+        bugsnag.uploadReactNativeMappings = false
     }
 }

--- a/features/fixtures/rn063/package.json
+++ b/features/fixtures/rn063/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/runtime": "^7.12.1",
+    "@bugsnag/source-maps": "^1.0.0-alpha.0",
     "@react-native-community/eslint-config": "^2.0.0",
     "babel-jest": "^26.6.0",
     "eslint": "^7.11.0",

--- a/features/react_native.feature
+++ b/features/react_native.feature
@@ -1,8 +1,8 @@
 Feature: Plugin integrated in React Native app
 
-Scenario: React Native sends requests
+Scenario: Source maps are uploaded when assembling an app with the default project structure
     When I build the React Native app
-    And I wait to receive 2 requests
+    And I wait to receive 3 requests
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
@@ -11,3 +11,80 @@ Scenario: React Native sends requests
     And 1 requests are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                     |
       | 1           | 1.0         | com.bugsnag.android.rnapp |
+
+    And 1 requests are valid for the JS source map API and match the following:
+        | appVersionCode | appVersion | platform |
+        | 1              | 1.0        | android  |
+
+Scenario: Source maps are uploaded when bundling an app with the default project structure
+    When I build the React Native app
+    And I wait to receive 3 requests
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | versionCode | versionName | appId                     |
+        | 1           | 1.0         | com.bugsnag.android.rnapp |
+
+    And 1 requests are valid for the JS source map API and match the following:
+        | appVersionCode | appVersion | platform |
+        | 1              | 1.0        | android  |
+
+Scenario: Source maps are uploaded when assembling an app which uses productFlavors
+    When I set environment variable "USE_RN_FLAVORS" to "true"
+    When I build the React Native app
+    And I wait to receive 6 requests
+
+    Then 2 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+        | 1              | 1.0        | gradle-android |
+
+    And 2 requests are valid for the android mapping API and match the following:
+        | versionCode | versionName | appId                         |
+        | 1           | 1.0         | com.bugsnag.android.rnapp.foo |
+        | 1           | 1.0         | com.bugsnag.android.rnapp.bar |
+
+    And 2 requests are valid for the JS source map API and match the following:
+        | appVersionCode | appVersion | platform |
+        | 1              | 1.0        | android  |
+        | 1              | 1.0        | android  |
+
+Scenario: Setting uploadReactNativeMappings to false will prevent any source map upload
+    When I set environment variable "UPLOAD_RN_MAPPINGS" to "false"
+    When I build the React Native app
+    And I wait to receive 2 requests
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | versionCode | versionName | appId                     |
+        | 1           | 1.0         | com.bugsnag.android.rnapp |
+
+Scenario: Manually invoking source map upload task
+    And I run the script "features/scripts/manual_upload_react_native.sh" synchronously
+    And I wait to receive 1 requests
+    And 1 requests are valid for the JS source map API and match the following:
+        | appVersionCode | appVersion |
+        | 1              | 1.0        |
+
+Scenario: Source maps are uploaded in an app using Hermes
+    When I set environment variable "RN_ENABLE_HERMES" to "true"
+    When I build the React Native app
+    And I wait to receive 3 requests
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | versionCode | versionName | appId                     |
+        | 1           | 1.0         | com.bugsnag.android.rnapp |
+
+    And 1 requests are valid for the JS source map API and match the following:
+        | appVersionCode | appVersion | platform |
+        | 1              | 1.0        | android  |

--- a/features/react_native.feature
+++ b/features/react_native.feature
@@ -17,7 +17,7 @@ Scenario: Source maps are uploaded when assembling an app with the default proje
         | 1              | 1.0        | android  |
 
 Scenario: Source maps are uploaded when bundling an app with the default project structure
-    When I build the React Native app
+    And I run the script "features/scripts/bundle_react_native_app.sh" synchronously
     And I wait to receive 3 requests
 
     Then 1 requests are valid for the build API and match the following:

--- a/features/react_native.feature
+++ b/features/react_native.feature
@@ -6,15 +6,15 @@ Scenario: Source maps are uploaded when assembling an app with the default proje
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
-      | 1              | 1.0        | gradle-android |
+      | 5              | 2.45.beta  | gradle-android |
 
     And 1 requests are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                     |
-      | 1           | 1.0         | com.bugsnag.android.rnapp |
+      | 5              | 2.45.beta  | com.bugsnag.android.rnapp |
 
     And 1 requests are valid for the JS source map API and match the following:
         | appVersionCode | appVersion | overwrite | dev   |
-        | 1              | 1.0        | false     | false |
+        | 5              | 2.45.beta  | false     | false |
 
 Scenario: Source maps are uploaded when bundling an app with the default project structure
     And I run the script "features/scripts/bundle_react_native_app.sh" synchronously
@@ -22,15 +22,15 @@ Scenario: Source maps are uploaded when bundling an app with the default project
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
-        | 1              | 1.0        | gradle-android |
+        | 5              | 2.45.beta  | gradle-android |
 
     And 1 requests are valid for the android mapping API and match the following:
         | versionCode | versionName | appId                     |
-        | 1           | 1.0         | com.bugsnag.android.rnapp |
+        | 5              | 2.45.beta  | com.bugsnag.android.rnapp |
 
     And 1 requests are valid for the JS source map API and match the following:
         | appVersionCode | appVersion | overwrite | dev   |
-        | 1              | 1.0        | false     | false |
+        | 5              | 2.45.beta  | false     | false |
 
 Scenario: Source maps are uploaded when assembling an app which uses productFlavors
     When I set environment variable "USE_RN_FLAVORS" to "true"
@@ -39,18 +39,18 @@ Scenario: Source maps are uploaded when assembling an app which uses productFlav
 
     Then 2 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
-        | 1              | 1.0        | gradle-android |
-        | 1              | 1.0        | gradle-android |
+        | 5              | 2.45.beta  | gradle-android |
+        | 5              | 2.45.beta  | gradle-android |
 
     And 2 requests are valid for the android mapping API and match the following:
         | versionCode | versionName | appId                         |
-        | 1           | 1.0         | com.bugsnag.android.rnapp.foo |
-        | 1           | 1.0         | com.bugsnag.android.rnapp.bar |
+        | 5           | 2.45.beta  | com.bugsnag.android.rnapp.foo |
+        | 5           | 2.45.beta  | com.bugsnag.android.rnapp.bar |
 
     And 2 requests are valid for the JS source map API and match the following:
         | appVersionCode | appVersion | overwrite | dev   |
-        | 1              | 1.0        | false     | false |
-        | 1              | 1.0        | false     | false |
+        | 5              | 2.45.beta  | false     | false |
+        | 5              | 2.45.beta  | false     | false |
 
 Scenario: Setting uploadReactNativeMappings to false will prevent any source map upload
     When I set environment variable "UPLOAD_RN_MAPPINGS" to "false"
@@ -59,18 +59,18 @@ Scenario: Setting uploadReactNativeMappings to false will prevent any source map
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
-        | 1              | 1.0        | gradle-android |
+        | 5              | 2.45.beta  | gradle-android |
 
     And 1 requests are valid for the android mapping API and match the following:
         | versionCode | versionName | appId                     |
-        | 1           | 1.0         | com.bugsnag.android.rnapp |
+        | 5           | 2.45.beta  | com.bugsnag.android.rnapp |
 
 Scenario: Manually invoking source map upload task
     And I run the script "features/scripts/manual_upload_react_native.sh" synchronously
     And I wait to receive 1 requests
     And 1 requests are valid for the JS source map API and match the following:
         | appVersionCode | appVersion | overwrite | dev   |
-        | 1              | 1.0        | false     | false |
+        | 5              | 2.45.beta  | false     | false |
 
 Scenario: Source maps are uploaded in an app using Hermes
     When I set environment variable "RN_ENABLE_HERMES" to "true"
@@ -79,12 +79,12 @@ Scenario: Source maps are uploaded in an app using Hermes
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
-        | 1              | 1.0        | gradle-android |
+        | 5              | 2.45.beta  | gradle-android |
 
     And 1 requests are valid for the android mapping API and match the following:
         | versionCode | versionName | appId                     |
-        | 1           | 1.0         | com.bugsnag.android.rnapp |
+        | 5           | 2.45.beta  | com.bugsnag.android.rnapp |
 
     And 1 requests are valid for the JS source map API and match the following:
         | appVersionCode | appVersion | overwrite | dev   |
-        | 1              | 1.0        | false     | false |
+        | 5              | 2.45.beta  | false     | false |

--- a/features/react_native.feature
+++ b/features/react_native.feature
@@ -13,8 +13,8 @@ Scenario: Source maps are uploaded when assembling an app with the default proje
       | 1           | 1.0         | com.bugsnag.android.rnapp |
 
     And 1 requests are valid for the JS source map API and match the following:
-        | appVersionCode | appVersion | platform |
-        | 1              | 1.0        | android  |
+        | appVersionCode | appVersion | overwrite | dev   |
+        | 1              | 1.0        | false     | false |
 
 Scenario: Source maps are uploaded when bundling an app with the default project structure
     And I run the script "features/scripts/bundle_react_native_app.sh" synchronously
@@ -29,8 +29,8 @@ Scenario: Source maps are uploaded when bundling an app with the default project
         | 1           | 1.0         | com.bugsnag.android.rnapp |
 
     And 1 requests are valid for the JS source map API and match the following:
-        | appVersionCode | appVersion | platform |
-        | 1              | 1.0        | android  |
+        | appVersionCode | appVersion | overwrite | dev   |
+        | 1              | 1.0        | false     | false |
 
 Scenario: Source maps are uploaded when assembling an app which uses productFlavors
     When I set environment variable "USE_RN_FLAVORS" to "true"
@@ -48,9 +48,9 @@ Scenario: Source maps are uploaded when assembling an app which uses productFlav
         | 1           | 1.0         | com.bugsnag.android.rnapp.bar |
 
     And 2 requests are valid for the JS source map API and match the following:
-        | appVersionCode | appVersion | platform |
-        | 1              | 1.0        | android  |
-        | 1              | 1.0        | android  |
+        | appVersionCode | appVersion | overwrite | dev   |
+        | 1              | 1.0        | false     | false |
+        | 1              | 1.0        | false     | false |
 
 Scenario: Setting uploadReactNativeMappings to false will prevent any source map upload
     When I set environment variable "UPLOAD_RN_MAPPINGS" to "false"
@@ -69,8 +69,8 @@ Scenario: Manually invoking source map upload task
     And I run the script "features/scripts/manual_upload_react_native.sh" synchronously
     And I wait to receive 1 requests
     And 1 requests are valid for the JS source map API and match the following:
-        | appVersionCode | appVersion |
-        | 1              | 1.0        |
+        | appVersionCode | appVersion | overwrite | dev   |
+        | 1              | 1.0        | false     | false |
 
 Scenario: Source maps are uploaded in an app using Hermes
     When I set environment variable "RN_ENABLE_HERMES" to "true"
@@ -86,5 +86,5 @@ Scenario: Source maps are uploaded in an app using Hermes
         | 1           | 1.0         | com.bugsnag.android.rnapp |
 
     And 1 requests are valid for the JS source map API and match the following:
-        | appVersionCode | appVersion | platform |
-        | 1              | 1.0        | android  |
+        | appVersionCode | appVersion | overwrite | dev   |
+        | 1              | 1.0        | false     | false |

--- a/features/scripts/bundle_react_native_app.sh
+++ b/features/scripts/bundle_react_native_app.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+cd $RN_FIXTURE_DIR
+echo "Test fixture used: $RN_FIXTURE_DIR, AGP=$AGP_VERSION, Gradle=$GRADLE_WRAPPER_VERSION"
+npm install
+./gradlew :app:clean :app:bundle -x lint --stacktrace

--- a/features/scripts/manual_upload_react_native.sh
+++ b/features/scripts/manual_upload_react_native.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+cd $RN_FIXTURE_DIR
+echo "Test fixture used: $RN_FIXTURE_DIR, AGP=$AGP_VERSION, Gradle=$GRADLE_WRAPPER_VERSION"
+npm install
+./gradlew :app:clean :app:uploadBugsnagReleaseSourceMaps -x lint --stacktrace

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -65,7 +65,7 @@ Then(/^the exit code equals (\d+)$/) do |exit_code|
 end
 
 Then('{int} requests are valid for the build API and match the following:') do |request_count, data_table|
-  requests = get_build_requests
+  requests = get_requests_with_field('appVersionCode')
   assert_equal(request_count, requests.length, 'Wrong number of build API requests')
   RequestSetAssertions.assert_requests_match requests, data_table
 
@@ -75,7 +75,7 @@ Then('{int} requests are valid for the build API and match the following:') do |
 end
 
 Then('{int} requests are valid for the android mapping API and match the following:') do |request_count, data_table|
-  requests = get_android_mapping_requests
+  requests = get_requests_with_field('proguard')
   assert_equal(request_count, requests.length, 'Wrong number of mapping API requests')
   RequestSetAssertions.assert_requests_match requests, data_table
 
@@ -85,7 +85,7 @@ Then('{int} requests are valid for the android mapping API and match the followi
 end
 
 Then('{int} requests are valid for the android NDK mapping API and match the following:') do |request_count, data_table|
-  requests = get_android_ndk_mapping_requests
+  requests = get_requests_with_field('soSymbolFile')
   assert_equal(request_count, requests.length, 'Wrong number of NDK mapping API requests')
   RequestSetAssertions.assert_requests_match requests, data_table
 
@@ -95,7 +95,7 @@ Then('{int} requests are valid for the android NDK mapping API and match the fol
 end
 
 Then('{int} requests are valid for the android unity NDK mapping API and match the following:') do |request_count, data_table|
-  requests = get_android_unity_ndk_mapping_requests
+  requests = get_requests_with_field('soSymbolTableFile')
   assert_equal(request_count, requests.length, 'Wrong number of android unity NDK mapping API requests')
   RequestSetAssertions.assert_requests_match requests, data_table
 
@@ -106,7 +106,7 @@ end
 
 
 Then('{int} requests are valid for the JS source map API and match the following:') do |request_count, data_table|
-  requests = get_js_source_map_requests
+  requests = get_requests_with_field('sourceMap')
   assert_equal(request_count, requests.length, 'Wrong number of JS source map API requests')
   RequestSetAssertions.assert_requests_match requests, data_table
 
@@ -179,7 +179,7 @@ end
 
 def valid_js_source_map_api?(request_body)
   assert_equal($api_key, request_body['apiKey'])
-  assert_equal("android", request_body['platform'])
+  assert_equal('android', request_body['platform'])
   assert_not_nil(request_body['minifiedUrl'])
   assert_not_nil(request_body['sourceMap'])
   assert_not_nil(request_body['projectRoot'])

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -104,6 +104,17 @@ Then('{int} requests are valid for the android unity NDK mapping API and match t
   end
 end
 
+
+Then('{int} requests are valid for the JS source map API and match the following:') do |request_count, data_table|
+  requests = get_js_source_map_requests
+  assert_equal(request_count, requests.length, 'Wrong number of JS source map API requests')
+  RequestSetAssertions.assert_requests_match requests, data_table
+
+  requests.each do |request|
+    valid_js_source_map_api?(request[:body])
+  end
+end
+
 Then('{int} requests have an R8 mapping file with the following symbols:') do |request_count, data_table|
   requests = get_android_mapping_requests
   assert_equal(request_count, requests.length, 'Wrong number of mapping API requests')
@@ -164,4 +175,12 @@ def valid_mapping_api?(request_body)
   assert_not_nil(request_body['versionCode'])
   assert_not_nil(request_body['buildUUID'])
   assert_not_nil(request_body['versionName'])
+end
+
+def valid_js_source_map_api?(request_body)
+  assert_equal($api_key, request_body['apiKey'])
+  assert_equal("android", request_body['platform'])
+  assert_not_nil(request_body['minifiedUrl'])
+  assert_not_nil(request_body['sourceMap'])
+  assert_not_nil(request_body['projectRoot'])
 end

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -116,7 +116,7 @@ Then('{int} requests are valid for the JS source map API and match the following
 end
 
 Then('{int} requests have an R8 mapping file with the following symbols:') do |request_count, data_table|
-  requests = get_android_mapping_requests
+  requests = get_requests_with_field('proguard')
   assert_equal(request_count, requests.length, 'Wrong number of mapping API requests')
 
   # inflate gzipped proguard mapping file & verify contents

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -65,7 +65,7 @@ Then(/^the exit code equals (\d+)$/) do |exit_code|
 end
 
 Then('{int} requests are valid for the build API and match the following:') do |request_count, data_table|
-  requests = get_requests_with_field('appVersionCode')
+  requests = get_requests_with_field('builderName')
   assert_equal(request_count, requests.length, 'Wrong number of build API requests')
   RequestSetAssertions.assert_requests_match requests, data_table
 
@@ -180,7 +180,6 @@ end
 def valid_js_source_map_api?(request_body)
   assert_equal($api_key, request_body['apiKey'])
   assert_equal('android', request_body['platform'])
-  assert_not_nil(request_body['minifiedUrl'])
   assert_not_nil(request_body['sourceMap'])
-  assert_not_nil(request_body['projectRoot'])
+  assert_not_nil(request_body['bundle'])
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -43,37 +43,9 @@ def is_above_or_equal_to_target(target)
   return version.to_i >= target
 end
 
-def get_build_requests
+def get_requests_with_field(name)
   Server.stored_requests.reject do |request|
-    value = read_key_path(request[:body], 'appVersionCode')
-    value.nil?
-  end
-end
-
-def get_android_mapping_requests
-  Server.stored_requests.reject do |request|
-    value = read_key_path(request[:body], 'proguard')
-    value.nil?
-  end
-end
-
-def get_android_ndk_mapping_requests
-  Server.stored_requests.reject do |request|
-    value = read_key_path(request[:body], 'soSymbolFile')
-    value.nil?
-  end
-end
-
-def get_android_unity_ndk_mapping_requests
-  Server.stored_requests.reject do |request|
-    value = read_key_path(request[:body], 'soSymbolTableFile')
-    value.nil?
-  end
-end
-
-def get_js_source_map_requests
-  Server.stored_requests.reject do |request|
-    value = read_key_path(request[:body], 'sourceMap')
+    value = read_key_path(request[:body], name)
     value.nil?
   end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -71,4 +71,11 @@ def get_android_unity_ndk_mapping_requests
   end
 end
 
+def get_js_source_map_requests
+  Server.stored_requests.reject do |request|
+    value = read_key_path(request[:body], 'sourceMap')
+    value.nil?
+  end
+end
+
 $api_key = "TEST_API_KEY"

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -481,11 +481,15 @@ class BugsnagPlugin : Plugin<Project> {
             sourceMapFileProvider.set(File(rnSourceMap))
             overwrite.set(bugsnag.overwrite)
             endpoint.set(bugsnag.endpoint)
-            devEnabled.set(dev)
+            devEnabled.set("true" == dev)
             failOnUploadError.set(bugsnag.failOnUploadError)
 
             val jsProjectRoot = project.rootProject.rootDir.parentFile
             projectRootFileProvider.from(jsProjectRoot)
+
+            val cliPath = "../../node_modules/@bugsnag/source-maps/bin/cli"
+            val file = project.layout.projectDirectory.file(cliPath)
+            bugsnagSourceMaps.set(file)
             mustRunAfter(rnTask)
         }
     }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -288,16 +288,6 @@ class BugsnagPlugin : Plugin<Project> {
                 else -> null
             }
 
-            val uploadSourceMapProvider = when {
-                reactNativeEnabled -> registerUploadSourceMapTask(
-                    project,
-                    variant,
-                    output,
-                    manifestInfoFileProvider
-                )
-                else -> null
-            }
-
             val releaseUploadTask = registerReleasesUploadTask(
                 project,
                 variant,
@@ -347,9 +337,6 @@ class BugsnagPlugin : Plugin<Project> {
                 subProj.repositories.maven { repo ->
                     repo.setUrl("$rootDir/../node_modules/@bugsnag/react-native/android")
                 }
-            }
-            if (uploadSourceMapProvider != null) {
-                variant.register(project, uploadSourceMapProvider, reactNativeEnabled)
             }
         }
     }
@@ -500,31 +487,6 @@ class BugsnagPlugin : Plugin<Project> {
             val jsProjectRoot = project.rootProject.rootDir.parentFile
             projectRootFileProvider.from(jsProjectRoot)
             mustRunAfter(rnTask)
-        }
-    }
-
-    /**
-     * Creates a bugsnag task to upload JS source maps
-     */
-    private fun registerUploadSourceMapTask(
-        project: Project,
-        variant: ApkVariant,
-        output: ApkVariantOutput,
-        manifestInfoFileProvider: Provider<RegularFile>
-    ): TaskProvider<out BugsnagUploadJsSourceMapTask> {
-        val outputName = taskNameForOutput(output)
-        val taskName = "uploadBugsnag${outputName}SourceMaps"
-        val path = "intermediates/bugsnag/requests/sourceMapFor${outputName}"
-        val requestOutputFileProvider = project.layout.buildDirectory.file(path)
-
-//        variant.
-
-        return project.tasks.register<BugsnagUploadJsSourceMapTask>(taskName) {
-            requestOutputFile.set(requestOutputFileProvider)
-            manifestInfoFile.set(manifestInfoFileProvider)
-            // TODO set properties from variant
-//            bundleJsFile.set()
-//            sourceMapFile.set()
         }
     }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
@@ -1,28 +1,16 @@
 package com.bugsnag.android.gradle
 
-import com.bugsnag.android.gradle.internal.GradleVersions
-import com.bugsnag.android.gradle.internal.property
-import com.bugsnag.android.gradle.internal.register
-import com.bugsnag.android.gradle.internal.versionNumber
 import org.gradle.api.DefaultTask
-import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.TaskProvider
 import javax.inject.Inject
 
-sealed class BugsnagUploadJsSourceMapTask @Inject constructor(
+open class BugsnagUploadJsSourceMapTask @Inject constructor(
     objects: ObjectFactory
 ) : DefaultTask(), AndroidManifestInfoReceiver {
 
@@ -36,139 +24,20 @@ sealed class BugsnagUploadJsSourceMapTask @Inject constructor(
     override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
 
     @get:InputFile
-    val bundleJsFileProvider: RegularFileProperty = objects.fileProperty()
+    val bundleJsFile: RegularFileProperty = objects.fileProperty()
 
     @get:InputFile
-    val sourceMapFileProvider: RegularFileProperty = objects.fileProperty()
+    val sourceMapFile: RegularFileProperty = objects.fileProperty()
 
     @get:OutputFile
     val requestOutputFile: RegularFileProperty = objects.fileProperty()
-
-    @get:InputFiles
-    abstract val projectRootFileProvider: ConfigurableFileCollection
-
-    @get:Input
-    val overwrite: Property<Boolean> = objects.property()
-
-    @get:Input
-    val endpoint: Property<String> = objects.property()
-
-    @get:Input
-    val devEnabled: Property<String> = objects.property()
-
-    @get:Input
-    val failOnUploadError: Property<Boolean> = objects.property()
 
     @TaskAction
     fun uploadJsSourceMap() {
         // Construct a basic request
         val manifestInfo = parseManifestInfo()
-
-        val builder = ProcessBuilder(
-            "echo", // TODO this is a placeholder until bugsnag-source-maps is ready
-
-            "--api-key",
-            manifestInfo.apiKey,
-
-            "--app-version",
-            manifestInfo.versionName,
-
-            "--app-version-code",
-            manifestInfo.versionCode,
-
-            "--dev",
-            devEnabled.get(),
-
-            "--platform",
-            "android",
-
-            "--source-map",
-            sourceMapFileProvider.asFile.get().absolutePath,
-
-            "--bundle",
-            bundleJsFileProvider.asFile.get().absolutePath,
-
-            "--overwrite",
-            overwrite.get().toString(),
-
-            "--endpoint",
-            endpoint.get(),
-
-            "--project-root",
-            projectRootFileProvider.singleFile.absolutePath
-        )
-        builder.redirectError(ProcessBuilder.Redirect.INHERIT)
-
-        project.logger.lifecycle("Bugsnag: uploading react native sourcemap: ${builder.command()}")
-
-        val process = builder.start()
-        val exitCode = process.waitFor()
-
-        if (exitCode != 0 && failOnUploadError.get()) {
-            throw IllegalStateException(
-                "Bugsnag: source map upload failed, $exitCode." +
-                    "Please ensure that bugsnag-source-maps is installed and source maps are enabled."
-            )
-        }
-
-        val cliResult = when (exitCode) {
-            0 -> "success"
-            else -> "failure"
-        }
+        val cliResult = "success"
+        project.logger.lifecycle("Uploading sourcemap: $bundleJsFile, JS bundle: $bundleJsFile")
         requestOutputFile.asFile.get().writeText(cliResult)
     }
-
-    companion object {
-
-        /**
-         * Introspects the command line arguments for the React Native Exec task
-         * and returns the value of the argument which matches the given key.
-         */
-        fun findReactNativeTaskArg(task: Task, key: String): String? {
-            val args = task.property("args") as List<*>
-            val index = args.indexOf(key)
-            if (index != -1 && index < args.size) {
-                return args[index + 1] as String?
-            }
-            return null
-        }
-
-        /**
-         * Registers the appropriate subtype to this [project] with the given [name] and
-         * [configurationAction]
-         */
-        internal fun register(
-            project: Project,
-            name: String,
-            configurationAction: BugsnagUploadJsSourceMapTask.() -> Unit
-        ): TaskProvider<out BugsnagUploadJsSourceMapTask> {
-            return when {
-                project.gradle.versionNumber() >= GradleVersions.VERSION_5_3 -> {
-                    project.tasks.register<BugsnagUploadJsSourceMapTaskGradle53Plus>(name, configurationAction)
-                } else -> {
-                    project.tasks.register<BugsnagUploadJsSourceMapTaskLegacy>(name, configurationAction)
-                }
-            }
-        }
-    }
-}
-
-/**
- * Legacy [BugsnagUploadJsSourceMapTask] task that requires using [ProjectLayout.configurableFiles].
- */
-internal open class BugsnagUploadJsSourceMapTaskLegacy @Inject constructor(
-    objects: ObjectFactory,
-    projectLayout: ProjectLayout
-) : BugsnagUploadJsSourceMapTask(objects) {
-
-    @get:InputFiles
-    override val projectRootFileProvider: ConfigurableFileCollection = projectLayout.configurableFiles()
-}
-
-internal open class BugsnagUploadJsSourceMapTaskGradle53Plus @Inject constructor(
-    objects: ObjectFactory
-) : BugsnagUploadJsSourceMapTask(objects) {
-
-    @get:InputFiles
-    override val projectRootFileProvider: ConfigurableFileCollection = objects.fileCollection()
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
@@ -84,11 +84,13 @@ sealed class BugsnagUploadJsSourceMapTask @Inject constructor(
             project.logger.lifecycle("Bugsnag: uploaded react native sourcemap: $outputMsg")
         }
 
-        if (exitCode != 0 && failOnUploadError.get()) {
+        if (exitCode != 0) {
             val errMsg = process.errorStream.bufferedReader().use { it.readText() }
-            throw IllegalStateException(
-                "Bugsnag: source map upload failed. Exit code=$exitCode, msg=$errMsg."
-            )
+            val msg = "Bugsnag: source map upload failed. Exit code=$exitCode, msg=$errMsg."
+            when {
+                failOnUploadError.get() -> throw IllegalStateException(msg)
+                else -> project.logger.error(msg)
+            }
         }
 
         val cliResult = when (exitCode) {

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
@@ -1,16 +1,28 @@
 package com.bugsnag.android.gradle
 
+import com.bugsnag.android.gradle.internal.GradleVersions
+import com.bugsnag.android.gradle.internal.property
+import com.bugsnag.android.gradle.internal.register
+import com.bugsnag.android.gradle.internal.versionNumber
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
 import javax.inject.Inject
 
-open class BugsnagUploadJsSourceMapTask @Inject constructor(
+sealed class BugsnagUploadJsSourceMapTask @Inject constructor(
     objects: ObjectFactory
 ) : DefaultTask(), AndroidManifestInfoReceiver {
 
@@ -24,20 +36,139 @@ open class BugsnagUploadJsSourceMapTask @Inject constructor(
     override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
 
     @get:InputFile
-    val bundleJsFile: RegularFileProperty = objects.fileProperty()
+    val bundleJsFileProvider: RegularFileProperty = objects.fileProperty()
 
     @get:InputFile
-    val sourceMapFile: RegularFileProperty = objects.fileProperty()
+    val sourceMapFileProvider: RegularFileProperty = objects.fileProperty()
 
     @get:OutputFile
     val requestOutputFile: RegularFileProperty = objects.fileProperty()
+
+    @get:InputFiles
+    abstract val projectRootFileProvider: ConfigurableFileCollection
+
+    @get:Input
+    val overwrite: Property<Boolean> = objects.property()
+
+    @get:Input
+    val endpoint: Property<String> = objects.property()
+
+    @get:Input
+    val devEnabled: Property<String> = objects.property()
+
+    @get:Input
+    val failOnUploadError: Property<Boolean> = objects.property()
 
     @TaskAction
     fun uploadJsSourceMap() {
         // Construct a basic request
         val manifestInfo = parseManifestInfo()
-        val cliResult = "success"
-        project.logger.lifecycle("Uploading sourcemap: $bundleJsFile, JS bundle: $bundleJsFile")
+
+        val builder = ProcessBuilder(
+            "echo", // TODO this is a placeholder until bugsnag-source-maps is ready
+
+            "--api-key",
+            manifestInfo.apiKey,
+
+            "--app-version",
+            manifestInfo.versionName,
+
+            "--app-version-code",
+            manifestInfo.versionCode,
+
+            "--dev",
+            devEnabled.get(),
+
+            "--platform",
+            "android",
+
+            "--source-map",
+            sourceMapFileProvider.asFile.get().absolutePath,
+
+            "--bundle",
+            bundleJsFileProvider.asFile.get().absolutePath,
+
+            "--overwrite",
+            overwrite.get().toString(),
+
+            "--endpoint",
+            endpoint.get(),
+
+            "--project-root",
+            projectRootFileProvider.singleFile.absolutePath
+        )
+        builder.redirectError(ProcessBuilder.Redirect.INHERIT)
+
+        project.logger.lifecycle("Bugsnag: uploading react native sourcemap: ${builder.command()}")
+
+        val process = builder.start()
+        val exitCode = process.waitFor()
+
+        if (exitCode != 0 && failOnUploadError.get()) {
+            throw IllegalStateException(
+                "Bugsnag: source map upload failed, $exitCode." +
+                    "Please ensure that bugsnag-source-maps is installed and source maps are enabled."
+            )
+        }
+
+        val cliResult = when (exitCode) {
+            0 -> "success"
+            else -> "failure"
+        }
         requestOutputFile.asFile.get().writeText(cliResult)
     }
+
+    companion object {
+
+        /**
+         * Introspects the command line arguments for the React Native Exec task
+         * and returns the value of the argument which matches the given key.
+         */
+        fun findReactNativeTaskArg(task: Task, key: String): String? {
+            val args = task.property("args") as List<*>
+            val index = args.indexOf(key)
+            if (index != -1 && index < args.size) {
+                return args[index + 1] as String?
+            }
+            return null
+        }
+
+        /**
+         * Registers the appropriate subtype to this [project] with the given [name] and
+         * [configurationAction]
+         */
+        internal fun register(
+            project: Project,
+            name: String,
+            configurationAction: BugsnagUploadJsSourceMapTask.() -> Unit
+        ): TaskProvider<out BugsnagUploadJsSourceMapTask> {
+            return when {
+                project.gradle.versionNumber() >= GradleVersions.VERSION_5_3 -> {
+                    project.tasks.register<BugsnagUploadJsSourceMapTaskGradle53Plus>(name, configurationAction)
+                } else -> {
+                    project.tasks.register<BugsnagUploadJsSourceMapTaskLegacy>(name, configurationAction)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Legacy [BugsnagUploadJsSourceMapTask] task that requires using [ProjectLayout.configurableFiles].
+ */
+internal open class BugsnagUploadJsSourceMapTaskLegacy @Inject constructor(
+    objects: ObjectFactory,
+    projectLayout: ProjectLayout
+) : BugsnagUploadJsSourceMapTask(objects) {
+
+    @get:InputFiles
+    override val projectRootFileProvider: ConfigurableFileCollection = projectLayout.configurableFiles()
+}
+
+internal open class BugsnagUploadJsSourceMapTaskGradle53Plus @Inject constructor(
+    objects: ObjectFactory
+) : BugsnagUploadJsSourceMapTask(objects) {
+
+    @get:InputFiles
+    override val projectRootFileProvider: ConfigurableFileCollection = objects.fileCollection()
 }


### PR DESCRIPTION
## Goal

Adds mazerunner scenarios that verify the BAGP can upload JS source maps in a react native app. This additionally integrates `bugsnag-source-maps` into the plugin as a prerelease version is now available.

## Changeset

- Made it possible for each RN fixture to enable productFlavors, to enable Hermes, and to disable bugsnag's `uploadReactNativeMappings` flag
- Integrated the `bugsnag-source-maps` command by finding the project's `node_modules` folder and running the CLI
- Added scenarios for:
  - Assembling an app
  - Bundling an app
  - Assembling an app that uses product flavors
  - Manually invoking the source map upload task
  - Disabling sourcemap upload
  - Uploading a Hermes sourcemap
- Updated CI version of Node to 12

Steps were added to mazerunner to help verify the source map request contained the expected fields.


