### PR TITLE
Disable react native sourcemap upload by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## TBD
 
+* Disable react native sourcemap upload by default
+  [#351](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/351)
+
 * Add nodeModulesDir to bugsnag plugin extension
   [#343](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/343)
 

--- a/features/fixtures/rn060/android/app/build.gradle
+++ b/features/fixtures/rn060/android/app/build.gradle
@@ -228,10 +228,8 @@ if (!System.env.UPDATING_GRADLEW) {
     bugsnag {
         endpoint = "http://localhost:9339"
         releasesEndpoint = "http://localhost:9339"
+        uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 
-        if (System.env.UPLOAD_RN_MAPPINGS == "false") {
-            uploadReactNativeMappings = false
-        }
         if (System.env.CUSTOM_NODE_MODULES_DIR == "true") {
             nodeModulesDir = new File(project.rootDir.parentFile, "node_modules")
         }

--- a/features/fixtures/rn061/android/app/build.gradle
+++ b/features/fixtures/rn061/android/app/build.gradle
@@ -219,10 +219,8 @@ if (!System.env.UPDATING_GRADLEW) {
     bugsnag {
         endpoint = "http://localhost:9339"
         releasesEndpoint = "http://localhost:9339"
+        uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 
-        if (System.env.UPLOAD_RN_MAPPINGS == "false") {
-            uploadReactNativeMappings = false
-        }
         if (System.env.CUSTOM_NODE_MODULES_DIR == "true") {
             nodeModulesDir = new File(project.rootDir.parentFile, "node_modules")
         }

--- a/features/fixtures/rn062/android/app/build.gradle
+++ b/features/fixtures/rn062/android/app/build.gradle
@@ -243,10 +243,8 @@ if (!System.env.UPDATING_GRADLEW) {
     bugsnag {
         endpoint = "http://localhost:9339"
         releasesEndpoint = "http://localhost:9339"
+        uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 
-        if (System.env.UPLOAD_RN_MAPPINGS == "false") {
-            uploadReactNativeMappings = false
-        }
         if (System.env.CUSTOM_NODE_MODULES_DIR == "true") {
             nodeModulesDir = new File(project.rootDir.parentFile, "node_modules")
         }

--- a/features/fixtures/rn063/android/app/build.gradle
+++ b/features/fixtures/rn063/android/app/build.gradle
@@ -237,10 +237,8 @@ if (!System.env.UPDATING_GRADLEW) {
     bugsnag {
         endpoint = "http://localhost:9339"
         releasesEndpoint = "http://localhost:9339"
+        uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 
-        if (System.env.UPLOAD_RN_MAPPINGS == "false") {
-            uploadReactNativeMappings = false
-        }
         if (System.env.CUSTOM_NODE_MODULES_DIR == "true") {
             nodeModulesDir = new File(project.rootDir.parentFile, "node_modules")
         }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -193,7 +193,7 @@ class BugsnagPlugin : Plugin<Project> {
             val jvmMinificationEnabled = project.isJvmMinificationEnabled(variant)
             val ndkEnabled = isNdkUploadEnabled(bugsnag, android)
             val unityEnabled = isUnityLibraryUploadEnabled(bugsnag, android)
-            val reactNativeEnabled = isReactNativeUploadEnabled(project, bugsnag)
+            val reactNativeEnabled = isReactNativeUploadEnabled(bugsnag)
 
             // skip tasks for variant if JVM/NDK/Unity minification not enabled
             if (!jvmMinificationEnabled && !ndkEnabled && !unityEnabled && !reactNativeEnabled) {
@@ -699,12 +699,9 @@ class BugsnagPlugin : Plugin<Project> {
     }
 
     internal fun isReactNativeUploadEnabled(
-        project: Project,
         bugsnag: BugsnagPluginExtension
     ): Boolean {
-        val props = project.extensions.extraProperties
-        val hasReact = props.has("react")
-        return bugsnag.uploadReactNativeMappings.getOrElse(hasReact)
+        return bugsnag.uploadReactNativeMappings.getOrElse(false)
     }
 
     /**

--- a/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
@@ -55,7 +55,7 @@ class PluginExtensionTest {
         val plugin = proj.plugins.findPlugin(BugsnagPlugin::class.java)!!
         assertFalse(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
         assertFalse(plugin.isNdkUploadEnabled(bugsnag, android))
-        assertFalse(plugin.isReactNativeUploadEnabled(proj, bugsnag))
+        assertFalse(plugin.isReactNativeUploadEnabled(bugsnag))
         assertEquals(emptyList<File>(), plugin.getSharedObjectSearchPaths(proj, bugsnag, android))
     }
 
@@ -120,7 +120,7 @@ class PluginExtensionTest {
         val plugin = proj.plugins.findPlugin(BugsnagPlugin::class.java)!!
         assertTrue(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
         assertTrue(plugin.isNdkUploadEnabled(bugsnag, android))
-        assertTrue(plugin.isReactNativeUploadEnabled(proj, bugsnag))
+        assertTrue(plugin.isReactNativeUploadEnabled(bugsnag))
         val expected = listOf(
             File("/test/bar"),
             File(proj.projectDir, "src/main/jniLibs"),
@@ -153,14 +153,14 @@ class PluginExtensionTest {
     }
 
     /**
-     * Verifies that the React Native heuristics control whether tasks are created
+     * Verifies that in a project with the React property extension upload is disabled by default
      */
     @Test
     fun reactNativeUploadHeuristics() {
         val bugsnag = proj.extensions.getByType(BugsnagPluginExtension::class.java)
         val plugin = proj.plugins.findPlugin(BugsnagPlugin::class.java)!!
         proj.extensions.extraProperties.set("react", "some value")
-        assertTrue(plugin.isReactNativeUploadEnabled(proj, bugsnag))
+        assertFalse(plugin.isReactNativeUploadEnabled(bugsnag))
     }
 
     /**


### PR DESCRIPTION
## Goal

Disables React Native sourcemap upload by default. Users can still enable this by manually setting `uploadReactNativeMappings` to `true`. This will be added to user's build scripts automatically by the RN CLI, which is seen as an opt-in to using the functionality.

## Testing

Relied on existing unit and E2E tests.