### PR TITLE
Emit a compatibility error when AGP 7+ is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## TBD
+
+* Emit a helpful compatibility error when Android Gradle Plugin 7 or higher is detected
+
 ## 5.7.6 (2021-04-08)
 
 * Replace Groovy XML library used for parsing AndroidManifest.xml

--- a/features/agp7_emits_error.feature
+++ b/features/agp7_emits_error.feature
@@ -1,0 +1,7 @@
+Feature: AGP7 Emits Compatibility Error
+
+Scenario: Compatibility Error Emitted when AGP7 is used
+    When I build the failing "default_app" on AGP7 using the "standard" bugsnag config
+    And I wait for 3 seconds
+    Then I should receive no requests
+

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -53,6 +53,13 @@ steps %Q{
 }
 end
 
+When("I build the failing {string} on AGP7 using the {string} bugsnag config") do |module_config, bugsnag_config|
+steps %Q{
+    When I set environment variable "AGP_VERSION" to "7.0.0-alpha15"
+    And I build the failing "#{module_config}" using the "#{bugsnag_config}" bugsnag config
+}
+end
+
 When("I build the failing {string} using the {string} bugsnag config") do |module_config, bugsnag_config|
   Runner.environment["MODULE_CONFIG"] = module_config
   Runner.environment["BUGSNAG_CONFIG"] = bugsnag_config

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -71,7 +71,7 @@ class BugsnagPlugin : Plugin<Project> {
         if (AgpVersions.CURRENT >= AgpVersions.VERSION_7_0) {
             throw StopExecutionException(
                 "Using com.bugsnag.android.gradle with Android Gradle Plugin 7+ " +
-                    "requires an upgrade to com.bugsnag.android.gradle:7.0.0. " +
+                    "requires an upgrade to com.bugsnag.android.gradle:7.+. " +
                     "For more information about this change, see " +
                     "https://docs.bugsnag.com/build-integrations/gradle/"
             )

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -5,6 +5,7 @@ import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.bugsnag.android.gradle.BugsnagInstallJniLibsTask.Companion.resolveBugsnagArtifacts
+import com.bugsnag.android.gradle.internal.AgpVersions
 import com.bugsnag.android.gradle.internal.BugsnagHttpClientHelper
 import com.bugsnag.android.gradle.internal.NDK_SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.TASK_JNI_LIBS
@@ -40,6 +41,7 @@ import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
 
@@ -66,12 +68,22 @@ class BugsnagPlugin : Plugin<Project> {
 
     @Suppress("LongMethod")
     override fun apply(project: Project) {
+        if (AgpVersions.CURRENT >= AgpVersions.VERSION_7_0) {
+            throw StopExecutionException(
+                "Using com.bugsnag.android.gradle with Android Gradle Plugin 7+ " +
+                    "requires an upgrade to com.bugsnag.android.gradle:7.0.0. " +
+                    "For more information about this change, see " +
+                    "https://docs.bugsnag.com/platforms/android/"
+            )
+        }
+
         // After Gradle 5.2, this can use service injection for injecting ObjectFactory
         val bugsnag = project.extensions.create(
             "bugsnag",
             BugsnagPluginExtension::class.java,
             project.objects
         )
+
         project.pluginManager.withPlugin("com.android.application") {
             if (!bugsnag.enabled.get()) {
                 return@withPlugin

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -73,7 +73,7 @@ class BugsnagPlugin : Plugin<Project> {
                 "Using com.bugsnag.android.gradle with Android Gradle Plugin 7+ " +
                     "requires an upgrade to com.bugsnag.android.gradle:7.0.0. " +
                     "For more information about this change, see " +
-                    "https://docs.bugsnag.com/platforms/android/"
+                    "https://docs.bugsnag.com/build-integrations/gradle/"
             )
         }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
@@ -1,13 +1,13 @@
 @file:Suppress("MatchingDeclarationName", "TooManyFunctions") // This file contains multiple top-level members
 package com.bugsnag.android.gradle.internal
 
+// TODO use the new replacement when min AGP version is 4.0
 import com.android.build.VariantOutput
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.BaseVariant
-// TODO use the new replacement when min AGP version is 4.0
 import com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
 import okio.HashingSink
 import okio.blackholeSink
@@ -46,6 +46,7 @@ internal object AgpVersions {
     val VERSION_4_0: VersionNumber = VersionNumber.parse("4.0.0")
     val VERSION_4_1: VersionNumber = VersionNumber.parse("4.1.0")
     val VERSION_4_2: VersionNumber = VersionNumber.parse("4.2.0")
+    val VERSION_7_0: VersionNumber = VersionNumber.parse("7.0.0")
 }
 
 /** A fast file hash that don't load the entire file contents into memory at once. */


### PR DESCRIPTION
## Goal
Emit a helpful compatibility error when the plugin is used with Android Gradle Plugin 7 or higher, as this version of the Bugsnag Gradle Plugin is not compatible.

## Testing
A new test fixture has been included to ensure that AGP 7 inclusion fails the build.