### PR TITLE
Support uploading JS sourcemaps generated with Hermes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Support uploading JS sourcemaps generated with Hermes
+  [#362](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/362)
+
 ## 5.7.2 (2021-01-27)
 
 * Add support for DexGuard 9

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -458,11 +458,11 @@ class BugsnagPlugin : Plugin<Project> {
         // https://github.com/facebook/react-native/blob/master/react.gradle#L132
         val rnTaskName = "bundle${variant.name.capitalize()}JsAndAssets"
         val rnTask: Task = project.tasks.findByName(rnTaskName) ?: return null
-        val rnSourceMap = BugsnagUploadJsSourceMapTask.findReactNativeTaskArg(rnTask, "--sourcemap-output")
+        val rnSourceMap = findReactNativeSourcemapFile(project, variant)
         val rnBundle = BugsnagUploadJsSourceMapTask.findReactNativeTaskArg(rnTask, "--bundle-output")
         val dev = BugsnagUploadJsSourceMapTask.findReactNativeTaskArg(rnTask, "--dev")
 
-        if (rnSourceMap == null || rnBundle == null || dev == null) {
+        if (rnBundle == null || dev == null) {
             project.logger.error("Bugsnag: unable to upload JS sourcemaps. Please enable sourcemap + bundle output.")
             return null
         }

--- a/src/test/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTest.kt
@@ -1,0 +1,45 @@
+package com.bugsnag.android.gradle
+
+import com.android.build.gradle.api.ApkVariant
+import org.gradle.api.Project
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+import java.io.File
+
+@RunWith(MockitoJUnitRunner::class)
+class BugsnagUploadJsSourceMapTest {
+
+    @Mock
+    lateinit var variant: ApkVariant
+
+    @Mock
+    lateinit var project: Project
+
+    @Before
+    fun setUp() {
+        `when`(project.buildDir).thenReturn(File("/build"))
+        `when`(variant.dirName).thenReturn("release")
+    }
+
+    @Test
+    fun testFindReactNativeSourcemapFile() {
+        assertEquals(
+            "/build/generated/sourcemaps/react/release/index.android.bundle.map",
+            findReactNativeSourcemapFile(project, variant)
+        )
+    }
+
+    @Test
+    fun testCustomBundleName() {
+        `when`(project.property("react")).thenReturn(mapOf(Pair("bundleAssetName", "foo")))
+        assertEquals(
+            "/build/generated/sourcemaps/react/release/foo.map",
+            findReactNativeSourcemapFile(project, variant)
+        )
+    }
+}


### PR DESCRIPTION
## Goal

Supports uploading JS sourcemaps generated with Hermes. Previously the plugin introspected react.gradle's `--sourcemap-output`, but this is the wrong file for Hermes apps. The sourcemap output location is therefore calculated manually instead by mimicking [RN's logic](https://github.com/facebook/react-native/blob/master/react.gradle#L116).

## Changeset

Manually calculated the RN sourcemap file location for the JS sourcemap upload task.

## Testing

Relied on existing E2E test coverage to confirm that a sourcemap was uploaded.

Performed additional manual testing in an example app, confirming that the build was successful with:

- `uploadReactNativeMappings` disabled
- Hermes enabled
- Hermes disabled

It was observed that the same sourcemap path was passed to the RN CLI both when hermes was enabled/disabled.

It may be worth performing some E2E testing that symbolication on the dashboard works, but I'm not 100% sure on how to best go about that?