### PR TITLE
Move addition of the local Maven repo for ReactNative into afterEvaluate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Fix `nodeModulesDir` option not being applied
+  [#366](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/366)
+
 ## 5.7.3 (2021-02-02)
 
 * Support uploading JS sourcemaps generated with Hermes

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -76,7 +76,6 @@ class BugsnagPlugin : Plugin<Project> {
             if (!bugsnag.enabled.get()) {
                 return@withPlugin
             }
-            addReactNativeMavenRepo(project, bugsnag)
 
             val httpClientHelperProvider = BugsnagHttpClientHelper.create(
                 project,
@@ -94,9 +93,12 @@ class BugsnagPlugin : Plugin<Project> {
             }
 
             project.afterEvaluate {
+                addReactNativeMavenRepo(project, bugsnag)
+
                 if (!bugsnag.enabled.get()) {
                     return@afterEvaluate
                 }
+
                 android.applicationVariants.configureEach { variant ->
                     val filterImpl = VariantFilterImpl(variant.name)
                     if (!isVariantEnabled(bugsnag, filterImpl)) {


### PR DESCRIPTION
## Goal

The `withPlugin` block runs before configuration has been applied. This means that a custom `nodeModulesDir` won't be present yet and so the default will always be used. Moving this to `afterEvaluate` ensures that we can use a custom `nodeModulesDir` if one has been given

Note that this happens before the `enabled` check so that the Bugsnag React Native package can still be resolved. Otherwise the build fails when BAGP is loaded but disabled

## Testing

Tested in a local monorepo setup with hoisting