### PR TITLE
Add E2E tests for overriding versionCode

### DIFF
--- a/features/fixtures/config/android/on_variants_version_code.gradle
+++ b/features/fixtures/config/android/on_variants_version_code.gradle
@@ -1,0 +1,24 @@
+apply plugin: 'com.android.application'
+apply from: "../../config/android/common.gradle"
+
+android {
+    flavorDimensions "regular"
+
+    productFlavors {
+        foo {
+            applicationIdSuffix ".foo"
+        }
+        bar {
+            applicationIdSuffix ".bar"
+        }
+    }
+
+    buildTypes.configureEach {
+        onVariantProperties.withBuildType(name) {
+            outputs.forEach { variantOutput ->
+                variantOutput.versionCode.set(9000)
+            }
+        }
+    }
+}
+

--- a/features/fixtures/config/android/version_code_override.gradle
+++ b/features/fixtures/config/android/version_code_override.gradle
@@ -1,0 +1,21 @@
+apply plugin: 'com.android.application'
+apply from: "../../config/android/common.gradle"
+
+android {
+    flavorDimensions "regular"
+
+    productFlavors {
+        foo {
+            applicationIdSuffix ".foo"
+        }
+        bar {
+            applicationIdSuffix ".bar"
+        }
+    }
+
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            output.versionCodeOverride = 9000
+        }
+    }
+}

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -32,6 +32,14 @@ Before('@skip_agp4_1_or_higher') do |scenario|
   skip_this_scenario if is_above_or_equal_to_target(410)
 end
 
+Before('@skip_agp4_2_or_higher') do |scenario|
+  skip_this_scenario if is_above_or_equal_to_target(420)
+end
+
+Before('@agp_4_1_only') do |scenario|
+  skip_this_scenario if !equals_target(410)
+end
+
 Before('@skip_agp3_4_0') do |scenario|
   skip_this_scenario if equals_target(340)
 end

--- a/features/version_code_override.feature
+++ b/features/version_code_override.feature
@@ -1,0 +1,30 @@
+Feature: Version code override
+
+Scenario: Setting versionCodeOverride is respected
+    When I build "version_code_override" using the "standard" bugsnag config
+    And I wait to receive 4 requests
+
+    Then 2 requests are valid for the build API and match the following:
+      | appVersionCode | appVersion |
+      | 9000              | 1.0        |
+      | 9000              | 1.0        |
+
+    And 2 requests are valid for the android mapping API and match the following:
+      | versionCode | versionName | appId                           |
+      | 9000           | 1.0         | com.bugsnag.android.example.bar |
+      | 9000           | 1.0         | com.bugsnag.android.example.foo |
+
+@agp_4_1_only
+Scenario: Setting onVariants.outputs.versionCode is respected
+    When I build "on_variants_version_code" using the "standard" bugsnag config
+    And I wait to receive 4 requests
+
+    Then 2 requests are valid for the build API and match the following:
+      | appVersionCode | appVersion |
+      | 9000              | 1.0        |
+      | 9000              | 1.0        |
+
+    And 2 requests are valid for the android mapping API and match the following:
+      | versionCode | versionName | appId                           |
+      | 9000           | 1.0         | com.bugsnag.android.example.bar |
+      | 9000           | 1.0         | com.bugsnag.android.example.foo |


### PR DESCRIPTION
## Goal

Adds E2E tests for overriding the versionCode, to confirm that the manifest versionCode matches what is reported in requests to Bugsnag's API.