### PR TITLE
Update mazerunner to v3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', tag: 'v2.6.0'
+gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/clear-env-option'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/clear-env-option'
+gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: e8a70972f802a48ecb661a9d4dba711927a7fc59
-  tag: v2.6.0
+  revision: 8cba7aa85e36f5c87821c93ea3cae119b3be61d7
+  branch: tms/clear-env-option
   specs:
-    bugsnag-maze-runner (2.6.0)
+    bugsnag-maze-runner (3.3.0)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -45,7 +45,7 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    curb (0.9.10)
+    curb (0.9.11)
     diff-lcs (1.4.4)
     eventmachine (1.2.7)
     faye-websocket (0.11.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 8cba7aa85e36f5c87821c93ea3cae119b3be61d7
-  branch: tms/clear-env-option
+  revision: 2bc87663b66355a73d86bbe1b9159ac6b9387a9f
+  tag: v3.4.0
   specs:
     bugsnag-maze-runner (3.3.0)
       appium_lib (~> 10.2)


### PR DESCRIPTION
## Goal

Updates mazerunner to v3. This is required to use steps added in v3 where the server sends a failure status code.