### PR TITLE
Remove bintray from our build.gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 env:
   global:
   - ANDROID_HOME=/usr/local/android-sdk
+  - ORG_GRADLE_PROJECT_RELEASE_SIGNING_ENABLED=false
 
 android:
   components:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN apt-get install -y git rubygems
 RUN gem install bundler
 
 ADD . bugsnag-android-gradle-plugin
-RUN cd bugsnag-android-gradle-plugin && ./gradlew clean build install -PlocalVersion=9000.0.0-test
+RUN cd bugsnag-android-gradle-plugin && ./gradlew clean build install -PVERSION_NAME=9000.0.0-test
 RUN cd bugsnag-android-gradle-plugin/dexguard-test-project && bundle install
 ADD dexguard-test-project/DexGuard-8.1.15/dexguard-license.txt /root/dexguard-license.txt

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ifeq ($(VERSION),)
 	@$(error VERSION is not defined. Run with `make VERSION=number bump`)
 endif
 	@echo Bumping the version number to $(VERSION)
-	@sed -i '' "s/version = .*/version = $(VERSION)/" gradle.properties
+	@sed -i '' "s/VERSION_NAME=.*/VERSION_NAME=$(VERSION)/" gradle.properties
 	@sed -i '' "s/## TBD/## $(VERSION) ($(shell date '+%Y-%m-%d'))/" CHANGELOG.md
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,14 +20,12 @@ plugins {
     id "java-gradle-plugin"
     id "groovy"
     id "com.gradle.plugin-publish" version "0.12.0"
-    id "com.bmuschko.nexus" version "2.3.1"
-    id "com.jfrog.bintray" version "1.8.5"
+    id "com.vanniktech.maven.publish" version "0.12.0"
     id "com.github.hierynomus.license" version "0.15.0"
 }
 
 apply plugin: "org.jetbrains.kotlin.jvm"
 apply plugin: "org.jetbrains.kotlin.kapt"
