### PR TITLE
Compress JVM mapping files using gzip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Create separate task for generating JVM mapping file
   [#335](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/335)
 
+* Compress JVM mapping files using gzip
+  [#336](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/336)
+
 ## 5.3.0 (2020-10-15)
 
 * Ensure libil2cpp has correct file extension

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateProguardTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateProguardTask.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.gradle
 
 import com.bugsnag.android.gradle.internal.GradleVersions
+import com.bugsnag.android.gradle.internal.outputZipFile
 import com.bugsnag.android.gradle.internal.property
 import com.bugsnag.android.gradle.internal.register
 import com.bugsnag.android.gradle.internal.versionNumber
@@ -60,7 +61,9 @@ sealed class BugsnagGenerateProguardTask @Inject constructor(
             }
         }
         val archive = archiveOutputFile.asFile.get()
-        mappingFile.copyTo(archive)
+        mappingFile.inputStream().use { stream ->
+            outputZipFile(stream, archive)
+        }
     }
 
     companion object {

--- a/src/main/kotlin/com/bugsnag/android/gradle/SharedObjectMappingFileFactory.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/SharedObjectMappingFileFactory.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.gradle
 import com.android.build.gradle.AppExtension
 import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.SharedObjectType.NDK
 import com.bugsnag.android.gradle.SharedObjectMappingFileFactory.SharedObjectType.UNITY
+import com.bugsnag.android.gradle.internal.outputZipFile
 import okio.buffer
 import okio.gzip
 import okio.sink
@@ -121,21 +122,6 @@ internal object SharedObjectMappingFileFactory {
     }
 
     private fun getObjDumpOverride(objDumpPaths: Map<String, String>, arch: String) = objDumpPaths[arch]
-
-    /**
-     * Outputs the contents of stdout into the gzip file output file
-     *
-     * @param stdout The input stream
-     * @param outputFile The output file
-     * included in the output file or not
-     */
-    private fun outputZipFile(stdout: InputStream, outputFile: File) {
-        stdout.source().use { source ->
-            outputFile.sink().gzip().buffer().use { gzipSink ->
-                gzipSink.writeAll(source)
-            }
-        }
-    }
 
     private fun findObjDump(project: Project, arch: String): File {
         val abi = Abi.findByName(arch)

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/IOUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/IOUtil.kt
@@ -1,0 +1,23 @@
+package com.bugsnag.android.gradle.internal
+
+import okio.buffer
+import okio.gzip
+import okio.sink
+import okio.source
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Outputs the contents of stdout into the gzip file output file
+ *
+ * @param stdout The input stream
+ * @param outputFile The output file
+ * included in the output file or not
+ */
+internal fun outputZipFile(stdout: InputStream, outputFile: File) {
+    stdout.source().use { source ->
+        outputFile.sink().gzip().buffer().use { gzipSink ->
+            gzipSink.writeAll(source)
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Compresses JVM mapping files using gzip before they are delivered to the Bugsnag Upload API. Using compression should drastically reduce the amount of bandwidth required - in a basic example project this reduced the file size from 1.5Mb to 0.25Mb.

## Changeset

Repurposed the existing `outputZipFile` function so that it can be used in `BugsnagGenerateProguardTask` as well as `SharedObjectMappingFileFactory`.

## Testing

Relied on existing mazerunner scenarios and additionally verified manually that deobfuscation was correct. An additional PR will enhance mazerunner scenarios to decompress and inspect the contents of the mapping file, once the test infrastructure is in place.