### PR TITLE
Create separate task for generating JVM mapping file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Create separate task for generating JVM mapping file
+  [#335](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/335)
+
 ## 5.3.0 (2020-10-15)
 
 * Ensure libil2cpp has correct file extension

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
@@ -1,8 +1,8 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.ApkVariantOutput
-import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.NDK_SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.GradleVersions
+import com.bugsnag.android.gradle.internal.NDK_SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.clearDir
 import com.bugsnag.android.gradle.internal.includesAbi
 import com.bugsnag.android.gradle.internal.mapProperty

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateProguardTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateProguardTask.kt
@@ -1,0 +1,108 @@
+package com.bugsnag.android.gradle
+
+import com.bugsnag.android.gradle.internal.GradleVersions
+import com.bugsnag.android.gradle.internal.property
+import com.bugsnag.android.gradle.internal.register
+import com.bugsnag.android.gradle.internal.versionNumber
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.NONE
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+import javax.inject.Inject
+
+/**
+ * Task to generate compressed JVM mapping files to Bugsnag.
+ */
+sealed class BugsnagGenerateProguardTask @Inject constructor(
+    objects: ObjectFactory
+) : DefaultTask(), AndroidManifestInfoReceiver {
+
+    init {
+        group = BugsnagPlugin.GROUP_NAME
+        description = "Generates a compressed JVM mapping file for upload to Bugsnag"
+    }
+
+    @get:InputFiles
+    abstract val mappingFileProperty: ConfigurableFileCollection
+
+    @get:PathSensitive(NONE)
+    @get:InputFile
+    override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
+
+    @get:OutputFile
+    val archiveOutputFile: RegularFileProperty = objects.fileProperty()
+
+    @get:Input
+    val failOnUploadError: Property<Boolean> = objects.property()
+
+    @TaskAction
+    fun upload() {
+        val mappingFile = mappingFileProperty.singleFile
+        if (mappingFile.length() == 0L) { // proguard's -dontobfuscate generates an empty mapping file
+            logger.warn("Bugsnag: Ignoring empty proguard file")
+            return
+        }
+        if (!mappingFile.exists()) {
+            logger.warn("Bugsnag: Mapping file not found: $mappingFile")
+            if (failOnUploadError.get()) {
+                throw IllegalStateException("Mapping file not found: $mappingFile")
+            }
+        }
+        val archive = archiveOutputFile.asFile.get()
+        mappingFile.copyTo(archive)
+    }
+
+    companion object {
+
+        /**
+         * Registers the appropriate subtype to this [project] with the given [name] and
+         * [configurationAction]
+         */
+        internal fun register(
+            project: Project,
+            name: String,
+            configurationAction: BugsnagGenerateProguardTask.() -> Unit
+        ): TaskProvider<out BugsnagGenerateProguardTask> {
+            return when {
+                project.gradle.versionNumber() >= GradleVersions.VERSION_5_3 -> {
+                    project.tasks.register<BugsnagGenerateProguardTaskGradle53Plus>(name, configurationAction)
+                }
+                else -> {
+                    project.tasks.register<BugsnagGenerateProguardTaskLegacy>(name, configurationAction)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Legacy [BugsnagGenerateProguardTask] task that requires using [getProject] and
+ * [ProjectLayout.configurableFiles].
+ */
+internal open class BugsnagGenerateProguardTaskLegacy @Inject constructor(
+    objects: ObjectFactory,
+    projectLayout: ProjectLayout
+) : BugsnagGenerateProguardTask(objects) {
+
+    @get:InputFiles
+    override val mappingFileProperty: ConfigurableFileCollection = projectLayout.configurableFiles()
+}
+
+internal open class BugsnagGenerateProguardTaskGradle53Plus @Inject constructor(
+    objects: ObjectFactory
+) : BugsnagGenerateProguardTask(objects) {
+
+    @get:InputFiles
+    override val mappingFileProperty: ConfigurableFileCollection = objects.fileCollection()
+}

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
@@ -1,7 +1,8 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.ApkVariantOutput
-import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.UNITY_SO_MAPPING_DIR
+import com.bugsnag.android.gradle.internal.UNITY_SO_COPY_DIR
+import com.bugsnag.android.gradle.internal.UNITY_SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.clearDir
 import com.bugsnag.android.gradle.internal.includesAbi
 import com.bugsnag.android.gradle.internal.mapProperty
@@ -202,12 +203,6 @@ internal open class BugsnagGenerateUnitySoMappingTask @Inject constructor(
     }
 
     companion object {
-
-        /**
-         * Intermediate path where libunity and other Unity SO files are copied
-         * after being extracted from the Gzip archive
-         */
-        private const val UNITY_SO_COPY_DIR = "intermediates/bugsnag/unitySoFiles"
 
         internal fun register(
             project: Project,

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagInstallJniLibsTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagInstallJniLibsTask.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.gradle
 
 import com.bugsnag.android.gradle.internal.GradleVersions
+import com.bugsnag.android.gradle.internal.JNI_LIBS_DIR
 import com.bugsnag.android.gradle.internal.register
 import com.bugsnag.android.gradle.internal.versionNumber
 import org.gradle.api.DefaultTask
@@ -33,7 +34,7 @@ sealed class BugsnagInstallJniLibsTask(
 
     @get:OutputDirectory
     val buildDirDestination: DirectoryProperty = objects.directoryProperty()
-        .convention(projectLayout.buildDirectory.dir("intermediates/bugsnag-libs"))
+        .convention(projectLayout.buildDirectory.dir(JNI_LIBS_DIR))
 
     @get:InputFiles
     abstract val bugsnagArtifacts: ConfigurableFileCollection

--- a/src/main/kotlin/com/bugsnag/android/gradle/SharedObjectMappingFileFactory.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/SharedObjectMappingFileFactory.kt
@@ -26,9 +26,6 @@ internal object SharedObjectMappingFileFactory {
         UNITY
     }
 
-    internal const val NDK_SO_MAPPING_DIR = "intermediates/bugsnag/soMappings/ndk"
-    internal const val UNITY_SO_MAPPING_DIR = "intermediates/bugsnag/soMappings/unity"
-
     internal data class Params(
         val sharedObject: File,
         val abi: Abi,

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagIntermediates.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagIntermediates.kt
@@ -1,0 +1,73 @@
+package com.bugsnag.android.gradle.internal
+
+import com.android.build.gradle.api.ApkVariantOutput
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+
+/**
+ * Intermediate path where libunity and other Unity SO files are copied
+ * after being extracted from the Gzip archive
+ */
+internal const val UNITY_SO_COPY_DIR = "intermediates/bugsnag/unitySoFiles"
+
+/**
+ * Directory where SO files are extracted from bugsnag-android AARs
+ */
+internal const val JNI_LIBS_DIR = "intermediates/bugsnag-libs"
+
+/**
+ * Intermediate directory where NDK SO mapping files are generated
+ */
+internal const val NDK_SO_MAPPING_DIR = "intermediates/bugsnag/soMappings/ndk"
+
+/**
+ * Intermediate directory where NDK SO mapping files are generated
+ */
+internal const val UNITY_SO_MAPPING_DIR = "intermediates/bugsnag/soMappings/unity"
+
+/**
+ * Gets a unique suffix for a [ApkVariantOutput] which is used in tasks and intermediate directories
+ */
+internal fun ApkVariantOutput.taskNameSuffix() = name.capitalize()
+
+
+/** Intermediate locations for task outputs/inputs **/
+
+
+internal fun intermediateForUnitySoRequest(project: Project, output: ApkVariantOutput): Provider<RegularFile> {
+    val path =  "intermediates/bugsnag/requests/unityFor${output.taskNameSuffix()}.json"
+    return project.layout.buildDirectory.file(path)
+}
+
+internal fun intermediateForReleaseRequest(project: Project, output: ApkVariantOutput): Provider<RegularFile> {
+    val path = "intermediates/bugsnag/requests/releasesFor${output.taskNameSuffix()}.json"
+    return project.layout.buildDirectory.file(path)
+}
+
+internal fun intermediateForNdkSoRequest(project: Project, output: ApkVariantOutput): Provider<RegularFile> {
+    val path = "intermediates/bugsnag/requests/ndkFor${output.taskNameSuffix()}.json"
+    return project.layout.buildDirectory.file(path)
+}
+
+internal fun intermediateForMappingFileRequest(project: Project, output: ApkVariantOutput): Provider<RegularFile> {
+    val path = "intermediates/bugsnag/requests/proguardFor${output.taskNameSuffix()}.json"
+    return project.layout.buildDirectory.file(path)
+}
+
+internal fun intermediateForGenerateJvmMapping(project: Project, output: ApkVariantOutput): Provider<RegularFile> {
+    val path = "intermediates/bugsnag/jvmMappings/mappingFor${output.taskNameSuffix()}.gz"
+    return project.layout.buildDirectory.file(path)
+}
+
+internal fun Project.computeManifestInfoOutputV2(variant: String): Provider<RegularFile> {
+    val path = "intermediates/bugsnag/manifestInfoFor${variant.capitalize()}.json"
+    return layout.buildDirectory.file(path)
+}
+
+internal fun Project.computeManifestInfoOutputV1(
+    output: ApkVariantOutput): Provider<RegularFile> {
+    val path = "intermediates/bugsnag/manifestInfoFor${output.taskNameSuffix()}.json"
+    return layout.buildDirectory.file(path)
+}
+

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagTasks.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagTasks.kt
@@ -1,0 +1,33 @@
+package com.bugsnag.android.gradle.internal
+
+import com.android.build.gradle.api.ApkVariantOutput
+
+
+/** Names of bugsnag gradle tasks **/
+
+
+internal const val TASK_JNI_LIBS = "bugsnagInstallJniLibsTask"
+
+internal fun taskNameForGenerateJvmMapping(output: ApkVariantOutput) =
+    "generateBugsnag${output.taskNameSuffix()}Mapping"
+
+internal fun taskNameForUploadJvmMapping(output: ApkVariantOutput) =
+    "uploadBugsnag${output.taskNameSuffix()}Mapping"
+
+internal fun taskNameForGenerateNdkMapping(output: ApkVariantOutput) =
+    "generateBugsnagNdk${output.taskNameSuffix()}Mapping"
+
+internal fun taskNameForGenerateUnityMapping(output: ApkVariantOutput) =
+    "generateBugsnagUnity${output.taskNameSuffix()}Mapping"
+
+internal fun taskNameForUploadNdkMapping(output: ApkVariantOutput) =
+    "uploadBugsnagNdk${output.taskNameSuffix()}Mapping"
+
+internal fun taskNameForUploadUnityMapping(output: ApkVariantOutput) =
+    "uploadBugsnagUnity${output.taskNameSuffix()}Mapping"
+
+internal fun taskNameForUploadRelease(output: ApkVariantOutput) =
+    "bugsnagRelease${output.taskNameSuffix()}Task"
+
+internal fun taskNameForManifestUuid(variant: String) =
+    "processBugsnag${variant.capitalize()}Manifest"

--- a/src/test/kotlin/com/bugsnag/android/gradle/PluginTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/PluginTest.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android.gradle
 
-import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.api.ApkVariantOutput
+import com.bugsnag.android.gradle.internal.taskNameSuffix
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Assert.assertEquals
@@ -16,9 +16,6 @@ import org.mockito.junit.MockitoJUnitRunner
 class PluginTest {
 
     @Mock
-    lateinit var variant: ApkVariant
-
-    @Mock
     lateinit var variantOutput: ApkVariantOutput
 
     @Test
@@ -28,17 +25,9 @@ class PluginTest {
     }
 
     @Test
-    fun testVariantName() {
-        val plugin = proj.plugins.getPlugin(BugsnagPlugin::class.java)
-        `when`(variant.name).thenReturn("javaExample")
-        assertEquals("JavaExample", plugin.taskNameForVariant(variant))
-    }
-
-    @Test
     fun testOutputName() {
-        val plugin = proj.plugins.getPlugin(BugsnagPlugin::class.java)
         `when`(variantOutput.name).thenReturn("javaExample-hdpi")
-        assertEquals("JavaExample-hdpi", plugin.taskNameForOutput(variantOutput))
+        assertEquals("JavaExample-hdpi", variantOutput.taskNameSuffix())
     }
 
     companion object {


### PR DESCRIPTION
## Goal

Creates a separate task named `BugsnagGenerateProguardTask` that finds the mapping file which will be uploaded to Bugsnag. This will make it possible to cache compressed ProGuard mapping files on disk if the upload task fails.

The changeset additionally reorganises the task name/intermediate location calculations so that they live in separate files from `BugsnagPlugin`.

## Changeset

- Split `BugsnagGenerateProguardTask` and `BugsnagUploadProguardTask` into separate tasks
- Ensured that `BugsnagGenerateProguardTask` finds the mapping file and copies it to the location (a future PR will create a gzip archive from this)
- Reorganized directories of intermediate files created by the plugin into `BugsnagIntermediates`
- Reorganized names of tasks created by the plugin into `BugsnagTasks`


## Testing

Relied on existing E2E tests - this should not result in any functional changes to the plugin.