### PR TITLE
fix(gradle): replaced jcenter with mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
-        jcenter()
+        mavenCentral()
         google()
     }
 
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:$agpVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.9.1"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.17.1"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:9.4.1"
     }
 }
@@ -33,7 +33,7 @@ apply plugin: "org.jlleitschuh.gradle.ktlint"
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 }
@@ -48,7 +48,7 @@ sourceSets {
 
 // Repositories for dependencies
 repositories {
-    jcenter()
+    mavenCentral()
     google()
 }
 
@@ -72,23 +72,25 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     }
 }
 
+// Several of these need to be kept as 'compile' for license checking to work
+// as otherwise the downloadLicenses task misses these deps
 // Build dependencies
 dependencies {
     kapt "com.squareup.moshi:moshi-kotlin-codegen:1.9.3"
     compileOnly "com.android.tools.build:gradle:$agpVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
 
     // For uploading proguard/ndk files
-    implementation "com.squareup.okhttp3:okhttp:4.8.0"
-    implementation "com.squareup.retrofit2:retrofit:2.9.0"
-    implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
-    implementation "com.squareup.retrofit2:converter-scalars:2.9.0"
+    compile "com.squareup.okhttp3:okhttp:4.8.0"
+    compile "com.squareup.retrofit2:retrofit:2.9.0"
+    compile "com.squareup.retrofit2:converter-moshi:2.9.0"
+    compile "com.squareup.retrofit2:converter-scalars:2.9.0"
 
     // For serialization of shared data
-    implementation "com.squareup.moshi:moshi:1.9.3"
+    compile "com.squareup.moshi:moshi:1.9.3"
 
     // For multiple I/O use cases
-    implementation "com.squareup.okio:okio:2.7.0"
+    compile "com.squareup.okio:okio:2.7.0"
 
     testImplementation "com.android.tools.build:gradle:$agpVersion"
     testImplementation "junit:junit:4.12"

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
-  <Blacklist></Blacklist>
-  <Whitelist>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
     <ID>ComplexCondition:AndroidManifestParser.kt$AndroidManifestParser$apiKey == null || "" == apiKey || versionCode == null || buildUuid == null || versionName == null || applicationId == null</ID>
     <ID>ComplexCondition:BugsnagPlugin.kt$BugsnagPlugin$!jvmMinificationEnabled &amp;&amp; !ndkEnabled &amp;&amp; !unityEnabled &amp;&amp; !reactNativeEnabled</ID>
     <ID>MagicNumber:BugsnagPluginExtension.kt$BugsnagPluginExtension$60000</ID>
@@ -12,8 +12,9 @@
     <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ private fun registerUploadSourceMapTask( project: Project, variant: ApkVariant, output: ApkVariantOutput, bugsnag: BugsnagPluginExtension, manifestInfoFileProvider: Provider&lt;RegularFile&gt; ): TaskProvider&lt;out BugsnagUploadJsSourceMapTask&gt;?</ID>
     <ID>ReturnCount:ManifestUuidTaskV2Compat.kt$internal fun createManifestUpdateTask( bugsnag: BugsnagPluginExtension, project: Project, variantName: String ): TaskProvider&lt;BugsnagManifestUuidTaskV2&gt;?</ID>
     <ID>ReturnCount:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$ fun generateSoMappingFile(project: Project, params: Params): File?</ID>
-    <ID>SpreadOperator:BugsnagReleasesTask.kt$BugsnagReleasesTask$(*cmd)</ID>
     <ID>SpreadOperator:DexguardCompat.kt$(buildDir, *path, variant.dirName, outputDir, "mapping.txt")</ID>
+    <ID>SwallowedException:MappingFileProvider.kt$catch (exc: Throwable) { project.provider { project.layout.files(variant.mappingFile) } }</ID>
+    <ID>ThrowingExceptionsWithoutMessageOrCause:BugsnagManifestUuidTask.kt$BugsnagManifestUuidTask$IllegalStateException()</ID>
     <ID>TooGenericExceptionCaught:BugsnagHttpClientHelper.kt$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:BugsnagManifestUuidTask.kt$BugsnagManifestUuidTask$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:BugsnagMultiPartUploadRequest.kt$BugsnagMultiPartUploadRequest$exc: Throwable</ID>
@@ -21,6 +22,6 @@
     <ID>TooGenericExceptionCaught:MappingFileProvider.kt$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$e: Exception</ID>
     <ID>TooGenericExceptionCaught:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$ex: Throwable</ID>
-    <ID>TooManyFunctions:BugsnagPlugin.kt$BugsnagPlugin$BugsnagPlugin</ID>
-  </Whitelist>
+    <ID>TooManyFunctions:BugsnagPlugin.kt$BugsnagPlugin : Plugin</ID>
+  </CurrentIssues>
 </SmellBaseline>


### PR DESCRIPTION
## Goal
Remove jcenter from the repository list of the bugsnag-android-gradle-project:

* Replace jcenter reference in the plugin project with mavenCentral
* Bump detekt to version 1.17.1 to avoid dependencies served only from jcenter
* Rerun the detekt baseline to cover the existing codebase

This does *not* cover the jcenter references in the test fixtures as these specifically cover versions of AGP that have transitive dependencies on jcenter.

## Testing
Relied on existing tests