### PR TITLE
Prevent windows crash when generating Unity mapping files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Prevent windows crash when generating Unity mapping files
+  [#344](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/344)
+
 ## 5.4.0 (2020-11-04)
 
 This release improves performance by always compressing ProGuard/R8 mapping files before attempting upload.

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
@@ -62,7 +62,7 @@ internal open class BugsnagGenerateUnitySoMappingTask @Inject constructor(
     val unitySharedObjectDir: DirectoryProperty = objects.directoryProperty()
         .convention(projectLayout.buildDirectory.dir(UNITY_SO_COPY_DIR))
 
-    @get:InputDirectory
+    @get:Internal
     val rootProjectDir: DirectoryProperty = objects.directoryProperty()
 
     @TaskAction


### PR DESCRIPTION
## Goal

Prevents a crash on Windows when generating Unity mapping files. The `rootProjectDir` was unnecessarily defined as a task input, which is hashed by Gradle for the purposes of knowing whether to cache the output or not. On Windows a file lock is taken out on this directory which prevents the hash, throwing an exception. Marking the property as internal instead means no exception is thrown.

## Testing

Ran on a Windows machine and verified that the task completed without throwing an exception when using a local artefact.

It's worth noting that objdump appears to fail to generate SO files for libunity/libil2cpp, so this will require further investigation - but this fixes the immediate issue of crashing in the plugin.