### PR TITLE
Avoid release build failure for invalid API key

### DIFF
--- a/features/fail_on_upload_error.feature
+++ b/features/fail_on_upload_error.feature
@@ -20,3 +20,4 @@ Scenario: Upload failure due to connectivity failure
     When I build the failing "default_app" using the "wrong_endpoint" bugsnag config
     And I wait for 3 seconds
     Then I should receive no requests
+    Then the exit code equals 0

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -57,7 +57,7 @@ When("I build the failing {string} using the {string} bugsnag config") do |modul
   Runner.environment["MODULE_CONFIG"] = module_config
   Runner.environment["BUGSNAG_CONFIG"] = bugsnag_config
   _, exit_code = Runner.run_script("features/scripts/bundle_project_module.sh", blocking: true)
-  assert(exit_code != 0, "Expected script to fail with non-zero exit code, got #{exit_code}")
+  assert(exit_code == 0, "Expected script to pass with zero exit code, got #{exit_code}")
 end
 
 Then(/^the exit code equals (\d+)$/) do |exit_code|

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagMultiPartUploadRequest.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagMultiPartUploadRequest.kt
@@ -41,10 +41,7 @@ class BugsnagMultiPartUploadRequest(
                 uploadToServer(body)!!
             }
         } catch (exc: Throwable) {
-            when {
-                failOnUploadError -> throw exc
-                else -> "Failure"
-            }
+            "Failure"
         }
     }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
@@ -156,10 +156,7 @@ sealed class BugsnagReleasesTask(
             val response = try {
                 deliverPayload(payload, manifestInfo)
             } catch (exc: Throwable) {
-                when {
-                    failOnUploadError.get() -> throw exc
-                    else -> "Failure"
-                }
+                "Failure"
             }
             response
         }


### PR DESCRIPTION
## Goal

On integrating `bugsnag-android-gradle-plugin` to upload mappings at the build time, our release builds fail on having invalid api key. Normally the valid api key is fed to a placeholder so it can be accessible only in specific setups but invalid in others.

## Design

Ths proposed change should prevent failing release builds in setups where the api key shouldn't be accessible. It increases the flexibility of the plugin usage regardless having a valid/invalid api-key while at the same time retain logging errors if any. 

## Changeset

Similar to the case now in `bugsnag-android`, where an invalid api-key, [example](https://gist.github.com/IslamSalah/bab00b32e40ad4126c0b10b0636a0cc7), prevent sending events to the dashboard without failing builds. The proposed change stops concerned exceptions

## Testing

Automated tests should pass normally. Below screenshots might give more visibility 

#### Before change
<img width="949" alt="before" src="https://user-images.githubusercontent.com/8607770/114383493-e6cfbc80-9b8d-11eb-9be8-fbd301600a50.png">

#### After change
<img width="1334" alt="after" src="https://user-images.githubusercontent.com/8607770/114383523-ee8f6100-9b8d-11eb-8415-aca0106d2153.png">