### PR TITLE
Improve DexGuard support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Improve DexGuard support
+  [#377](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/377)
+
 ## 5.7.4 (2021-03-04)
 
 * Fix `nodeModulesDir` option not being applied

--- a/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
@@ -6,6 +6,8 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 
 import java.nio.file.Paths
+import java.util.jar.Attributes
+import java.util.jar.Manifest
 
 /**
  * Contains functions which exploit Groovy's metaprogramming to provide backwards
@@ -44,9 +46,15 @@ class GroovyCompat {
                 if (dexguard.path == null) {
                     return null
                 }
+
                 File dexguardDir = Paths.get(dexguard.path).toFile()
-                String normalizedDir = dexguardDir.canonicalFile.name
-                return normalizedDir.replace("DexGuard-", "")
+
+                // Get the version from the dexguard.jar manifest
+                URL url = new URL("jar:file:$dexguardDir/lib/dexguard.jar!/")
+                URLConnection jarURLConnection = url.openConnection() as JarURLConnection
+                Manifest manifest = jarURLConnection.manifest
+                Attributes attrs = manifest.mainAttributes
+                return attrs.getValue("Implementation-Version")
             }
         } catch (MissingPropertyException ignored) {
             // running earlier version of DexGuard, ignore missing property

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
@@ -52,8 +52,9 @@ private fun findDexguardMappingFile(
     val buildDir = project.buildDir.toString()
     var outputDir = variantOutput.dirName
     // Don't account for splits in bundles
-    if (path[path.size - 1] == "bundle")
+    if (path[path.size - 1] == "bundle") {
         outputDir = ""
+    }
     return Paths.get(buildDir, *path, variant.dirName, outputDir, "mapping.txt").toFile()
 }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
@@ -18,8 +18,8 @@ internal fun findMappingFileDexguard9(
     variantOutput: ApkVariantOutput
 ): List<File> {
     return listOf(
-        findDexguardMappingFile(project, variant, variantOutput, "outputs", "dexguard", "mapping", "apk"),
-        findDexguardMappingFile(project, variant, variantOutput, "outputs", "dexguard", "mapping", "bundle")
+        findDexguardMappingFile(project, variant, variantOutput, arrayOf("outputs", "dexguard", "mapping", "apk")),
+        findDexguardMappingFile(project, variant, variantOutput, arrayOf("outputs", "dexguard", "mapping", "bundle"))
     )
 }
 
@@ -31,7 +31,7 @@ internal fun findMappingFileDexguardLegacy(
     variant: ApkVariant,
     variantOutput: ApkVariantOutput
 ): File {
-    return findDexguardMappingFile(project, variant, variantOutput, "outputs", "mapping")
+    return findDexguardMappingFile(project, variant, variantOutput, arrayOf("outputs", "mapping"))
 }
 
 /**
@@ -47,16 +47,13 @@ private fun findDexguardMappingFile(
     project: Project,
     variant: ApkVariant,
     variantOutput: ApkVariantOutput,
-    vararg path: String
+    path: Array<String>
 ): File {
     val buildDir = project.buildDir.toString()
     var outputDir = variantOutput.dirName
-    if (variantOutput.dirName.endsWith("dpi" + File.separator)) {
-        outputDir = File(variantOutput.dirName).parent
-        if (outputDir == null) { // if only density splits enabled
-            outputDir = ""
-        }
-    }
+    // Don't account for splits in bundles
+    if (path[path.size - 1] == "bundle")
+        outputDir = ""
     return Paths.get(buildDir, *path, variant.dirName, outputDir, "mapping.txt").toFile()
 }
 

--- a/src/test/kotlin/com/bugsnag/android/gradle/internal/DexguardCompatKtTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/internal/DexguardCompatKtTest.kt
@@ -72,13 +72,6 @@ class DexguardCompatKtTest {
     }
 
     @Test
-    fun dexguardGetFromPath() {
-        // dexguard.path set
-        `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("path", "DexGuard-9.0.07")))
-        assertEquals("9.0.07", GroovyCompat.getDexguardVersionString(proj))
-    }
-
-    @Test
     fun dexguardMajorVersionNull() {
         // handles when dexguard is not applied
         `when`(extensions.findByName("dexguard")).thenReturn(null)
@@ -90,13 +83,6 @@ class DexguardCompatKtTest {
         // dexguard.version set
         `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("version", "8.7.02")))
         assertEquals(8, getDexguardMajorVersionInt(proj))
-    }
-
-    @Test
-    fun dexguardMajorFromPath() {
-        // dexguard.path set
-        `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("path", "DexGuard-9.0.07")))
-        assertEquals(9, getDexguardMajorVersionInt(proj))
     }
 
     @Test


### PR DESCRIPTION
## Goal

Improves compatibility with DexGuard, by using the changeset contributed in #365.

This PR makes a small style change and adds a changelog entry in separate commits - these are the only tweaks made.

## Testing

Assembled/bundled the DexGuard example apps on DexGuard 8/9 respectively, ensuring that the upload task ran:

Default APK
productFlavors APK
splits APK
productFlavors with splits