### PR TITLE
Automatically add maven repository for react-native AARs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## TBD
 
+* Automatically add maven repository for react-native AARs
+  [#334](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/334)
+
 * Populate task inputs for BugsnagUploadJsSourceMapTask
   [#332](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/332)
 

--- a/features/fixtures/rn060/android/app/src/main/java/com/rn060/MainApplication.java
+++ b/features/fixtures/rn060/android/app/src/main/java/com/rn060/MainApplication.java
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
+import com.bugsnag.android.Bugsnag;
 import com.facebook.soloader.SoLoader;
 
 import java.util.List;
@@ -44,6 +45,7 @@ public class MainApplication extends Application implements ReactApplication {
   @Override
   public void onCreate() {
     super.onCreate();
+    Bugsnag.start(this);
     SoLoader.init(this, /* native exopackage */ false);
   }
 }

--- a/features/fixtures/rn060/package.json
+++ b/features/fixtures/rn060/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@bugsnag/react-native": "^7.5.1",
     "react": "16.8.6",
     "react-native": "0.60.6"
   },

--- a/features/fixtures/rn061/android/app/src/main/java/com/rn061/MainApplication.java
+++ b/features/fixtures/rn061/android/app/src/main/java/com/rn061/MainApplication.java
@@ -7,6 +7,7 @@ import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
+import com.bugsnag.android.Bugsnag;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
@@ -42,6 +43,7 @@ public class MainApplication extends Application implements ReactApplication {
   @Override
   public void onCreate() {
     super.onCreate();
+    Bugsnag.start(this);
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this); // Remove this line if you don't want Flipper enabled
   }

--- a/features/fixtures/rn061/package.json
+++ b/features/fixtures/rn061/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@bugsnag/react-native": "^7.5.1",
     "react": "16.9.0",
     "react-native": "0.61.5"
   },

--- a/features/fixtures/rn062/android/app/src/main/java/com/rn062/MainApplication.java
+++ b/features/fixtures/rn062/android/app/src/main/java/com/rn062/MainApplication.java
@@ -8,6 +8,7 @@ import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
+import com.bugsnag.android.Bugsnag;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
@@ -43,6 +44,7 @@ public class MainApplication extends Application implements ReactApplication {
   @Override
   public void onCreate() {
     super.onCreate();
+    Bugsnag.start(this);
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
   }

--- a/features/fixtures/rn062/package.json
+++ b/features/fixtures/rn062/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@bugsnag/react-native": "^7.5.1",
     "react": "16.11.0",
     "react-native": "0.62.2"
   },

--- a/features/fixtures/rn063/android/app/src/main/java/com/rn063/MainApplication.java
+++ b/features/fixtures/rn063/android/app/src/main/java/com/rn063/MainApplication.java
@@ -8,6 +8,7 @@ import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
+import com.bugsnag.android.Bugsnag;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
@@ -43,6 +44,7 @@ public class MainApplication extends Application implements ReactApplication {
   @Override
   public void onCreate() {
     super.onCreate();
+    Bugsnag.start(this);
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
   }

--- a/features/fixtures/rn063/package.json
+++ b/features/fixtures/rn063/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@bugsnag/react-native": "^7.5.1",
     "react": "16.13.1",
     "react-native": "0.63.3"
   },

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -290,6 +290,25 @@ class BugsnagPlugin : Plugin<Project> {
             if (uploadSourceMapProvider != null) {
                 variant.register(project, uploadSourceMapProvider, reactNativeEnabled)
             }
+            addReactNativeMavenRepo(project)
+        }
+    }
+
+    /**
+     * If the project uses react-native, this adds the node_module directory
+     * containing the Android AARs as a maven repository. This allows the
+     * project to compile without the user explicitly adding the maven repository.
+     */
+    private fun addReactNativeMavenRepo(project: Project) {
+        val props = project.extensions.extraProperties
+        val hasReact = props.has("react")
+        if (hasReact) {
+            project.rootProject.allprojects { subProj ->
+                val rootDir = subProj.rootDir
+                subProj.repositories.maven { repo ->
+                    repo.setUrl("$rootDir/../node_modules/@bugsnag/react-native/android")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Goal

Automatically adds a [maven repository](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:declaring_multiple_repositories) for the directory in the `@bugsnag/react-native` node_module which contains the bugsnag-android AARs. This simplifies the setup for React Native apps using bugsnag, as they will no longer need to add [`bugsnag-react-native.gradle`](https://docs.bugsnag.com/platforms/react-native/react-native/#android) in their build scripts.

The repository is added for any project using react-native as it is required for the app to compile.

## Testing

Ran the example react-native app in the following scenarios:

1. current instructions: `apply from: "../../node_modules/@bugsnag/react-native/bugsnag-react-native.gradle"` 
2. no plugin or current instructions
3. the bugsnag plugin applied to the project

The build failed for 2 which confirms that the plugin picks up the AARs in the node module.