### PR TITLE
Add warning in BAGP for React Native when running via react-native CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Add warning in BAGP for React Native when running via react-native CLI
+  [#357](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/357)
+
 ## 5.7.0 (2021-01-13)
 
 * Support AGP 4.2

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -35,6 +35,7 @@ import com.bugsnag.android.gradle.internal.taskNameForUploadUnityMapping
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
@@ -281,6 +282,21 @@ class BugsnagPlugin : Plugin<Project> {
             }
             if (uploadSourceMapProvider != null) {
                 variant.register(project, uploadSourceMapProvider, reactNativeEnabled)
+            }
+
+            try {
+                project.tasks.named("installRelease").configure {
+                    if (reactNativeEnabled) {
+                        project.logger.warn(
+                            "Bugsnag: JS sourcemaps and JVM/NDK mapping files are not uploaded when " +
+                                "using the react-native CLI (e.g. react-native run-android --variant=release). " +
+                                "You should generate a release APK using ./gradlew assembleRelease or " +
+                                "./gradlew bundleRelease instead. See the React Native docs for further info: " +
+                                "https://reactnative.dev/docs/signed-apk-android#generating-the-release-apk"
+                        )
+                    }
+                }
+            } catch (ignored: UnknownTaskException) {
             }
         }
     }


### PR DESCRIPTION
## Goal

Adds a warning when installRelease is run in React Native. This indicates that the user ran `react-native run-android --variant=release`, whereas a user should run `./gradlew assembleRelease` or `./gradlew bundleRelease` to generate an artifact for which sourcemaps should be uploaded. This warning is only logged when a task named 'installRelease' is created in the project and JS sourcemap upload is enabled.

## Testing
Ran `./gradlew assembleRelease` and `react-native run-android` to confirm no message was received, and that the warning was only logged for `react-native run-android --variant=release`