### PR TITLE
Add support for DexGuard 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Add support for DexGuard 9
+  [#359](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/359)
+
 ## 5.7.1 (2021-01-18)
 
 * Add warning in BAGP for React Native when running via react-native CLI

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -6,12 +6,14 @@
     <ID>ComplexCondition:BugsnagPlugin.kt$BugsnagPlugin$!jvmMinificationEnabled &amp;&amp; !ndkEnabled &amp;&amp; !unityEnabled &amp;&amp; !reactNativeEnabled</ID>
     <ID>MagicNumber:BugsnagPluginExtension.kt$BugsnagPluginExtension$60000</ID>
     <ID>MagicNumber:BugsnagReleasesTask.kt$BugsnagReleasesTask$200</ID>
+    <ID>MagicNumber:MappingFileProvider.kt$9</ID>
     <ID>MaxLineLength:BugsnagManifestUuidTask.kt$BugsnagManifestUuidTask$private</ID>
     <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ @Suppress("SENSELESS_COMPARISON") internal fun isUnityLibraryUploadEnabled( bugsnag: BugsnagPluginExtension, android: AppExtension ): Boolean</ID>
     <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ private fun registerUploadSourceMapTask( project: Project, variant: ApkVariant, output: ApkVariantOutput, bugsnag: BugsnagPluginExtension, manifestInfoFileProvider: Provider&lt;RegularFile&gt; ): TaskProvider&lt;out BugsnagUploadJsSourceMapTask&gt;?</ID>
     <ID>ReturnCount:ManifestUuidTaskV2Compat.kt$internal fun createManifestUpdateTask( bugsnag: BugsnagPluginExtension, project: Project, variantName: String ): TaskProvider&lt;BugsnagManifestUuidTaskV2&gt;?</ID>
     <ID>ReturnCount:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$ fun generateSoMappingFile(project: Project, params: Params): File?</ID>
     <ID>SpreadOperator:BugsnagReleasesTask.kt$BugsnagReleasesTask$(*cmd)</ID>
+    <ID>SpreadOperator:DexguardCompat.kt$(buildDir, *path, variant.dirName, outputDir, "mapping.txt")</ID>
     <ID>TooGenericExceptionCaught:BugsnagHttpClientHelper.kt$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:BugsnagManifestUuidTask.kt$BugsnagManifestUuidTask$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:BugsnagMultiPartUploadRequest.kt$BugsnagMultiPartUploadRequest$exc: Throwable</ID>

--- a/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
@@ -3,6 +3,9 @@ package com.bugsnag.android.gradle
 import com.android.build.api.artifact.Artifacts
 import com.android.build.gradle.AppExtension
 import org.gradle.api.Action
+import org.gradle.api.Project
+
+import java.nio.file.Paths
 
 /**
  * Contains functions which exploit Groovy's metaprogramming to provide backwards
@@ -21,6 +24,33 @@ class GroovyCompat {
             onProperties {
                 onPropertiesCallback.execute(artifacts)
             }
+        }
+    }
+
+    /**
+     * Retrieves the Dexguard Plugin version from either the path or the version on the DexGuard plugin.
+     */
+    static String getDexguardVersionString(Project project) {
+        def dexguard = project.extensions.findByName("dexguard")
+
+        try {
+            if (dexguard == null) {
+                return null
+            }
+            if (dexguard.version != null) {
+                return dexguard.version
+            } else {
+                // the path value is structured like this: DexGuard-8.7.02
+                if (dexguard.path == null) {
+                    return null
+                }
+                File dexguardDir = Paths.get(dexguard.path).toFile()
+                String normalizedDir = dexguardDir.canonicalFile.name
+                return normalizedDir.replace("DexGuard-", "")
+            }
+        } catch (MissingPropertyException ignored) {
+            // running earlier version of DexGuard, ignore missing property
+            return null
         }
     }
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/MappingFileProvider.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/MappingFileProvider.kt
@@ -1,15 +1,14 @@
 package com.bugsnag.android.gradle
 
-import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.api.ApkVariantOutput
+import com.bugsnag.android.gradle.internal.findMappingFileDexguard9
+import com.bugsnag.android.gradle.internal.findMappingFileDexguardLegacy
+import com.bugsnag.android.gradle.internal.getDexguardMajorVersionInt
 import com.bugsnag.android.gradle.internal.hasDexguardPlugin
-import com.bugsnag.android.gradle.internal.hasMultipleOutputs
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
-import java.io.File
-import java.nio.file.Paths
 
 /**
  * Creates a Provider which finds the mapping file for a given variantOutput and filters out
@@ -18,59 +17,46 @@ import java.nio.file.Paths
 internal fun createMappingFileProvider(
     project: Project,
     variant: ApkVariant,
-    variantOutput: ApkVariantOutput,
-    android: AppExtension
+    variantOutput: ApkVariantOutput
 ): Provider<FileCollection> {
-    return findMappingFiles(project, variant, variantOutput, android)
+    return findMappingFiles(project, variant, variantOutput)
         .map { files -> files.filter { it.exists() } }
 }
 
 private fun findMappingFiles(
     project: Project,
     variant: ApkVariant,
-    variantOutput: ApkVariantOutput,
-    android: AppExtension
+    variantOutput: ApkVariantOutput
 ): Provider<FileCollection> {
-    if (project.hasDexguardPlugin() && android.hasMultipleOutputs()) {
-        val mappingFile = findDexguardMappingFile(project, variant, variantOutput)
-        if (mappingFile.exists()) {
-            return project.provider { project.layout.files(mappingFile) }
-        } else {
-            project.logger.warn(
-                "Bugsnag: Could not find DexGuard mapping file at: $mappingFile -" +
-                    " falling back to AGP mapping file value"
-            )
+    return when {
+        project.hasDexguardPlugin() -> {
+            if (getDexguardMajorVersionInt(project) >= 9) {
+                project.provider {
+                    val files = findMappingFileDexguard9(project, variant, variantOutput)
+                    project.layout.files(files)
+                }
+            } else {
+                project.provider {
+                    val file = findMappingFileDexguardLegacy(project, variant, variantOutput)
+                    project.layout.files(file)
+                }
+            }
         }
-    }
-
-    // Use AGP supplied value, preferring the new "getMappingFileProvider" API but falling back
-    // to the old "mappingFile" API if necessary
-    return try {
-        variant.mappingFileProvider
-    } catch (exc: Throwable) {
-        project.provider { project.layout.files(variant.mappingFile) }
+        else -> {
+            findMappingFileAgp(variant, project)
+        }
     }
 }
 
 /**
- * Retrieves the location of a DexGuard mapping file for the given variantOutput. The expected location for this
- * is: build/outputs/mapping/<productFlavor>/<buildType>/<split>
- *
- * variant.mappingFile cannot currently be overridden using the AGP DSL on a per-variantOutput basis, which
- * necessitates this workaround. https://issuetracker.google.com/issues/78921539
+ * Use AGP supplied value, preferring the new "getMappingFileProvider" API but falling back
+ * to the old "mappingFile" API if necessary
  */
-private fun findDexguardMappingFile(
-    project: Project,
+internal fun findMappingFileAgp(
     variant: ApkVariant,
-    variantOutput: ApkVariantOutput
-): File {
-    val buildDir = project.buildDir.toString()
-    var outputDir = variantOutput.dirName
-    if (variantOutput.dirName.endsWith("dpi" + File.separator)) {
-        outputDir = File(variantOutput.dirName).parent
-        if (outputDir == null) { // if only density splits enabled
-            outputDir = ""
-        }
-    }
-    return Paths.get(buildDir, "outputs", "mapping", variant.dirName, outputDir, "mapping.txt").toFile()
+    project: Project
+) = try {
+    variant.mappingFileProvider
+} catch (exc: Throwable) {
+    project.provider { project.layout.files(variant.mappingFile) }
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
@@ -1,0 +1,86 @@
+package com.bugsnag.android.gradle.internal
+
+import com.android.build.gradle.api.ApkVariant
+import com.android.build.gradle.api.ApkVariantOutput
+import com.bugsnag.android.gradle.GroovyCompat
+import org.gradle.api.Project
+import org.gradle.util.VersionNumber
+import java.io.File
+import java.nio.file.Paths
+
+/**
+ * Finds the mapping file locations for DexGuard >=9. This can be different depending on whether it
+ * is a bundle or an APK.
+ */
+internal fun findMappingFileDexguard9(
+    project: Project,
+    variant: ApkVariant,
+    variantOutput: ApkVariantOutput
+): List<File> {
+    return listOf(
+        findDexguardMappingFile(project, variant, variantOutput, "outputs", "dexguard", "mapping", "apk"),
+        findDexguardMappingFile(project, variant, variantOutput, "outputs", "dexguard", "mapping", "bundle")
+    )
+}
+
+/**
+ * Finds the mapping file location for DexGuard <9
+ */
+internal fun findMappingFileDexguardLegacy(
+    project: Project,
+    variant: ApkVariant,
+    variantOutput: ApkVariantOutput
+): File {
+    return findDexguardMappingFile(project, variant, variantOutput, "outputs", "mapping")
+}
+
+/**
+ * Retrieves the location of a DexGuard mapping file for the given variantOutput.
+ * The expected location for this is:
+ * /build/outputs/mapping/<productFlavor>/<buildType>/<split>/mapping.txt
+ *
+ * variant.mappingFile cannot currently be overridden using the AGP DSL on a per variantOutput
+ * basis, which is why the DexGuard plugin sets a different output for its mapping files.
+ * see https://issuetracker.google.com/issues/78921539
+ */
+private fun findDexguardMappingFile(
+    project: Project,
+    variant: ApkVariant,
+    variantOutput: ApkVariantOutput,
+    vararg path: String
+): File {
+    val buildDir = project.buildDir.toString()
+    var outputDir = variantOutput.dirName
+    if (variantOutput.dirName.endsWith("dpi" + File.separator)) {
+        outputDir = File(variantOutput.dirName).parent
+        if (outputDir == null) { // if only density splits enabled
+            outputDir = ""
+        }
+    }
+    return Paths.get(buildDir, *path, variant.dirName, outputDir, "mapping.txt").toFile()
+}
+
+/**
+ * Returns true if the DexGuard plugin has been applied to the project
+ */
+internal fun Project.hasDexguardPlugin(): Boolean {
+    return pluginManager.hasPlugin("dexguard")
+}
+
+/**
+ * Retrieves the major version of DexGuard in use in the project
+ */
+internal fun getDexguardMajorVersionInt(project: Project): Int {
+    val version = GroovyCompat.getDexguardVersionString(project) ?: ""
+    val versionNumber = VersionNumber.parse(version)
+    return versionNumber.major
+}
+
+/**
+ * Gets the task name for the Dexguard App Bundle task for this variant.
+ */
+internal fun getDexguardAabTaskName(variant: ApkVariant): String {
+    val buildType = variant.buildType.name.capitalize()
+    val flavor = variant.flavorName.capitalize()
+    return "dexguardAab$flavor$buildType"
+}

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
@@ -113,13 +113,6 @@ internal fun AppExtension.hasMultipleOutputs(): Boolean {
 }
 
 /**
- * Returns true if the DexGuard plugin has been applied to the project
- */
-internal fun Project.hasDexguardPlugin(): Boolean {
-    return pluginManager.hasPlugin("dexguard")
-}
-
-/**
  * Returns true if an APK variant output includes SO files for the given ABI.
  */
 internal fun ApkVariantOutput.includesAbi(abi: String): Boolean {

--- a/src/test/kotlin/com/bugsnag/android/gradle/MappingFileProviderKtTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/MappingFileProviderKtTest.kt
@@ -1,0 +1,31 @@
+package com.bugsnag.android.gradle
+
+import com.android.build.gradle.api.ApkVariant
+import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Provider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class MappingFileProviderKtTest {
+
+    @Mock
+    lateinit var proj: Project
+
+    @Mock
+    lateinit var variant: ApkVariant
+
+    @Mock
+    lateinit var fileCollectionProvider: Provider<FileCollection>
+
+    @Test
+    fun findMappingFileAgp() {
+        `when`(variant.mappingFileProvider).thenReturn(fileCollectionProvider)
+        assertEquals(fileCollectionProvider, findMappingFileAgp(variant, proj))
+    }
+}

--- a/src/test/kotlin/com/bugsnag/android/gradle/internal/DexguardCompatKtTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/internal/DexguardCompatKtTest.kt
@@ -1,0 +1,169 @@
+package com.bugsnag.android.gradle.internal
+
+import com.android.build.gradle.api.ApkVariant
+import com.android.build.gradle.api.ApkVariantOutput
+import com.android.builder.model.BuildType
+import com.bugsnag.android.gradle.GroovyCompat
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionContainer
+import org.gradle.api.plugins.PluginManager
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+import java.io.File
+
+@RunWith(MockitoJUnitRunner::class)
+class DexguardCompatKtTest {
+
+    @Mock
+    lateinit var proj: Project
+
+    @Mock
+    lateinit var pluginManager: PluginManager
+
+    @Mock
+    lateinit var extensions: ExtensionContainer
+
+    @Mock
+    lateinit var variant: ApkVariant
+
+    @Mock
+    lateinit var variantOutput: ApkVariantOutput
+
+    @Mock
+    lateinit var buildType: BuildType
+
+    @Before
+    fun setUp() {
+        `when`(proj.pluginManager).thenReturn(pluginManager)
+        `when`(proj.extensions).thenReturn(extensions)
+        `when`(proj.buildDir).thenReturn(File("/build-dir"))
+        `when`(variant.buildType).thenReturn(buildType)
+    }
+
+    @Test
+    fun hasDexguardPlugin() {
+        `when`(pluginManager.hasPlugin("dexguard")).thenReturn(false)
+        assertFalse(proj.hasDexguardPlugin())
+
+        `when`(pluginManager.hasPlugin("dexguard")).thenReturn(true)
+        assertTrue(proj.hasDexguardPlugin())
+    }
+
+    @Test
+    fun dexguardGetVersionNull() {
+        // handles when dexguard is not applied
+        `when`(extensions.findByName("dexguard")).thenReturn(null)
+        assertNull(GroovyCompat.getDexguardVersionString(proj))
+    }
+
+    @Test
+    fun dexguardGetFromVersion() {
+        // dexguard.version set
+        `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("version", "8.7.02")))
+        assertEquals("8.7.02", GroovyCompat.getDexguardVersionString(proj))
+    }
+
+    @Test
+    fun dexguardGetFromPath() {
+        // dexguard.path set
+        `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("path", "DexGuard-9.0.07")))
+        assertEquals("9.0.07", GroovyCompat.getDexguardVersionString(proj))
+    }
+
+    @Test
+    fun dexguardMajorVersionNull() {
+        // handles when dexguard is not applied
+        `when`(extensions.findByName("dexguard")).thenReturn(null)
+        assertEquals(0, getDexguardMajorVersionInt(proj))
+    }
+
+    @Test
+    fun dexguardMajorFromVersion() {
+        // dexguard.version set
+        `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("version", "8.7.02")))
+        assertEquals(8, getDexguardMajorVersionInt(proj))
+    }
+
+    @Test
+    fun dexguardMajorFromPath() {
+        // dexguard.path set
+        `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("path", "DexGuard-9.0.07")))
+        assertEquals(9, getDexguardMajorVersionInt(proj))
+    }
+
+    @Test
+    fun testFindMappingFileDexguard9() {
+        // default APK build
+        `when`(variant.dirName).thenReturn(File("release").path)
+        `when`(variantOutput.dirName).thenReturn("")
+        val defaultMappingFiles = findMappingFileDexguard9(proj, variant, variantOutput)
+        assertEquals(File("/build-dir/outputs/dexguard/mapping/apk/release/mapping.txt"), defaultMappingFiles[0])
+        assertEquals(File("/build-dir/outputs/dexguard/mapping/apk/release/mapping.txt"), defaultMappingFiles[0])
+
+        // ABI split
+        `when`(variant.dirName).thenReturn(File("release").path)
+        `when`(variantOutput.dirName).thenReturn("x86")
+        val abiSplitApk = File("/build-dir/outputs/dexguard/mapping/apk/release/x86/mapping.txt")
+        assertEquals(abiSplitApk, findMappingFileDexguard9(proj, variant, variantOutput)[0])
+
+        // productFlavor
+        `when`(variant.dirName).thenReturn(File("demo/full").path)
+        `when`(variantOutput.dirName).thenReturn("")
+        val productFlavorApk = File("/build-dir/outputs/dexguard/mapping/apk/demo/full/mapping.txt")
+        assertEquals(productFlavorApk, findMappingFileDexguard9(proj, variant, variantOutput)[0])
+
+        // productFlavor split
+        `when`(variant.dirName).thenReturn(File("demo/full").path)
+        `when`(variantOutput.dirName).thenReturn("x86/hdpi")
+        val productFlavorSplitApk = File("/build-dir/outputs/dexguard/mapping/apk/demo/full/x86/hdpi/mapping.txt")
+        assertEquals(productFlavorSplitApk, findMappingFileDexguard9(proj, variant, variantOutput)[0])
+    }
+
+    @Test
+    fun testFindMappingFileDexguardLegacy() {
+        // default APK build
+        `when`(variant.dirName).thenReturn(File("release").path)
+        `when`(variantOutput.dirName).thenReturn("")
+        val defaultApk = File("/build-dir/outputs/mapping/release/mapping.txt")
+        assertEquals(defaultApk, findMappingFileDexguardLegacy(proj, variant, variantOutput))
+
+        // ABI split
+        `when`(variant.dirName).thenReturn(File("release").path)
+        `when`(variantOutput.dirName).thenReturn("x86")
+        val abiSplitApk = File("/build-dir/outputs/mapping/release/x86/mapping.txt")
+        assertEquals(abiSplitApk, findMappingFileDexguardLegacy(proj, variant, variantOutput))
+
+        // productFlavor
+        `when`(variant.dirName).thenReturn(File("demo/full").path)
+        `when`(variantOutput.dirName).thenReturn("")
+        val productFlavorApk = File("/build-dir/outputs/mapping/demo/full/mapping.txt")
+        assertEquals(productFlavorApk, findMappingFileDexguardLegacy(proj, variant, variantOutput))
+
+        // productFlavor split
+        `when`(variant.dirName).thenReturn(File("demo/full").path)
+        `when`(variantOutput.dirName).thenReturn("x86/hdpi")
+        val productFlavorSplitApk = File("/build-dir/outputs/mapping/demo/full/x86/hdpi/mapping.txt")
+        assertEquals(productFlavorSplitApk, findMappingFileDexguardLegacy(proj, variant, variantOutput))
+    }
+
+    @Test
+    fun testDexguardAabTask() {
+        // default aab task name
+        `when`(variant.flavorName).thenReturn("")
+        `when`(buildType.name).thenReturn("release")
+        assertEquals("dexguardAabRelease", getDexguardAabTaskName(variant))
+
+        // productFlavor aab task name
+        `when`(variant.flavorName).thenReturn("fish")
+        `when`(buildType.name).thenReturn("demo")
+        assertEquals("dexguardAabFishDemo", getDexguardAabTaskName(variant))
+    }
+}


