### PR TITLE
Add nodeModulesDir to bugsnag plugin extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## TBD
 
+* Add nodeModulesDir to bugsnag plugin extension
+  [#343](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/343)
+
 * Automatically add maven repository for react-native AARs
   [#334](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/334)
 

--- a/features/fixtures/rn060/android/app/build.gradle
+++ b/features/fixtures/rn060/android/app/build.gradle
@@ -232,5 +232,8 @@ if (!System.env.UPDATING_GRADLEW) {
         if (System.env.UPLOAD_RN_MAPPINGS == "false") {
             uploadReactNativeMappings = false
         }
+        if (System.env.CUSTOM_NODE_MODULES_DIR == "true") {
+            nodeModulesDir = new File(project.rootDir.parentFile, "node_modules")
+        }
     }
 }

--- a/features/fixtures/rn061/android/app/build.gradle
+++ b/features/fixtures/rn061/android/app/build.gradle
@@ -223,5 +223,8 @@ if (!System.env.UPDATING_GRADLEW) {
         if (System.env.UPLOAD_RN_MAPPINGS == "false") {
             uploadReactNativeMappings = false
         }
+        if (System.env.CUSTOM_NODE_MODULES_DIR == "true") {
+            nodeModulesDir = new File(project.rootDir.parentFile, "node_modules")
+        }
     }
 }

--- a/features/fixtures/rn062/android/app/build.gradle
+++ b/features/fixtures/rn062/android/app/build.gradle
@@ -247,5 +247,8 @@ if (!System.env.UPDATING_GRADLEW) {
         if (System.env.UPLOAD_RN_MAPPINGS == "false") {
             uploadReactNativeMappings = false
         }
+        if (System.env.CUSTOM_NODE_MODULES_DIR == "true") {
+            nodeModulesDir = new File(project.rootDir.parentFile, "node_modules")
+        }
     }
 }

--- a/features/fixtures/rn063/android/app/build.gradle
+++ b/features/fixtures/rn063/android/app/build.gradle
@@ -241,5 +241,8 @@ if (!System.env.UPDATING_GRADLEW) {
         if (System.env.UPLOAD_RN_MAPPINGS == "false") {
             uploadReactNativeMappings = false
         }
+        if (System.env.CUSTOM_NODE_MODULES_DIR == "true") {
+            nodeModulesDir = new File(project.rootDir.parentFile, "node_modules")
+        }
     }
 }

--- a/features/react_native.feature
+++ b/features/react_native.feature
@@ -101,3 +101,20 @@ Scenario: Plugin handles server failure gracefully
         | 5              | 2.45.beta  | false     | false |
         | 5              | 2.45.beta  | false     | false |
     And the exit code equals 0
+
+Scenario: Source maps are uploaded when assembling an app with a custom nodeModulesDir
+    When I set environment variable "CUSTOM_NODE_MODULES_DIR" to "true"
+    When I build the React Native app
+    And I wait to receive 3 requests
+
+    Then 1 requests are valid for the build API and match the following:
+      | appVersionCode | appVersion | buildTool      |
+      | 5              | 2.45.beta  | gradle-android |
+
+    And 1 requests are valid for the android mapping API and match the following:
+      | versionCode | versionName | appId                     |
+      | 5              | 2.45.beta  | com.bugsnag.android.rnapp |
+
+    And 1 requests are valid for the JS source map API and match the following:
+        | appVersionCode | appVersion | overwrite | dev   |
+        | 5              | 2.45.beta  | false     | false |

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
@@ -16,6 +16,7 @@ import java.io.File
 // To make kotlin happy with gradle's nullability
 private val NULL_STRING: String? = null
 private val NULL_BOOLEAN: Boolean? = null
+private val NULL_FILE: File? = null
 
 /**
  * Defines configuration options (Gradle plugin extensions) for the BugsnagPlugin
@@ -60,6 +61,9 @@ open class BugsnagPluginExtension(objects: ObjectFactory) {
 
     val sharedObjectPaths: ListProperty<File> = objects.listProperty<File>()
         .convention(emptyList())
+
+    val nodeModulesDir: Property<File> = objects.property<File>()
+        .convention(NULL_FILE)
 
     val projectRoot: Property<String> = objects.property<String>().convention(NULL_STRING)
 

--- a/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
@@ -47,6 +47,7 @@ class PluginExtensionTest {
             assertNull(sourceControl.repository.orNull)
             assertNull(sourceControl.revision.orNull)
             assertNull(sourceControl.provider.orNull)
+            assertNull(nodeModulesDir.orNull)
         }
 
         // ndk/unity upload defaults to false
@@ -84,6 +85,7 @@ class PluginExtensionTest {
             metadata.set(mapOf(Pair("test", "a")))
             objdumpPaths.set(mapOf(Pair("armeabi-v7a", "/test/foo")))
             sharedObjectPaths.set(listOf(File("/test/bar")))
+            nodeModulesDir.set(File("/test/foo/node_modules"))
 
             sourceControl.repository.set("https://github.com")
             sourceControl.revision.set("d0e98fc")
@@ -107,6 +109,7 @@ class PluginExtensionTest {
             assertEquals(mapOf(Pair("test", "a")), metadata.get())
             assertEquals(mapOf(Pair("armeabi-v7a", "/test/foo")), objdumpPaths.get())
             assertEquals(listOf(File("/test/bar")), sharedObjectPaths.get())
+            assertEquals(File("/test/foo/node_modules"), nodeModulesDir.get())
             assertEquals("https://github.com", sourceControl.repository.get())
             assertEquals("d0e98fc", sourceControl.revision.get())
             assertEquals("github", sourceControl.provider.get())


### PR DESCRIPTION
## Goal

The gradle plugin assumes that the local `node_modules` for an Android project are always in the same location, which works fine for the default case. However, if a user puts them in a different directory then the plugin would not be able to run the `bugsnag-source-maps` command, or find bugsnag-android’s AARs bundled in the react-native node_module.

This changeset supports this scenario by exposing a configuration option on the bugsnag plugin extension which allows users to override the default location of the node_modules.

## Testing

Added E2E scenario to verify that setting the `nodeModulesDir` to a custom location works.