### PR TITLE
Add react native maven repo earlier in plugin lifecycle

### DIFF
--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -75,6 +75,7 @@ class BugsnagPlugin : Plugin<Project> {
             if (!bugsnag.enabled.get()) {
                 return@withPlugin
             }
+            addReactNativeMavenRepo(project, bugsnag)
 
             val httpClientHelperProvider = BugsnagHttpClientHelper.create(
                 project,
@@ -319,7 +320,6 @@ class BugsnagPlugin : Plugin<Project> {
             if (uploadSourceMapProvider != null) {
                 variant.register(project, uploadSourceMapProvider, reactNativeEnabled)
             }
-            addReactNativeMavenRepo(project, bugsnag)
         }
     }
 


### PR DESCRIPTION
## Goal

The plugin adds a maven repository so that it can find the AARs bundled in the node_module, which avoids the user having to perform additional setup. If JVM minification isn't enabled when performing a gradle build then the plugin wouldn't have any effect as it bails out early rather than adding tasks: https://github.com/bugsnag/bugsnag-android-gradle-plugin/blob/integration/road-945-rn-sourcemaps/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt#L199

This meant that in some circumstances the maven repository would not be added. The fix in this changeset ensures that the react native maven repo is added once as soon as the plugin initializes, so that the dependency always has a chance to resolve. It's worth noting that if the user has disabled the plugin entirely they will need to add the maven repository themselves.