### PR TITLE
Update mazerunner to v3.7.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.4.0'
+gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.7.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,11 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 2bc87663b66355a73d86bbe1b9159ac6b9387a9f
-  tag: v3.4.0
+  revision: 06d2a4d4e07fe78e67d94eb757ea85c2f8747533
+  tag: v3.7.4
   specs:
-    bugsnag-maze-runner (3.3.0)
+    bugsnag-maze-runner (3.7.4)
       appium_lib (~> 10.2)
+      boring (~> 0.1.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
       curb (~> 0.9.6)
@@ -23,10 +24,11 @@ GEM
       appium_lib_core (~> 3.3)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (3.11.0)
+    appium_lib_core (3.11.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
-    backports (3.18.2)
+    backports (3.21.0)
+    boring (0.1.0)
     builder (3.2.4)
     childprocess (3.0.0)
     cucumber (3.1.2)
@@ -48,36 +50,36 @@ GEM
     curb (0.9.11)
     diff-lcs (1.4.4)
     eventmachine (1.2.7)
-    faye-websocket (0.11.0)
+    faye-websocket (0.11.1)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     gherkin (5.1.0)
-    mini_portile2 (2.4.0)
-    minitest (5.14.2)
+    minitest (5.14.4)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.6-x86_64-darwin)
+      racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
-    power_assert (1.2.0)
+    power_assert (2.0.0)
+    racc (1.5.2)
     rake (12.3.3)
     rubyzip (2.3.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    test-unit (3.3.6)
+    test-unit (3.3.9)
       power_assert
     tomlrb (1.3.0)
-    websocket-driver (0.7.3)
+    websocket-driver (0.7.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   bugsnag-maze-runner!
 
 BUNDLED WITH
-   2.1.4
+   2.2.18

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -61,3 +61,7 @@ def get_requests_with_field(name)
 end
 
 $api_key = "TEST_API_KEY"
+
+AfterConfiguration do |_config|
+  MazeRunner.config.enforce_bugsnag_integrity = false
+end


### PR DESCRIPTION
## Goal

Bumps mazerunner to the latest v3, which should reduce the amount of change in an eventual upgrade to v5.

## Testing

Relied on existing test coverage.