### PR TITLE
More robust DexGuard support

### DIFF
--- a/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
@@ -6,6 +6,8 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 
 import java.nio.file.Paths
+import java.util.jar.Attributes
+import java.util.jar.Manifest
 
 /**
  * Contains functions which exploit Groovy's metaprogramming to provide backwards
@@ -44,9 +46,15 @@ class GroovyCompat {
                 if (dexguard.path == null) {
                     return null
                 }
+
                 File dexguardDir = Paths.get(dexguard.path).toFile()
-                String normalizedDir = dexguardDir.canonicalFile.name
-                return normalizedDir.replace("DexGuard-", "")
+
+                // Get the version from the dexguard.jar manifest
+                URL url = new URL("jar:file:$dexguardDir/lib/dexguard.jar!/")
+                URLConnection jarURLConnection = url.openConnection() as JarURLConnection
+                Manifest manifest = jarURLConnection.manifest
+                Attributes attrs = manifest.mainAttributes
+                return attrs.getValue("Implementation-Version")
             }
         } catch (MissingPropertyException ignored) {
             // running earlier version of DexGuard, ignore missing property

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
@@ -18,8 +18,8 @@ internal fun findMappingFileDexguard9(
     variantOutput: ApkVariantOutput
 ): List<File> {
     return listOf(
-        findDexguardMappingFile(project, variant, variantOutput, "outputs", "dexguard", "mapping", "apk"),
-        findDexguardMappingFile(project, variant, variantOutput, "outputs", "dexguard", "mapping", "bundle")
+        findDexguardMappingFile(project, variant, variantOutput, arrayOf("outputs", "dexguard", "mapping", "apk")),
+        findDexguardMappingFile(project, variant, variantOutput, arrayOf("outputs", "dexguard", "mapping", "bundle"))
     )
 }
 
@@ -31,7 +31,7 @@ internal fun findMappingFileDexguardLegacy(
     variant: ApkVariant,
     variantOutput: ApkVariantOutput
 ): File {
-    return findDexguardMappingFile(project, variant, variantOutput, "outputs", "mapping")
+    return findDexguardMappingFile(project, variant, variantOutput, arrayOf("outputs", "mapping"))
 }
 
 /**
@@ -47,16 +47,13 @@ private fun findDexguardMappingFile(
     project: Project,
     variant: ApkVariant,
     variantOutput: ApkVariantOutput,
-    vararg path: String
+    path: Array<String>
 ): File {
     val buildDir = project.buildDir.toString()
     var outputDir = variantOutput.dirName
-    if (variantOutput.dirName.endsWith("dpi" + File.separator)) {
-        outputDir = File(variantOutput.dirName).parent
-        if (outputDir == null) { // if only density splits enabled
-            outputDir = ""
-        }
-    }
+    // Don't account for splits in bundles
+    if (path[path.size - 1] == "bundle")
+        outputDir = ""
     return Paths.get(buildDir, *path, variant.dirName, outputDir, "mapping.txt").toFile()
 }
 

--- a/src/test/kotlin/com/bugsnag/android/gradle/internal/DexguardCompatKtTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/internal/DexguardCompatKtTest.kt
@@ -72,13 +72,6 @@ class DexguardCompatKtTest {
     }
 
     @Test
-    fun dexguardGetFromPath() {
-        // dexguard.path set
-        `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("path", "DexGuard-9.0.07")))
-        assertEquals("9.0.07", GroovyCompat.getDexguardVersionString(proj))
-    }
-
-    @Test
     fun dexguardMajorVersionNull() {
         // handles when dexguard is not applied
         `when`(extensions.findByName("dexguard")).thenReturn(null)
@@ -90,13 +83,6 @@ class DexguardCompatKtTest {
         // dexguard.version set
         `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("version", "8.7.02")))
         assertEquals(8, getDexguardMajorVersionInt(proj))
-    }
-
-    @Test
-    fun dexguardMajorFromPath() {
-        // dexguard.path set
-        `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("path", "DexGuard-9.0.07")))
-        assertEquals(9, getDexguardMajorVersionInt(proj))
     }
 
     @Test


### PR DESCRIPTION
## Goal

Thank you for your efforts to ensure compatibility with Guardsquare's DexGuard and your recent additions for DexGuard version 9. However, we have received a couple of support tickets notifying us that in some cases, the upload of mapping files does not happen as expected. I would like to propose a couple of changes to achieve full compatibility with DexGuard.

## Design

First, we have noticed some problems when only screen density splits are enabled. They are treated specially in `DexGuardCompat.kt`, which shouldn't be the case. Since DexGuard 9.0.6, we have implemented full support for splits (i.e. we produce a mapping file in its own location for each split). When dealing with bundles, we have only one mapping file, for which no split directories should be taken into account.

Second, the approach of deciding which DexGuard version is being used (based on the path name containing `DexGuard-x.x.x`) is not very robust. I have changed it to using the manifest of the `dexguard.jar`, located in the `lib` directory of a DexGuard distribution. This is also the way we check for the version in our Gradle plugin and is more robust for users who rename directories.

## Changeset

- No special handling of density splits in `DexguardCompat.kt`.
- Appropriate handling of bundles in `DexguardCompat.kt`.
- Get the version from the manifest of `dexguard.jar` in `GroovyCompat.groovy`.
- Removed tests for getting the version from the path in `DexguardCompatKtTest.kt`.

## Testing

Manual testing with Bugsnag integrated in one of our samples. The stacktraces are correctly deobfuscated for obfuscated APK's with and without splits, and for obfuscated bundles.