-apply plugin: "maven-publish"
 apply plugin: "io.gitlab.arturbosch.detekt"
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 
@@ -62,6 +60,7 @@ compileGroovy {
 tasks.named("compileGroovy") {
     classpath = sourceSets.main.compileClasspath
 }
+
 tasks.named("compileKotlin") {
     classpath += files(sourceSets.main.groovy.classesDirectory)
 }
@@ -100,130 +99,34 @@ dependencies {
     testImplementation "com.google.truth:truth:1.0.1"
 }
 
-// Maven publishing settings (nexus-maven-plugins)
-modifyPom {
-    project {
-        name "Bugsnag Android Gradle Plugin"
-        description "Gradle plugin to automatically upload ProGuard mapping files to Bugsnag."
-        url "https://github.com/bugsnag/bugsnag-android-gradle-plugin"
-
-        scm {
-            url "https://github.com/bugsnag/bugsnag-android-gradle-plugin"
-            connection "scm:git:git://github.com/bugsnag/bugsnag-android-gradle-plugin.git"
-            developerConnection "scm:git:ssh://git@github.com/bugsnag/bugsnag-android-gradle-plugin.git"
-        }
-
-        licenses {
-            license {
-                name "MIT"
-                url "http://opensource.org/licenses/MIT"
-                distribution "repo"
-            }
-        }
-
-        organization {
-            name "Bugsnag"
-            url "https://bugsnag.com"
-        }
-
-        developers {
-            developer {
-                id "loopj"
-                name "James Smith"
-                email "james@bugsnag.com"
-            }
-        }
-    }
-}
-
 // Gradle plugin publishing settings (plugins.gradle.com)
 pluginBundle {
-    website = "https://github.com/bugsnag/bugsnag-android-gradle-plugin"
-    vcsUrl = "https://github.com/bugsnag/bugsnag-android-gradle-plugin.git"
+    website = POM_URL
+    vcsUrl = POM_SCM_CONNECTION
 
     plugins {
         androidGradlePlugin {
             id = "com.bugsnag.android.gradle"
-            displayName = "Bugsnag Android Gradle Plugin"
-            description = "Gradle plugin to automatically upload ProGuard mapping files to Bugsnag."
+            displayName = POM_NAME
+            description = POM_DESCRIPTION
             tags = ["bugsnag", "proguard", "android", "upload"]
         }
     }
 
     mavenCoordinates {
-        groupId = "com.bugsnag"
-        artifactId = "bugsnag-android-gradle-plugin"
+        groupId = GROUP
+        artifactId = POM_ARTIFACT_ID
     }
 }
 
-install {
-    version = project.hasProperty("localVersion") ? project.getProperty("localVersion") : project.version
-}
-
-publishing {
-    publications {
-        Publication(MavenPublication) {
-            artifact jar
-            groupId "com.bugsnag"
-            artifactId "bugsnag-android-gradle-plugin"
-            version project.version
-        }
-
-        BintrayPublication(MavenPublication) {
-            artifact jar
-            groupId "com.bugsnag"
-            artifactId "bugsnag-android-gradle-plugin"
-            version project.version
-
-            pom.withXml {
-                def dependenciesNode = asNode().getAt('dependencies')[0] ?: asNode().appendNode('dependencies')
-
-                // Iterate over the implementation dependencies and add a <dependency> node for each
-                configurations.implementation.allDependencies.each {
-                    // Ensure dependencies such as fileTree are not included in the pom
-                    if (it.name != 'unspecified') {
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-
-                        dependencyNode.appendNode('groupId', it.group)
-                        dependencyNode.appendNode('artifactId', it.name)
-                        dependencyNode.appendNode('version', it.version)
-                        dependencyNode.appendNode('scope', 'runtime')
-                    }
-                }
-
-                configurations.testImplementation.allDependencies.each {
-                    // Ensure we don't add the same dependency twice
-                    if (it.name != 'unspecified' && !configurations.implementation.allDependencies.contains(it)) {
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-
-                        dependencyNode.appendNode('groupId', it.group)
-                        dependencyNode.appendNode('artifactId', it.name)
-                        dependencyNode.appendNode('version', it.version)
-                        dependencyNode.appendNode('scope', 'test')
-                    }
-                }
-            }
-        }
-    }
-}
-
-// Bintray upload
-bintray {
-    user = project.hasProperty("bintray_user") ? "$bintray_user" : System.getenv("bintray_user")
-    key = project.hasProperty("bintray_api_key") ? "$bintray_api_key" : System.getenv("bintray_api_key")
-
-    publications = ["BintrayPublication"]
-    configurations = ["archives"]
-    pkg {
-        repo = "maven"
-        name = "bugsnag-android-gradle-plugin"
-        userOrg = "bugsnag"
-        licenses = ["MIT"]
-        vcsUrl = "https://github.com/bugsnag/bugsnag-android-gradle-plugin.git"
-        version {
-            name = project.version
-            vcsTag = "v${project.version}"
-            attributes = ["gradle-plugin": "com.bugsnag.android.gradle"]
+mavenPublish {
+    targets {
+        bintray {
+            String bintrayUser = project.hasProperty("bintray_user") ? "$bintray_user" : System.getenv("bintray_user")
+            releaseRepositoryUrl = "https://api.bintray.com/maven/bugsnag/artifact-sandbox/;publish=0"
+            snapshotRepositoryUrl = null
+            repositoryUsername = bintrayUser
+            repositoryPassword = project.hasProperty("bintray_api_key") ? "$bintray_api_key" : System.getenv("bintray_api_key")
         }
     }
 }
@@ -250,6 +153,8 @@ detekt {
         }
     }
 }
+
+sourceCompatibility = JavaVersion.VERSION_1_8
 
 // see https://github.com/asciidoctor/asciidoctorj/pull/862
 Signature.metaClass.getToSignArtifact = { ->

--- a/build.gradle
+++ b/build.gradle
@@ -121,12 +121,11 @@ pluginBundle {
 
 mavenPublish {
     targets {
-        bintray {
-            String bintrayUser = project.hasProperty("bintray_user") ? "$bintray_user" : System.getenv("bintray_user")
-            releaseRepositoryUrl = "https://api.bintray.com/maven/bugsnag/artifact-sandbox/;publish=0"
-            snapshotRepositoryUrl = null
-            repositoryUsername = bintrayUser
-            repositoryPassword = project.hasProperty("bintray_api_key") ? "$bintray_api_key" : System.getenv("bintray_api_key")
+        sonatype {
+            releaseRepositoryUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            snapshotRepositoryUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+            repositoryUsername = project.hasProperty("NEXUS_USERNAME") ? "$NEXUS_USERNAME" : System.getenv("NEXUS_USERNAME")
+            repositoryPassword = project.hasProperty("NEXUS_PASSWORD") ? "$NEXUS_PASSWORD" : System.getenv("NEXUS_PASSWORD")
         }
     }
 }
@@ -136,8 +135,9 @@ license {
     header rootProject.file("LICENSE")
     ignoreFailures true
 }
+
 downloadLicenses {
-  dependencyConfiguration "compile"
+    dependencyConfiguration "compile"
 }
 
 sourceSets {

--- a/features/scripts/install_gradle_plugin.sh
+++ b/features/scripts/install_gradle_plugin.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-./gradlew install -x detekt -x test -PlocalVersion=9000.0.0-test
+./gradlew build install -x groovyDoc -x detekt -x test -PVERSION_NAME=9000.0.0-test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,24 @@
-group = com.bugsnag
-version = 5.7.6
-
 ANDROID_MIN_SDK_VERSION=14
 ANDROID_TARGET_SDK_VERSION=29
 ANDROID_COMPILE_SDK_VERSION=29
+
+POM_NAME=Bugsnag Android Gradle Plugin
+POM_ARTIFACT_ID=bugsnag-android-gradle-plugin
+POM_PACKAGING=jar
+GROUP=com.bugsnag
+VERSION_NAME=5.7.6
+POM_DESCRIPTION=Gradle plugin to automatically upload ProGuard mapping files to Bugsnag.
+POM_URL=https://github.com/bugsnag/bugsnag-android-gradle-plugin/
+POM_SCM_URL=https://github.com/bugsnag/bugsnag-android-gradle-plugin/
+POM_SCM_CONNECTION=scm:git:git://github.com/bugsnag/bugsnag-android-gradle-plugin.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/bugsnag/bugsnag-android-gradle-plugin.git
+POM_LICENCE_NAME=MIT
+POM_LICENCE_URL=http://opensource.org/licenses/MIT
+POM_LICENCE_DIST=repo
+POM_DEVELOPER_ID=bugsnag
+POM_DEVELOPER_NAME=Bugsnag
+POM_DEVELOPER_URL=https://bugsnag.com
+SONATYPE_STAGING_PROFILE=com.bugsnag
 
 org.gradle.jvmargs=-Xmx4096m
 org.gradle.parallel=true


### PR DESCRIPTION
## Goal
Remove jcenter and bintray from our publishing stages and align the publishing step with bugsnag-android.

## Testing
Manually tested by pushing a new publishing a new plugin to Sonatype and building the example app with it.