### PR TITLE
Replace Groovy XML library used for parsing AndroidManifest.xml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,6 @@ jobs:
     - name: AGP 4.2.0 E2E tests
       env:
         - AGP_VERSION=4.2.0-beta03
-        - GRADLE_WRAPPER_VERSION=6.7.1
+        - GRADLE_WRAPPER_VERSION=7.0-rc-1
         - RN_FIXTURE_DIR=features/fixtures/rn063/android
       script: bundle exec maze-runner -c --verbose --fail-fast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Replace Groovy XML library used for parsing AndroidManifest.xml
+  [#379](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/379)
+
 ## 5.7.5 (2021-03-30)
 
 * Improve DexGuard support

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -2,7 +2,7 @@
 <SmellBaseline>
   <Blacklist></Blacklist>
   <Whitelist>
-    <ID>ComplexCondition:AndroidManifestParser.kt$AndroidManifestParser$apiKey == null || "" == apiKey || versionCode == null || buildUUID == null || versionName == null || applicationId == null</ID>
+    <ID>ComplexCondition:AndroidManifestParser.kt$AndroidManifestParser$apiKey == null || "" == apiKey || versionCode == null || buildUuid == null || versionName == null || applicationId == null</ID>
     <ID>ComplexCondition:BugsnagPlugin.kt$BugsnagPlugin$!jvmMinificationEnabled &amp;&amp; !ndkEnabled &amp;&amp; !unityEnabled &amp;&amp; !reactNativeEnabled</ID>
     <ID>MagicNumber:BugsnagPluginExtension.kt$BugsnagPluginExtension$60000</ID>
     <ID>MagicNumber:BugsnagReleasesTask.kt$BugsnagReleasesTask$200</ID>

--- a/features/fixtures/app/gradle.properties
+++ b/features/fixtures/app/gradle.properties
@@ -7,3 +7,6 @@ ANDROID_COMPILE_SDK_VERSION=27
 
 SAMPLE_VERSION_CODE=1
 SAMPLE_VERSION_NAME=1.0
+
+org.gradle.jvmargs=-Xmx4096m
+org.gradle.parallel=true

--- a/features/fixtures/ndkapp/gradle.properties
+++ b/features/fixtures/ndkapp/gradle.properties
@@ -1,3 +1,5 @@
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536m
 plugin_version=9000.0.0-test
+
+org.gradle.jvmargs=-Xmx4096m
+org.gradle.parallel=true

--- a/features/fixtures/rn-monorepo/abc/android/gradle.properties
+++ b/features/fixtures/rn-monorepo/abc/android/gradle.properties
@@ -26,3 +26,5 @@ android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.54.0
+org.gradle.jvmargs=-Xmx4096m
+org.gradle.parallel=true

--- a/features/fixtures/rn-monorepo/xyz/android/gradle.properties
+++ b/features/fixtures/rn-monorepo/xyz/android/gradle.properties
@@ -26,3 +26,5 @@ android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.54.0
+org.gradle.jvmargs=-Xmx4096m
+org.gradle.parallel=true

--- a/features/fixtures/rn060/android/gradle.properties
+++ b/features/fixtures/rn060/android/gradle.properties
@@ -19,3 +19,5 @@
 
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.jvmargs=-Xmx4096m
+org.gradle.parallel=true

--- a/features/fixtures/rn061/android/gradle.properties
+++ b/features/fixtures/rn061/android/gradle.properties
@@ -19,3 +19,5 @@
 
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.jvmargs=-Xmx4096m
+org.gradle.parallel=true

--- a/features/fixtures/rn062/android/gradle.properties
+++ b/features/fixtures/rn062/android/gradle.properties
@@ -26,3 +26,5 @@ android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.33.1
+org.gradle.jvmargs=-Xmx4096m
+org.gradle.parallel=true

--- a/features/fixtures/rn063/android/gradle.properties
+++ b/features/fixtures/rn063/android/gradle.properties
@@ -26,3 +26,5 @@ android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.54.0
+org.gradle.jvmargs=-Xmx4096m
+org.gradle.parallel=true

--- a/features/fixtures/unity_2018/example/gradle.properties
+++ b/features/fixtures/unity_2018/example/gradle.properties
@@ -1,1 +1,2 @@
-org.gradle.jvmargs=-Xmx4096M
+org.gradle.jvmargs=-Xmx4096m
+org.gradle.parallel=true

--- a/features/fixtures/unity_2019/gradle.properties
+++ b/features/fixtures/unity_2019/gradle.properties
@@ -1,2 +1,2 @@
-org.gradle.jvmargs=-Xmx4096M
+org.gradle.jvmargs=-Xmx4096m
 org.gradle.parallel=true

--- a/features/react_native.feature
+++ b/features/react_native.feature
@@ -1,5 +1,7 @@
 Feature: Plugin integrated in React Native app
 
+# blocked by PLAT-6305
+@skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when assembling an app with the default project structure
     When I build the React Native app
     And I wait to receive 3 requests
@@ -16,6 +18,8 @@ Scenario: Source maps are uploaded when assembling an app with the default proje
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
 
+# blocked by PLAT-6305
+@skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when bundling an app with the default project structure
     And I run the script "features/scripts/bundle_react_native_app.sh" synchronously
     And I wait to receive 3 requests
@@ -32,6 +36,8 @@ Scenario: Source maps are uploaded when bundling an app with the default project
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
 
+# blocked by PLAT-6305
+@skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when assembling an app which uses productFlavors
     When I set environment variable "USE_RN_FLAVORS" to "true"
     When I build the React Native app
@@ -52,6 +58,8 @@ Scenario: Source maps are uploaded when assembling an app which uses productFlav
         | 5              | 2.45.beta  | false     | false |
         | 5              | 2.45.beta  | false     | false |
 
+# blocked by PLAT-6305
+@skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when assembling an app within a monorepo
     When I run the script "features/scripts/build_react_native_monorepo_app.sh" synchronously
     And I wait to receive 3 requests
@@ -68,6 +76,8 @@ Scenario: Source maps are uploaded when assembling an app within a monorepo
       | appVersionCode | appVersion | overwrite | dev   |
       | 5              | 2.45.beta  | true      | false |
 
+# blocked by PLAT-6305
+@skip_gradle_7_or_higher
 Scenario: Setting uploadReactNativeMappings to false will prevent any source map upload
     When I set environment variable "UPLOAD_RN_MAPPINGS" to "false"
     When I build the React Native app
@@ -81,6 +91,8 @@ Scenario: Setting uploadReactNativeMappings to false will prevent any source map
         | versionCode | versionName | appId                     |
         | 5           | 2.45.beta  | com.bugsnag.android.rnapp |
 
+# blocked by PLAT-6305
+@skip_gradle_7_or_higher
 Scenario: Manually invoking source map upload task
     And I run the script "features/scripts/manual_upload_react_native.sh" synchronously
     And I wait to receive 1 requests
@@ -88,6 +100,8 @@ Scenario: Manually invoking source map upload task
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
 
+# blocked by PLAT-6305
+@skip_gradle_7_or_higher
 Scenario: Source maps are uploaded in an app using Hermes
     When I set environment variable "RN_ENABLE_HERMES" to "true"
     When I build the React Native app
@@ -105,6 +119,8 @@ Scenario: Source maps are uploaded in an app using Hermes
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
 
+# blocked by PLAT-6305
+@skip_gradle_7_or_higher
 Scenario: Plugin handles server failure gracefully
     When I set the HTTP status code to 500
     And I run the script "features/scripts/manual_upload_react_native.sh" synchronously
@@ -118,6 +134,8 @@ Scenario: Plugin handles server failure gracefully
         | 5              | 2.45.beta  | false     | false |
     And the exit code equals 0
 
+# blocked by PLAT-6305
+@skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when assembling an app with a custom nodeModulesDir
     When I set environment variable "CUSTOM_NODE_MODULES_DIR" to "true"
     When I build the React Native app

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -32,6 +32,11 @@ Before('@skip_agp4_1_or_higher') do |scenario|
   skip_this_scenario if is_above_or_equal_to_target(410)
 end
 
+Before('@skip_gradle_7_or_higher') do |scenario|
+  version = ENV["GRADLE_WRAPPER_VERSION"].slice(0, 1)
+  skip_this_scenario if version.to_i >= 7
+end
+
 Before('@skip_agp3_4_0') do |scenario|
   skip_this_scenario if equals_target(340)
 end

--- a/src/main/kotlin/com/bugsnag/android/gradle/AndroidManifestParser.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/AndroidManifestParser.kt
@@ -1,156 +1,165 @@
 package com.bugsnag.android.gradle
 
-import groovy.util.Node
-import groovy.util.NodeList
-import groovy.util.XmlNodePrinter
-import groovy.util.XmlParser
-import groovy.xml.Namespace
+import com.android.utils.forEach
 import org.gradle.api.logging.Logger
-import org.xml.sax.SAXException
+import org.w3c.dom.Document
 import java.io.File
-import java.io.FileWriter
-import java.io.IOException
-import java.io.PrintWriter
-import javax.xml.parsers.ParserConfigurationException
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
 
 internal class AndroidManifestParser {
 
-    private val namespace = Namespace("http://schemas.android.com/apk/res/android", "android")
-
-    fun readManifest(manifestPath: File, logger: Logger): AndroidManifestInfo {
-        logger.debug("Bugsnag: Reading manifest at: $manifestPath")
-        val root = XmlParser().parse(manifestPath)
-        val application = (root[TAG_APPLICATION] as NodeList)[0] as Node
-        val metadataTags = findMetadataTags(application)
-
-        // Get the Bugsnag API key
-        val apiKey = getManifestMetaData(metadataTags, TAG_API_KEY)
-        if (apiKey == null) {
-            logger.warn(
-                "Bugsnag: Could not find apiKey in '$TAG_API_KEY' " +
-                    "<meta-data> tag in your AndroidManifest.xml"
-            )
-        }
-
-        // Get the build version
-        val versionCode = getVersionCode(metadataTags, root)
-        if (versionCode == null) {
-            logger.warn("Bugsnag: Could not find 'android:versionCode' value in your AndroidManifest.xml")
-        }
-
-        // Uniquely identify the build so that we can identify the proguard file.
-        val buildUUID = getManifestMetaData(metadataTags, TAG_BUILD_UUID)
-        if (buildUUID == null) {
-            logger.warn(
-                "Bugsnag: Could not find '$TAG_BUILD_UUID'" +
-                    " <meta-data> tag in your AndroidManifest.xml"
-            )
-        }
-
-        // Get the version name
-        val versionName = getVersionName(metadataTags, root)
-        if (versionName == null) {
-            logger.warn("Bugsnag: Could not find 'android:versionName' value in your AndroidManifest.xml")
-        }
-
-        // Get the application ID
-        val applicationId = getApplicationId(root)
-        if (applicationId == null) {
-            logger.warn("Bugsnag: Could not find 'package' value in your AndroidManifest.xml")
-        }
-
-        if (apiKey == null || "" == apiKey || versionCode == null ||
-            buildUUID == null || versionName == null || applicationId == null
-        ) {
-            throw IllegalStateException(
-                """Bugsnag: Missing apiKey/versionCode/buildUuid/versionName/package, required to upload to bugsnag.
-                    |apiKey=$apiKey
-                    |versionCode=$versionCode
-                    |buildUUID=$buildUUID
-                    |versionName=$versionName
-                    |applicationId=$applicationId
-                    |Manifest file = $manifestPath
-                """.trimMargin()
-            )
-        }
-        return AndroidManifestInfo(apiKey, versionCode, buildUUID, versionName, applicationId)
-    }
-
-    @Throws(ParserConfigurationException::class, SAXException::class, IOException::class)
-    fun writeBuildUuid(
-        manifestPath: File,
-        outputPath: File = manifestPath,
-        // Uniquely identify the build so that we can identify the proguard file.
-        buildUuid: String
-    ) {
-        val root = XmlParser().parse(manifestPath)
-        val application = (root[TAG_APPLICATION] as NodeList)[0] as Node
-        val metadataTags = findMetadataTags(application)
-
-        // Add the new BUILD_UUID_TAG element
-        if (!hasBuildUuid(metadataTags)) {
-            application.appendNode(
-                TAG_META_DATA,
-                hashMapOf(
-                    namespace.get(ATTR_NAME) to TAG_BUILD_UUID,
-                    namespace.get(ATTR_VALUE) to buildUuid
-                )
-            )
-        }
-
-        // Write the manifest file
-        FileWriter(outputPath).use {
-            val printer = XmlNodePrinter(PrintWriter(it))
-            printer.isPreserveWhitespace = true
-            printer.print(root)
-        }
-    }
-
-    private fun findMetadataTags(application: Node): List<Node> {
-        return application.children()
-            .asSequence()
-            .filterIsInstance<Node>()
-            .filter { TAG_META_DATA == it.name() }
-            .toList()
-    }
-
-    private fun hasBuildUuid(metadataTags: List<Node>): Boolean {
-        return getManifestMetaData(metadataTags, TAG_BUILD_UUID) != null
-    }
-
-    private fun getManifestMetaData(metadataTags: List<Node>, key: String): String? {
-        val node = metadataTags.find {
-            val name = it.attribute(namespace.get(ATTR_NAME))
-            key == name
-        }
-        return node?.attribute(namespace.get(ATTR_VALUE)) as String?
-    }
-
-    private fun getVersionName(metaDataTags: List<Node>, xml: Node): String? {
-        val versionName = getManifestMetaData(metaDataTags, TAG_APP_VERSION)
-        return versionName ?: xml.attribute(namespace.get(ATTR_VERSION_NAME)) as String?
-    }
-
-    private fun getVersionCode(metaDataTags: List<Node>, xml: Node): String? {
-        val versionCode = getManifestMetaData(metaDataTags, TAG_VERSION_CODE)
-        return versionCode ?: xml.attribute(namespace.get(ATTR_VERSION_CODE)) as String?
-    }
-
-    private fun getApplicationId(xml: Node): String? {
-        return xml.attribute(ATTR_APPLICATION_ID) as String?
-    }
-
     companion object {
+        private const val TAG_MANIFEST = "manifest"
         private const val TAG_APPLICATION = "application"
         private const val TAG_META_DATA = "meta-data"
         private const val TAG_API_KEY = "com.bugsnag.android.API_KEY"
         private const val TAG_BUILD_UUID = "com.bugsnag.android.BUILD_UUID"
         private const val TAG_VERSION_CODE = "com.bugsnag.android.VERSION_CODE"
         private const val TAG_APP_VERSION = "com.bugsnag.android.APP_VERSION"
-        private const val ATTR_NAME = "name"
-        private const val ATTR_VALUE = "value"
+        private const val ATTR_NAME = "android:name"
+        private const val ATTR_VALUE = "android:value"
         private const val ATTR_APPLICATION_ID = "package"
-        private const val ATTR_VERSION_CODE = "versionCode"
-        private const val ATTR_VERSION_NAME = "versionName"
+        private const val ATTR_VERSION_CODE = "android:versionCode"
+        private const val ATTR_VERSION_NAME = "android:versionName"
+    }
+
+    /**
+     * Reads information from the AndroidManifest.xml that is required by Bugsnag. This includes
+     * the apiKey, versionCode, versionName, applicationId, and buildUUID.
+     */
+    fun readManifest(manifestPath: File, logger: Logger): AndroidManifestInfo {
+        logger.debug("Bugsnag: Reading manifest at: $manifestPath")
+
+        var apiKey: String? = null
+        var versionCode: String? = null
+        var buildUuid: String? = null
+        var versionName: String? = null
+        var applicationId: String? = null
+
+        openAndroidManifestXml(manifestPath) { doc ->
+            apiKey = findBugsnagMetadataValue(doc, TAG_API_KEY)
+            buildUuid = findBugsnagMetadataValue(doc, TAG_BUILD_UUID)
+            versionCode = findBugsnagMetadataValue(doc, TAG_VERSION_CODE)
+            versionName = findBugsnagMetadataValue(doc, TAG_APP_VERSION)
+
+            val manifest = doc.getElementsByTagName(TAG_MANIFEST).item(0)
+
+            if (manifest != null) {
+                applicationId = findManifestAttributeValue(manifest, ATTR_APPLICATION_ID)
+
+                // load defaults if com.bugsnag.android meta-data elements not present
+                if (versionCode == null) {
+                    versionCode = findManifestAttributeValue(manifest, ATTR_VERSION_CODE)
+                }
+                if (versionName == null) {
+                    versionName = findManifestAttributeValue(manifest, ATTR_VERSION_NAME)
+                }
+            }
+        }
+
+        if (apiKey == null || "" == apiKey || versionCode == null ||
+            buildUuid == null || versionName == null || applicationId == null
+        ) {
+            throw IllegalStateException(
+                """Bugsnag: Your AndroidManifest.xml is missing one or more of
+                    |apiKey/versionCode/buildUuid/versionName/package, which are required to upload to bugsnag.
+                    |apiKey=$apiKey
+                    |versionCode=$versionCode
+                    |buildUUID=$buildUuid
+                    |versionName=$versionName
+                    |applicationId=$applicationId
+                    |Manifest file = $manifestPath
+                """.trimMargin()
+            )
+        }
+        return AndroidManifestInfo(
+            requireNotNull(apiKey),
+            requireNotNull(versionCode),
+            requireNotNull(buildUuid),
+            requireNotNull(versionName),
+            requireNotNull(applicationId)
+        )
+    }
+
+    /**
+     * Opens the AndroidManifest.xml file and invokes a callback after parsing
+     * the XML into a [Document].
+     */
+    private fun openAndroidManifestXml(manifestPath: File, action: (doc: Document) -> Unit) {
+        manifestPath.inputStream().buffered().use { stream ->
+            runCatching {
+                val builder = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                val document = builder.parse(stream)
+                action(document)
+            }
+        }
+    }
+
+    /**
+     * Finds the value of an attribute in the <manifest> tag, such as android:versionCode.
+     * Returns null if this value is not present.
+     */
+    private fun findManifestAttributeValue(manifest: org.w3c.dom.Node, attrName: String): String? {
+        return manifest.attributes.getNamedItem(attrName)?.nodeValue
+    }
+
+    /**
+     * Finds the value of an attribute in a <meta-data> tag, such as com.bugsnag.android.BUILD_UUID.
+     * Returns null if this value is not present.
+     */
+    private fun findBugsnagMetadataValue(document: Document, attrName: String): String? {
+        document.getElementsByTagName(TAG_META_DATA).forEach { node ->
+            val key = node.attributes.getNamedItem(ATTR_NAME)?.nodeValue
+
+            if (attrName == key) {
+                return node.attributes.getNamedItem(ATTR_VALUE)?.nodeValue
+            }
+        }
+        return null
+    }
+
+    /**
+     * Writes a buildUUID to the AndroidManifest.xml so that Bugsnag can identify this build
+     * for mapping purposes. If a buildUUID is already present, no change is made.
+     */
+    fun writeBuildUuid(
+        manifestPath: File,
+        outputPath: File = manifestPath,
+        buildUuid: String
+    ) {
+        openAndroidManifestXml(manifestPath) { document ->
+            if (!hasBuildUuid(document)) {
+                val application = document.getElementsByTagName(TAG_APPLICATION).item(0)
+                val metadata = document.createElement(TAG_META_DATA)
+                metadata.setAttribute(ATTR_NAME, TAG_BUILD_UUID)
+                metadata.setAttribute(ATTR_VALUE, buildUuid)
+                application.appendChild(metadata)
+            }
+
+            val factory = TransformerFactory.newInstance()
+            val transformer = factory.newTransformer().apply {
+                setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes")
+                setOutputProperty(OutputKeys.INDENT, "yes")
+                setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2")
+            }
+            val source = DOMSource(document)
+            val output = StreamResult(outputPath)
+            transformer.transform(source, output)
+        }
+    }
+
+    private fun hasBuildUuid(document: Document): Boolean {
+        document.getElementsByTagName(TAG_META_DATA).forEach { node ->
+            val key = node.attributes.getNamedItem(ATTR_NAME)?.nodeValue
+
+            if (TAG_BUILD_UUID == key) {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestParseEmptyTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestParseEmptyTest.kt
@@ -1,0 +1,37 @@
+package com.bugsnag.android.gradle
+
+import org.gradle.api.logging.Logger
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import java.io.File
+
+@RunWith(MockitoJUnitRunner::class)
+class AndroidManifestParseEmptyTest {
+
+    @Mock
+    lateinit var logger: Logger
+
+    private lateinit var manifestFile: File
+
+    @Before
+    fun setUp() {
+        manifestFile = File.createTempFile("manifest_empty", ".xml")
+        val classLoader = AndroidManifestParseEmptyTest::class.java.classLoader
+        val res = classLoader.getResource("manifest_empty.xml")!!
+        File(res.file).copyTo(manifestFile, true)
+    }
+
+    @After
+    fun tearDown() {
+        manifestFile.delete()
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun readManifest() {
+        AndroidManifestParser().readManifest(manifestFile, logger)
+    }
+}

--- a/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestParseOverrideTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestParseOverrideTest.kt
@@ -1,0 +1,47 @@
+package com.bugsnag.android.gradle
+
+import org.gradle.api.logging.Logger
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import java.io.File
+
+@RunWith(MockitoJUnitRunner::class)
+class AndroidManifestParseOverrideTest {
+
+    private val info = AndroidManifestInfo(
+        "api-key",
+        "103",
+        "build-uuid-123",
+        "57.2",
+        "com.example"
+    )
+
+    @Mock
+    lateinit var logger: Logger
+
+    private lateinit var manifestFile: File
+
+    @Before
+    fun setUp() {
+        manifestFile = File.createTempFile("manifest_override", ".xml")
+        val classLoader = AndroidManifestParseOverrideTest::class.java.classLoader
+        val res = classLoader.getResource("manifest_override.xml")!!
+        File(res.file).copyTo(manifestFile, true)
+    }
+
+    @After
+    fun tearDown() {
+        manifestFile.delete()
+    }
+
+    @Test
+    fun readManifest() {
+        val read = AndroidManifestParser().readManifest(manifestFile, logger)
+        assertEquals(info, read)
+    }
+}

--- a/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestWriteTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestWriteTest.kt
@@ -30,8 +30,8 @@ class AndroidManifestWriteTest {
     @Test
     fun writeBuildUuid() {
         AndroidManifestParser().writeBuildUuid(manifestFile, outputFile, "build-uuid-123")
-        val obs = outputFile.readText()
-        val expected = classLoader.getResource("AndroidManifest.xml")!!.readText()
+        val obs = outputFile.readText().replace("\\s".toRegex(), "")
+        val expected = classLoader.getResource("AndroidManifest.xml")!!.readText().replace("\\s".toRegex(), "")
         assertEquals(expected, obs)
     }
 }

--- a/src/test/resources/manifest_empty.xml
+++ b/src/test/resources/manifest_empty.xml
@@ -1,0 +1,3 @@
+<manifest package="com.example" android:versionCode="12" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="5.2">
+  <application android:name="com.example.android.gradle.plugin.FooApp"/>
+</manifest>

--- a/src/test/resources/manifest_override.xml
+++ b/src/test/resources/manifest_override.xml
@@ -2,5 +2,7 @@
   <application android:name="com.example.android.gradle.plugin.FooApp">
     <meta-data android:name="com.bugsnag.android.API_KEY" android:value="api-key"/>
     <meta-data android:name="com.bugsnag.android.BUILD_UUID" android:value="build-uuid-123"/>
-  </application>
+    <meta-data android:name="com.bugsnag.android.APP_VERSION" android:value="57.2"/>
+    <meta-data android:name="com.bugsnag.android.VERSION_CODE" android:value="103"/>
+</application>
 </manifest>


### PR DESCRIPTION
## Goal

Gradle 7 updated the language it uses to Groovy 3. Part of the changes in Groovy 3 involved a reorganisation of packages which affected the classes used for XML parsing, which results in `NoSuchMethodError` being thrown when running the plugin on Gradle 7.

To avoid this behaviour the plugin has been updated to use a Java XML parser instead.

Resolves #369 

## Changeset

Refactored `AndroidManifestParser` to use an XML parser supplied via Java instead.

## Testing

Updated test matrix to run E2E tests against Gradle 7.0-rc-1, and added to unit test coverage.