### PR TITLE
[PLAT-5618] refactor: Source map CLI now adds the path suffix automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## TBD
 
-* Append sourcemap path to endpoint provided by plugin
+* Provide endpoint configuration to source map CLI
   [#352](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/352)
+  [#353](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/353)
 
 * Disable react native sourcemap upload by default
   [#351](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/351)
@@ -64,7 +65,7 @@ Depending on the contents of the mapping file, this can reduce the upload size b
 
 * Separate generation/upload of shared objects into two tasks
   [#303](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/303)
-  
+
 * Add uploadNdkUnityLibraryMappings flag to bugsnag extension
   [#306](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/306)
 
@@ -242,7 +243,7 @@ Skip uploading mapping files for shared objects which have no debug info
 
 ## 4.4.0 (2019-06-10)
 
-This release is companion update for bugsnag-android v4.15.0, which supports detecting and reporting C/C++ crashes without a separate library. 
+This release is companion update for bugsnag-android v4.15.0, which supports detecting and reporting C/C++ crashes without a separate library.
 
 Since `bugsnag-android` now contains native code, update shared object extraction to include libraries from there as well as `bugsnag-android-ndk`
 [#164](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/164)

--- a/features/ndk_app_legacy.feature
+++ b/features/ndk_app_legacy.feature
@@ -1,6 +1,7 @@
 Feature: Plugin integrated in NDK app
 
 @skip_agp4_0_or_higher
+@skip_agp3_4_0
 Scenario: NDK apps send requests
     When I build the NDK app
     And I wait to receive 6 requests
@@ -26,6 +27,7 @@ Scenario: NDK apps send requests
         | java.lang.String doSomething() |
 
 @skip_agp4_0_or_higher
+@skip_agp3_4_0
 Scenario: Custom projectRoot is added to payload
     When I set environment variable "PROJECT_ROOT" to "/repos/custom/my-app"
     And I build the NDK app
@@ -48,6 +50,7 @@ Scenario: Custom projectRoot is added to payload
 
 # Sets a non-existent objdump location for x86 and arm64-v8a, delivery should proceed as normal for other files
 @skip_agp4_0_or_higher
+@skip_agp3_4_0
 Scenario: Custom objdump location
     When I set environment variable "OBJDUMP_LOCATION" to "/fake/objdump"
     And I build the NDK app
@@ -67,6 +70,7 @@ Scenario: Custom objdump location
         | com.bugsnag.android.ndkapp |
 
 @skip_agp4_0_or_higher
+@skip_agp3_4_0
 Scenario: Mapping files uploaded for custom sharedObjectPaths
     When I set environment variable "USE_SHARED_OBJECT_PATH" to "true"
     When I build the NDK app

--- a/features/proxy.feature
+++ b/features/proxy.feature
@@ -40,6 +40,7 @@ Scenario: Authenticated HTTP proxy without creds
     And I should receive no requests
 
 @skip_agp4_0_or_higher
+@skip_agp3_4_0
 Scenario: NDK request for basic HTTP proxy AGP < 4
     When I start an http proxy
     And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -31,6 +31,10 @@ Before('@skip_agp4_1_or_higher') do |scenario|
   skip_this_scenario if is_above_or_equal_to_target(410)
 end
 
+Before('@skip_agp3_4_0') do |scenario|
+  skip_this_scenario if equals_target(340)
+end
+
 def equals_target(target)
   version = ENV["AGP_VERSION"].slice(0, 5)
   version = version.gsub(".", "")

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -40,7 +40,6 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
-import java.net.URL
 import java.util.UUID
 
 /**
@@ -483,7 +482,7 @@ class BugsnagPlugin : Plugin<Project> {
             bundleJsFileProvider.set(File(rnBundle))
             sourceMapFileProvider.set(File(rnSourceMap))
             overwrite.set(bugsnag.overwrite)
-            endpoint.set(getSourcemapUploadEndpoint(bugsnag))
+            endpoint.set(bugsnag.endpoint.get())
             devEnabled.set("true" == dev)
             failOnUploadError.set(bugsnag.failOnUploadError)
 
@@ -495,16 +494,6 @@ class BugsnagPlugin : Plugin<Project> {
             val cliPath = File(nodeModulesDir, "@bugsnag/source-maps/bin/cli")
             bugsnagSourceMaps.set(cliPath)
             mustRunAfter(rnTask)
-        }
-    }
-
-    internal fun getSourcemapUploadEndpoint(bugsnag: BugsnagPluginExtension): String? {
-        return when (val endpoint = bugsnag.endpoint.get()) {
-            UPLOAD_ENDPOINT_DEFAULT -> endpoint
-            else -> {
-                val host = URL(endpoint)
-                return URL(host, "react-native-source-map").toString()
-            }
         }
     }
 

--- a/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
@@ -56,7 +56,6 @@ class PluginExtensionTest {
         assertFalse(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
         assertFalse(plugin.isNdkUploadEnabled(bugsnag, android))
         assertFalse(plugin.isReactNativeUploadEnabled(bugsnag))
-        assertEquals("https://upload.bugsnag.com", plugin.getSourcemapUploadEndpoint(bugsnag))
         assertEquals(emptyList<File>(), plugin.getSharedObjectSearchPaths(proj, bugsnag, android))
     }
 
@@ -122,8 +121,7 @@ class PluginExtensionTest {
         assertTrue(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
         assertTrue(plugin.isNdkUploadEnabled(bugsnag, android))
         assertTrue(plugin.isReactNativeUploadEnabled(bugsnag))
-        val uploadEndpoint = plugin.getSourcemapUploadEndpoint(bugsnag)
-        assertEquals("http://localhost:1234/react-native-source-map", uploadEndpoint)
+        assertEquals("http://localhost:1234", bugsnag.endpoint.get())
         val expected = listOf(
             File("/test/bar"),
             File(proj.projectDir, "src/main/jniLibs"),


### PR DESCRIPTION
## Goal

One last change to this task – the source map lib [now determines the correct path](https://github.com/bugsnag/bugsnag-source-maps/pull/48).

## Testing

Updated existing tests. Will be tested via e2e RN CLI tests when they land.