### PR TITLE
Append sourcemap path to endpoint provided by plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## TBD
 
+* Append sourcemap path to endpoint provided by plugin
+  [#352](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/352)
+
 * Disable react native sourcemap upload by default
   [#351](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/351)
 

--- a/features/fixtures/rn060/package.json
+++ b/features/fixtures/rn060/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/runtime": "^7.12.1",
-    "@bugsnag/source-maps": "^1.0.0-alpha.0",
+    "@bugsnag/source-maps": "^1.0.0-beta.1",
     "@react-native-community/eslint-config": "^2.0.0",
     "babel-jest": "^26.6.0",
     "eslint": "^7.11.0",

--- a/features/fixtures/rn061/package.json
+++ b/features/fixtures/rn061/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/runtime": "^7.12.1",
-    "@bugsnag/source-maps": "^1.0.0-alpha.0",
+    "@bugsnag/source-maps": "^1.0.0-beta.1",
     "@react-native-community/eslint-config": "^2.0.0",
     "babel-jest": "^26.6.0",
     "eslint": "^7.11.0",

--- a/features/fixtures/rn062/package.json
+++ b/features/fixtures/rn062/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/runtime": "^7.12.1",
-    "@bugsnag/source-maps": "^1.0.0-alpha.0",
+    "@bugsnag/source-maps": "^1.0.0-beta.1",
     "@react-native-community/eslint-config": "^2.0.0",
     "babel-jest": "^26.6.0",
     "eslint": "^7.11.0",

--- a/features/fixtures/rn063/package.json
+++ b/features/fixtures/rn063/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/runtime": "^7.12.1",
-    "@bugsnag/source-maps": "^1.0.0-alpha.0",
+    "@bugsnag/source-maps": "^1.0.0-beta.1",
     "@react-native-community/eslint-config": "^2.0.0",
     "babel-jest": "^26.6.0",
     "eslint": "^7.11.0",

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -40,6 +40,7 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
+import java.net.URL
 import java.util.UUID
 
 /**
@@ -482,7 +483,7 @@ class BugsnagPlugin : Plugin<Project> {
             bundleJsFileProvider.set(File(rnBundle))
             sourceMapFileProvider.set(File(rnSourceMap))
             overwrite.set(bugsnag.overwrite)
-            endpoint.set(bugsnag.endpoint)
+            endpoint.set(getSourcemapUploadEndpoint(bugsnag))
             devEnabled.set("true" == dev)
             failOnUploadError.set(bugsnag.failOnUploadError)
 
@@ -494,6 +495,16 @@ class BugsnagPlugin : Plugin<Project> {
             val cliPath = File(nodeModulesDir, "@bugsnag/source-maps/bin/cli")
             bugsnagSourceMaps.set(cliPath)
             mustRunAfter(rnTask)
+        }
+    }
+
+    internal fun getSourcemapUploadEndpoint(bugsnag: BugsnagPluginExtension): String? {
+        return when (val endpoint = bugsnag.endpoint.get()) {
+            UPLOAD_ENDPOINT_DEFAULT -> endpoint
+            else -> {
+                val host = URL(endpoint)
+                return URL(host, "react-native-source-map").toString()
+            }
         }
     }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
@@ -18,6 +18,8 @@ private val NULL_STRING: String? = null
 private val NULL_BOOLEAN: Boolean? = null
 private val NULL_FILE: File? = null
 
+internal const val UPLOAD_ENDPOINT_DEFAULT: String = "https://upload.bugsnag.com"
+
 /**
  * Defines configuration options (Gradle plugin extensions) for the BugsnagPlugin
  */
@@ -48,7 +50,7 @@ open class BugsnagPluginExtension(objects: ObjectFactory) {
         .convention(false)
 
     val endpoint: Property<String> = objects.property<String>()
-        .convention("https://upload.bugsnag.com")
+        .convention(UPLOAD_ENDPOINT_DEFAULT)
 
     val releasesEndpoint = objects.property<String>()
         .convention("https://build.bugsnag.com")

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
@@ -127,12 +127,15 @@ sealed class BugsnagUploadJsSourceMapTask @Inject constructor(
             "--bundle",
             bundleJsFileProvider.asFile.get().absolutePath,
 
-            "--endpoint",
-            endpoint.get(),
-
             "--project-root",
             projectRootFileProvider.singleFile.absolutePath
         )
+
+        // only supply the endpoint if the user has overridden it (on-prem)
+        if (UPLOAD_ENDPOINT_DEFAULT != endpoint.get()) {
+            cmd.add("--endpoint")
+            cmd.add(endpoint.get())
+        }
 
         if (overwrite.get()) {
             cmd.add("--overwrite")

--- a/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
@@ -56,6 +56,7 @@ class PluginExtensionTest {
         assertFalse(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
         assertFalse(plugin.isNdkUploadEnabled(bugsnag, android))
         assertFalse(plugin.isReactNativeUploadEnabled(bugsnag))
+        assertEquals("https://upload.bugsnag.com", plugin.getSourcemapUploadEndpoint(bugsnag))
         assertEquals(emptyList<File>(), plugin.getSharedObjectSearchPaths(proj, bugsnag, android))
     }
 
@@ -121,6 +122,8 @@ class PluginExtensionTest {
         assertTrue(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
         assertTrue(plugin.isNdkUploadEnabled(bugsnag, android))
         assertTrue(plugin.isReactNativeUploadEnabled(bugsnag))
+        val uploadEndpoint = plugin.getSourcemapUploadEndpoint(bugsnag)
+        assertEquals("http://localhost:1234/react-native-source-map", uploadEndpoint)
         val expected = listOf(
             File("/test/bar"),
             File(proj.projectDir, "src/main/jniLibs"),


### PR DESCRIPTION
## Goal

The plugin needs to add the ~`/sourcemap`~ `/react-native-source-map` route when a custom endpoint is provided, which is then passed to the source map CLI.

## Changeset

If the endpoint is `upload.bugsnag.com`, ~just pass that~ pass nothing. Otherwise, ~`sourcemap`~ `react-native-source-map` should be appended onto the route.

The version of bugsnag-sourcemaps was also bumped to the latest available from npm.

## Testing

Added to existing unit tests to verify that the endpoint is calculated correctly.