### PR DESCRIPTION
## Goal

Adds support for uploading mapping files generated by DexGuard 9, which has changed the location where mapping files are output.

## Changeset

- Retrieved the DexGuard version from `dexguard.version` or `dexguard.path`, one of which is always set. This is used to change the behaviour depending on whether v9 is in use or not.
- If DexGuard <=8 is in use, read the mapping file from `build/outputs/mapping`, otherwise look in the new location of `build/outputs/dexguard/mapping`
- If DexGuard is in use, ensure that the BAGP task always runs after the dexguard task, so that the mapping file has been generated and is ready for upload. DexGuard generates the mapping file later in the build process than AGP as it reprocesses the APK generated by AGP.
- `BugsnagGenerateProguardTask` accepts multiple mapping files as a [task input](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks) because the mapping file location alters for DexGuard depending on whether an APK or App Bundle is being generated. The task action resolves which file exists when it is run and uploads that

## Testing

Added unit test coverage for DexGuard mapping file calculations, and relied on E2E tests to confirm there were no regressions for regular AGP users.

As DexGuard is not something that we're able to create public tests for, functionality was manually tested by confirming that mapping files were uploaded for the following scenarios on both DexGuard 8 & 9:

- A universal APK
- An app bundle
- An APK with productFlavors
- An App Bundle with productFlavors
- An APK with ABI splits
- An APK with productFlavors and ABI splits