### PR TITLE
Tweak error message for missing source-map tool

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.bugsnag
-version = 5.4.0
+version = 5.5.0-alpha01
 
 ANDROID_MIN_SDK_VERSION=14
 ANDROID_TARGET_SDK_VERSION=29


### PR DESCRIPTION
## Goal

Tweaks the error message for when the RN source map tool is not installed. The build is now failed only if the executable is present, as it was agreed this would otherwise break existing user's builds.