### PR TITLE
Allow decompression of JVM mapping files in mazerunner

### DIFF
--- a/features/abi_apk_splits.feature
+++ b/features/abi_apk_splits.feature
@@ -27,6 +27,11 @@ Scenario: ABI Splits project builds successfully
       | 7           | 1.0         | com.bugsnag.android.example |
       | 8           | 1.0         | com.bugsnag.android.example |
 
+    And 8 requests have an R8 mapping file with the following symbols:
+      | jvmSymbols |
+      | com.Bar |
+      | void doSomething() |
+
 @skip_agp4_1_or_higher
 Scenario: ABI Splits automatic upload disabled
     When I build "abi_splits" using the "all_disabled" bugsnag config

--- a/features/app_bundle.feature
+++ b/features/app_bundle.feature
@@ -12,6 +12,11 @@ Scenario: Single-module default app bundles successfully
       | versionCode | versionName | appId                       | overwrite |
       | 1           | 1.0         | com.bugsnag.android.example | null      |
 
+    And 1 requests have an R8 mapping file with the following symbols:
+      | jvmSymbols |
+      | com.Bar |
+      | void doSomething() |
+
 Scenario: Bundling multiple flavors automatically
     When I bundle "flavors" using the "standard" bugsnag config
     And I wait to receive 4 requests

--- a/features/default_app.feature
+++ b/features/default_app.feature
@@ -11,3 +11,8 @@ Scenario: Single-module default app builds successfully
     And 1 requests are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                       | overwrite |
       | 1           | 1.0         | com.bugsnag.android.example | null      |
+
+    And 1 requests have an R8 mapping file with the following symbols:
+      | jvmSymbols |
+      | com.Bar |
+      | void doSomething() |

--- a/features/flavors.feature
+++ b/features/flavors.feature
@@ -14,6 +14,11 @@ Scenario: Flavors automatic upload on build
       | 1           | 1.0         | com.bugsnag.android.example.bar |
       | 1           | 1.0         | com.bugsnag.android.example.foo |
 
+    And 2 requests have an R8 mapping file with the following symbols:
+      | jvmSymbols |
+      | com.Bar |
+      | void doSomething() |
+
 Scenario: Flavors automatic upload disabled
     When I build "flavors" using the "all_disabled" bugsnag config
     And I wait for 5 seconds

--- a/features/ndk_app_agp400.feature
+++ b/features/ndk_app_agp400.feature
@@ -30,7 +30,6 @@ Scenario: NDK apps send requests
     And 1 requests have an R8 mapping file with the following symbols:
       | jvmSymbols |
       | com.bugsnag.android.ndkapp.MainActivity |
-      | java.lang.String doSomething() |
 
 @requires_agp4_0_or_higher
 Scenario: Custom projectRoot is added to payload

--- a/features/ndk_app_agp400.feature
+++ b/features/ndk_app_agp400.feature
@@ -27,6 +27,11 @@ Scenario: NDK apps send requests
       | appId                      |
       | com.bugsnag.android.ndkapp |
 
+    And 1 requests have an R8 mapping file with the following symbols:
+      | jvmSymbols |
+      | com.bugsnag.android.ndkapp.MainActivity |
+      | java.lang.String doSomething() |
+
 @requires_agp4_0_or_higher
 Scenario: Custom projectRoot is added to payload
     When I set environment variable "PROJECT_ROOT" to "/repos/custom/my-app"

--- a/features/ndk_app_legacy.feature
+++ b/features/ndk_app_legacy.feature
@@ -20,6 +20,11 @@ Scenario: NDK apps send requests
         | appId                      |
         | com.bugsnag.android.ndkapp |
 
+    And 1 requests have an R8 mapping file with the following symbols:
+        | jvmSymbols |
+        | com.bugsnag.android.ndkapp.MainActivity |
+        | java.lang.String doSomething() |
+
 @skip_agp4_0_or_higher
 Scenario: Custom projectRoot is added to payload
     When I set environment variable "PROJECT_ROOT" to "/repos/custom/my-app"


### PR DESCRIPTION
## Goal

Allows JVM mapping files to be inflated from a gzip archive in mazerunner. This adds a mazerunner step which allows the developer to assert that mapping entries exist in the mapping file for a list of symbol names.

Existing E2E scenarios have also been updated so that they verify the contents of the mapping files. This aims to get a representative number of scenarios, including:

- Default JVM app
- App with productFlavors
- App with APK splits
- NDK app