### PR TITLE
Make the plugin compatible with AGP7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,23 +5,24 @@ buildscript {
         google()
     }
 
-    ext.agpVersion = "4.2.0-beta03" // compile against 4.1, but maintain compat to 3.4.0
-    ext.kotlinVersion = "1.3.72"
+    ext.agpVersion = "7.0.0-beta03"
+    ext.kotlinVersion = "1.4.31"
 
     dependencies {
         classpath "com.android.tools.build:gradle:$agpVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.17.1"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:9.4.1"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.1.0"
     }
 }
 // Gradle plugins
 plugins {
     id "java-gradle-plugin"
     id "groovy"
-    id "com.gradle.plugin-publish" version "0.12.0"
-    id "com.vanniktech.maven.publish" version "0.12.0"
-    id "com.github.hierynomus.license" version "0.15.0"
+    id 'maven-publish'
+    id "com.gradle.plugin-publish" version "0.15.0"
+    id "com.vanniktech.maven.publish" version "0.15.1"
+    id "com.github.hierynomus.license" version "0.16.1"
 }
 
 apply plugin: "org.jetbrains.kotlin.jvm"
@@ -119,13 +120,20 @@ pluginBundle {
     }
 }
 
-mavenPublish {
-    targets {
-        sonatype {
-            releaseRepositoryUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-            snapshotRepositoryUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
-            repositoryUsername = project.hasProperty("NEXUS_USERNAME") ? "$NEXUS_USERNAME" : System.getenv("NEXUS_USERNAME")
-            repositoryPassword = project.hasProperty("NEXUS_PASSWORD") ? "$NEXUS_PASSWORD" : System.getenv("NEXUS_PASSWORD")
+publishing {
+    repositories {
+        maven {
+            name = "Sonatype"
+            if (VERSION_NAME.contains("SNAPSHOT")) {
+                url = "https://oss.sonatype.org/content/repositories/snapshots/"
+            } else {
+                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            }
+
+            credentials {
+                username = project.hasProperty("NEXUS_USERNAME") ? "$NEXUS_USERNAME" : System.getenv("NEXUS_USERNAME")
+                password = project.hasProperty("NEXUS_PASSWORD") ? "$NEXUS_PASSWORD" : System.getenv("NEXUS_PASSWORD")
+            }
         }
     }
 }

--- a/features/fixtures/app/build.gradle
+++ b/features/fixtures/app/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         def agpVersion = System.env.AGP_VERSION ?: "7.0.0-beta03"
@@ -22,7 +22,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/features/fixtures/app/gradlew
+++ b/features/fixtures/app/gradlew
@@ -130,7 +130,7 @@ fi
 if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
-    
+
     JAVACMD=`cygpath --unix "$JAVACMD"`
 
     # We build the pattern for arguments to be converted via cygpath

--- a/features/fixtures/app/gradlew.bat
+++ b/features/fixtures/app/gradlew.bat
@@ -40,7 +40,7 @@ if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
-if "%ERRORLEVEL%" == "0" goto init
+if "%ERRORLEVEL%" == "0" goto execute
 
 echo.
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
@@ -54,7 +54,7 @@ goto fail
 set JAVA_HOME=%JAVA_HOME:"=%
 set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
-if exist "%JAVA_EXE%" goto init
+if exist "%JAVA_EXE%" goto execute
 
 echo.
 echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
@@ -64,21 +64,6 @@ echo location of your Java installation.
 
 goto fail
 
-:init
-@rem Get command-line arguments, handling Windows variants
-
-if not "%OS%" == "Windows_NT" goto win9xME_args
-
-:win9xME_args
-@rem Slurp the command line arguments.
-set CMD_LINE_ARGS=
-set _SKIP=2
-
-:win9xME_args_slurp
-if "x%~1" == "x" goto execute
-
-set CMD_LINE_ARGS=%*
-
 :execute
 @rem Setup the command line
 
@@ -86,7 +71,7 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -60,7 +60,7 @@ android {
 }
 
 dependencies {
-    compile 'com.bugsnag:bugsnag-android:5.0.0'
+    implementation 'com.bugsnag:bugsnag-android:5.0.0'
 }
 
 if (!System.env.UPDATING_GRADLEW) {

--- a/features/fixtures/ndkapp/gradlew
+++ b/features/fixtures/ndkapp/gradlew
@@ -130,7 +130,7 @@ fi
 if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
-    
+
     JAVACMD=`cygpath --unix "$JAVACMD"`
 
     # We build the pattern for arguments to be converted via cygpath

--- a/features/fixtures/ndkapp/gradlew.bat
+++ b/features/fixtures/ndkapp/gradlew.bat
@@ -40,7 +40,7 @@ if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
-if "%ERRORLEVEL%" == "0" goto init
+if "%ERRORLEVEL%" == "0" goto execute
 
 echo.
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
@@ -54,7 +54,7 @@ goto fail
 set JAVA_HOME=%JAVA_HOME:"=%
 set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
-if exist "%JAVA_EXE%" goto init
+if exist "%JAVA_EXE%" goto execute
 
 echo.
 echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
@@ -64,21 +64,6 @@ echo location of your Java installation.
 
 goto fail
 
-:init
-@rem Get command-line arguments, handling Windows variants
-
-if not "%OS%" == "Windows_NT" goto win9xME_args
-
-:win9xME_args
-@rem Slurp the command line arguments.
-set CMD_LINE_ARGS=
-set _SKIP=2
-
-:win9xME_args_slurp
-if "x%~1" == "x" goto execute
-
-set CMD_LINE_ARGS=%*
-
 :execute
 @rem Setup the command line
 
@@ -86,7 +71,7 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/features/fixtures/rn-monorepo/abc/android/app/build.gradle
+++ b/features/fixtures/rn-monorepo/abc/android/app/build.gradle
@@ -215,7 +215,7 @@ dependencies {
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use
 task copyDownloadableDepsToLibs(type: Copy) {
-    from configurations.compile
+    from configurations.implementation
     into 'libs'
 }
 

--- a/features/fixtures/rn063/android/app/build.gradle
+++ b/features/fixtures/rn063/android/app/build.gradle
@@ -225,7 +225,7 @@ dependencies {
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use
 task copyDownloadableDepsToLibs(type: Copy) {
-    from configurations.compile
+    from configurations.implementation
     into 'libs'
 }
 

--- a/features/fixtures/rn063/android/gradlew
+++ b/features/fixtures/rn063/android/gradlew
@@ -130,7 +130,7 @@ fi
 if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
-    
+
     JAVACMD=`cygpath --unix "$JAVACMD"`
 
     # We build the pattern for arguments to be converted via cygpath

--- a/features/fixtures/rn063/android/gradlew.bat
+++ b/features/fixtures/rn063/android/gradlew.bat
@@ -40,7 +40,7 @@ if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
-if "%ERRORLEVEL%" == "0" goto init
+if "%ERRORLEVEL%" == "0" goto execute
 
 echo.
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
@@ -54,7 +54,7 @@ goto fail
 set JAVA_HOME=%JAVA_HOME:"=%
 set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
-if exist "%JAVA_EXE%" goto init
+if exist "%JAVA_EXE%" goto execute
 
 echo.
 echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
@@ -64,21 +64,6 @@ echo location of your Java installation.
 
 goto fail
 
-:init
-@rem Get command-line arguments, handling Windows variants
-
-if not "%OS%" == "Windows_NT" goto win9xME_args
-
-:win9xME_args
-@rem Slurp the command line arguments.
-set CMD_LINE_ARGS=
-set _SKIP=2
-
-:win9xME_args_slurp
-if "x%~1" == "x" goto execute
-
-set CMD_LINE_ARGS=%*
-
 :execute
 @rem Setup the command line
 
@@ -86,7 +71,7 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/bugsnag/android/gradle/AndroidManifestParser.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/AndroidManifestParser.kt
@@ -1,8 +1,9 @@
 package com.bugsnag.android.gradle
 
-import com.android.utils.forEach
 import org.gradle.api.logging.Logger
 import org.w3c.dom.Document
+import org.w3c.dom.Node
+import org.w3c.dom.NodeList
 import java.io.File
 import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.transform.OutputKeys
@@ -161,5 +162,11 @@ internal class AndroidManifestParser {
             }
         }
         return false
+    }
+
+    private inline fun NodeList.forEach(action: (Node) -> Unit) {
+        for (index in 0 until length) {
+            action(item(index))
+        }
     }
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
@@ -1,14 +1,12 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.ApkVariantOutput
-import com.bugsnag.android.gradle.internal.GradleVersions
 import com.bugsnag.android.gradle.internal.NDK_SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.clearDir
 import com.bugsnag.android.gradle.internal.includesAbi
 import com.bugsnag.android.gradle.internal.mapProperty
 import com.bugsnag.android.gradle.internal.property
 import com.bugsnag.android.gradle.internal.register
-import com.bugsnag.android.gradle.internal.versionNumber
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
@@ -34,7 +32,7 @@ import javax.inject.Inject
 /**
  * Task that generates NDK shared object mapping files for upload to Bugsnag.
  */
-sealed class BugsnagGenerateNdkSoMappingTask(
+open class BugsnagGenerateNdkSoMappingTask @Inject constructor(
     objects: ObjectFactory,
     projectLayout: ProjectLayout
 ) : DefaultTask(), AndroidManifestInfoReceiver {
@@ -63,7 +61,7 @@ sealed class BugsnagGenerateNdkSoMappingTask(
     val objDumpPaths: MapProperty<String, String> = objects.mapProperty()
 
     @get:InputFiles
-    abstract val searchDirectories: ConfigurableFileCollection
+    val searchDirectories: ConfigurableFileCollection = objects.fileCollection()
 
     @TaskAction
     fun generateMappingFiles() {
@@ -135,33 +133,7 @@ sealed class BugsnagGenerateNdkSoMappingTask(
             name: String,
             configurationAction: BugsnagGenerateNdkSoMappingTask.() -> Unit
         ): TaskProvider<out BugsnagGenerateNdkSoMappingTask> {
-            val gradleVersion = project.gradle.versionNumber()
-            return when {
-                gradleVersion >= GradleVersions.VERSION_5_3 -> {
-                    project.tasks.register<BugsnagGenerateNdkSoMappingTask53Plus>(name, configurationAction)
-                }
-                else -> {
-                    project.tasks.register<BugsnagGenerateNdkSoMappingTaskLegacy>(name, configurationAction)
-                }
-            }
+            return project.tasks.register(name, configurationAction)
         }
     }
-}
-
-/** A legacy [BugsnagGenerateNdkSoMappingTask] that uses [ProjectLayout.configurableFiles]. */
-internal open class BugsnagGenerateNdkSoMappingTaskLegacy @Inject constructor(
-    objects: ObjectFactory,
-    projectLayout: ProjectLayout
-) : BugsnagGenerateNdkSoMappingTask(objects, projectLayout) {
-    @Suppress("DEPRECATION") // Here for backward compat
-    @get:InputFiles
-    override val searchDirectories: ConfigurableFileCollection = projectLayout.configurableFiles()
-}
-
-internal open class BugsnagGenerateNdkSoMappingTask53Plus @Inject constructor(
-    objects: ObjectFactory,
-    projectLayout: ProjectLayout
-) : BugsnagGenerateNdkSoMappingTask(objects, projectLayout) {
-    @get:InputFiles
-    override val searchDirectories: ConfigurableFileCollection = objects.fileCollection()
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateProguardTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateProguardTask.kt
@@ -1,14 +1,11 @@
 package com.bugsnag.android.gradle
 
-import com.bugsnag.android.gradle.internal.GradleVersions
 import com.bugsnag.android.gradle.internal.outputZipFile
 import com.bugsnag.android.gradle.internal.property
 import com.bugsnag.android.gradle.internal.register
-import com.bugsnag.android.gradle.internal.versionNumber
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -27,7 +24,7 @@ import javax.inject.Inject
 /**
  * Task to generate compressed JVM mapping files to Bugsnag.
  */
-sealed class BugsnagGenerateProguardTask @Inject constructor(
+open class BugsnagGenerateProguardTask @Inject constructor(
     objects: ObjectFactory
 ) : DefaultTask(), AndroidManifestInfoReceiver {
 
@@ -37,7 +34,7 @@ sealed class BugsnagGenerateProguardTask @Inject constructor(
     }
 
     @get:InputFiles
-    abstract val mappingFileProperty: ConfigurableFileCollection
+    val mappingFileProperty: ConfigurableFileCollection = objects.fileCollection()
 
     @get:PathSensitive(NONE)
     @get:InputFile
@@ -88,35 +85,7 @@ sealed class BugsnagGenerateProguardTask @Inject constructor(
             name: String,
             configurationAction: BugsnagGenerateProguardTask.() -> Unit
         ): TaskProvider<out BugsnagGenerateProguardTask> {
-            return when {
-                project.gradle.versionNumber() >= GradleVersions.VERSION_5_3 -> {
-                    project.tasks.register<BugsnagGenerateProguardTaskGradle53Plus>(name, configurationAction)
-                }
-                else -> {
-                    project.tasks.register<BugsnagGenerateProguardTaskLegacy>(name, configurationAction)
-                }
-            }
+            return project.tasks.register(name, configurationAction)
         }
     }
-}
-
-/**
- * Legacy [BugsnagGenerateProguardTask] task that requires using [getProject] and
- * [ProjectLayout.configurableFiles].
- */
-internal open class BugsnagGenerateProguardTaskLegacy @Inject constructor(
-    objects: ObjectFactory,
-    projectLayout: ProjectLayout
-) : BugsnagGenerateProguardTask(objects) {
-
-    @get:InputFiles
-    override val mappingFileProperty: ConfigurableFileCollection = projectLayout.configurableFiles()
-}
-
-internal open class BugsnagGenerateProguardTaskGradle53Plus @Inject constructor(
-    objects: ObjectFactory
-) : BugsnagGenerateProguardTask(objects) {
-
-    @get:InputFiles
-    override val mappingFileProperty: ConfigurableFileCollection = objects.fileCollection()
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagManifestUuidTaskV2.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagManifestUuidTaskV2.kt
@@ -1,6 +1,5 @@
 package com.bugsnag.android.gradle
 
-import com.android.Version
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.InputFile
@@ -8,7 +7,6 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import org.gradle.util.VersionNumber
 import javax.inject.Inject
 
 /**
@@ -17,19 +15,6 @@ import javax.inject.Inject
 open class BugsnagManifestUuidTaskV2 @Inject constructor(
     objects: ObjectFactory
 ) : BaseBugsnagManifestUuidTask(objects) {
-
-    internal companion object {
-        private val MIN_AGP_VERSION: VersionNumber = VersionNumber.parse("4.1.0-alpha04")
-
-        fun isApplicable(): Boolean {
-            return try {
-                VersionNumber.parse(Version.ANDROID_GRADLE_PLUGIN_VERSION) >= MIN_AGP_VERSION
-            } catch (ignored: Throwable) {
-                // Not on a new enough AGP version, return false
-                false
-            }
-        }
-    }
 
     // NONE because we only care about its contents, not location.
     @get:PathSensitive(PathSensitivity.NONE)

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
@@ -1,20 +1,17 @@
 package com.bugsnag.android.gradle
 
 import com.bugsnag.android.gradle.internal.BugsnagHttpClientHelper
-import com.bugsnag.android.gradle.internal.GradleVersions
 import com.bugsnag.android.gradle.internal.UploadRequestClient
 import com.bugsnag.android.gradle.internal.mapProperty
 import com.bugsnag.android.gradle.internal.property
 import com.bugsnag.android.gradle.internal.register
 import com.bugsnag.android.gradle.internal.runRequestWithRetries
 import com.bugsnag.android.gradle.internal.systemPropertyCompat
-import com.bugsnag.android.gradle.internal.versionNumber
 import com.squareup.moshi.JsonClass
 import okhttp3.OkHttpClient
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.model.ObjectFactory
@@ -50,9 +47,10 @@ import java.io.IOException
 import java.nio.charset.Charset
 import javax.inject.Inject
 
-sealed class BugsnagReleasesTask(
+open class BugsnagReleasesTask @Inject constructor(
     objects: ObjectFactory,
-    private val providerFactory: ProviderFactory
+    private val providerFactory: ProviderFactory,
+    private val execOperations: ExecOperations
 ) : DefaultTask(), AndroidManifestInfoReceiver {
 
     init {
@@ -80,13 +78,14 @@ sealed class BugsnagReleasesTask(
     // should take the JVM + NDK mapping files as inputs because the manifestInfo will
     // not necessarily vary between different builds. it is not guaranteed that
     // either of these properties will be set so they are marked as optional.
-    @get:InputFiles
-    @get:Optional
-    abstract val jvmMappingFileProperty: ConfigurableFileCollection
 
     @get:InputFiles
     @get:Optional
-    abstract val ndkMappingFileProperty: ConfigurableFileCollection
+    val jvmMappingFileProperty: ConfigurableFileCollection = objects.fileCollection()
+
+    @get:InputFiles
+    @get:Optional
+    val ndkMappingFileProperty: ConfigurableFileCollection = objects.fileCollection()
 
     @get:Input
     val retryCount: Property<Int> = objects.property()
@@ -144,25 +143,28 @@ sealed class BugsnagReleasesTask(
     @get:Optional
     val gitVersion: Property<String> = objects.property()
 
-    internal abstract fun exec(action: (ExecSpec) -> Unit): ExecResult
+    fun exec(action: (ExecSpec) -> Unit): ExecResult {
+        return execOperations.exec(action)
+    }
 
     @TaskAction
     fun fetchReleaseInfo() {
         val manifestInfo = parseManifestInfo()
         val payload = generateJsonPayload(manifestInfo)
 
-        val response = uploadRequestClient.get().makeRequestIfNeeded(manifestInfo, payload.hashCode()) {
-            logger.lifecycle("Bugsnag: Uploading to Releases API")
-            val response = try {
-                deliverPayload(payload, manifestInfo)
-            } catch (exc: Throwable) {
-                when {
-                    failOnUploadError.get() -> throw exc
-                    else -> "Failure"
+        val response =
+            uploadRequestClient.get().makeRequestIfNeeded(manifestInfo, payload.hashCode()) {
+                logger.lifecycle("Bugsnag: Uploading to Releases API")
+                val response = try {
+                    deliverPayload(payload, manifestInfo)
+                } catch (exc: Throwable) {
+                    when {
+                        failOnUploadError.get() -> throw exc
+                        else -> "Failure"
+                    }
                 }
+                response
             }
-            response
-        }
         requestOutputFile.asFile.get().writeText(response)
     }
 
@@ -183,7 +185,10 @@ sealed class BugsnagReleasesTask(
                 readRequestResponse(response.execute())
             }
         } catch (e: IOException) {
-            throw IllegalStateException("Request to Bugsnag Releases API failed, aborting build.", e)
+            throw IllegalStateException(
+                "Request to Bugsnag Releases API failed, aborting build.",
+                e
+            )
         }
     }
 
@@ -343,80 +348,8 @@ sealed class BugsnagReleasesTask(
             name: String,
             configurationAction: BugsnagReleasesTask.() -> Unit
         ): TaskProvider<out BugsnagReleasesTask> {
-            return when {
-                project.gradle.versionNumber() >= GradleVersions.VERSION_6 -> {
-                    project.tasks.register<BugsnagReleasesTaskGradle6Plus>(name, configurationAction)
-                }
-                project.gradle.versionNumber() >= GradleVersions.VERSION_5_3 -> {
-                    project.tasks.register<BugsnagReleasesTaskGradle53Plus>(name, configurationAction)
-                }
-                else -> {
-                    project.tasks.register<BugsnagReleasesTaskLegacy>(name, configurationAction)
-                }
-            }
+            return project.tasks.register(name, configurationAction)
         }
-    }
-}
-
-/**
- * Legacy [BugsnagReleasesTask] task that requires using [getProject] and
- * [ProjectLayout.configurableFiles].
- */
-internal open class BugsnagReleasesTaskLegacy @Inject constructor(
-    objects: ObjectFactory,
-    providerFactory: ProviderFactory,
-    projectLayout: ProjectLayout
-) : BugsnagReleasesTask(objects, providerFactory) {
-    @Suppress("DEPRECATION") // Here for backward compat
-    @get:InputFiles
-    @get:Optional
-    override val jvmMappingFileProperty: ConfigurableFileCollection = projectLayout.configurableFiles()
-
-    @Suppress("DEPRECATION") // Here for backward compat
-    @get:InputFiles
-    @get:Optional
-    override val ndkMappingFileProperty: ConfigurableFileCollection = projectLayout.configurableFiles()
-
-    override fun exec(action: (ExecSpec) -> Unit): ExecResult = project.exec(action)
-}
-
-/** Legacy [BugsnagReleasesTask] task that requires using [getProject]. */
-internal open class BugsnagReleasesTaskGradle53Plus @Inject constructor(
-    objects: ObjectFactory,
-    providerFactory: ProviderFactory
-) : BugsnagReleasesTask(objects, providerFactory) {
-    @get:InputFiles
-    @get:Optional
-    override val jvmMappingFileProperty: ConfigurableFileCollection = objects.fileCollection()
-
-    @get:InputFiles
-    @get:Optional
-    override val ndkMappingFileProperty: ConfigurableFileCollection = objects.fileCollection()
-
-    override fun exec(action: (ExecSpec) -> Unit): ExecResult {
-        return project.exec(action)
-    }
-}
-
-/**
- * A Gradle 6.0+ compatible [BugsnagReleasesTask], which uses [ExecOperations]
- * and supports configuration caching.
- */
-internal open class BugsnagReleasesTaskGradle6Plus @Inject constructor(
-    objects: ObjectFactory,
-    providerFactory: ProviderFactory,
-    private val execOperations: ExecOperations
-) : BugsnagReleasesTask(objects, providerFactory) {
-    @get:InputFiles
-    @get:Optional
-    override val jvmMappingFileProperty: ConfigurableFileCollection = objects.fileCollection()
-
-    @get:InputFiles
-    @get:Optional
-    override val ndkMappingFileProperty: ConfigurableFileCollection = objects.fileCollection()
-
-    override fun exec(action: (ExecSpec) -> Unit): ExecResult {
-        return execOperations.exec(action)
     }
 }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
@@ -1,15 +1,12 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.ApkVariant
-import com.bugsnag.android.gradle.internal.GradleVersions
 import com.bugsnag.android.gradle.internal.property
 import com.bugsnag.android.gradle.internal.register
-import com.bugsnag.android.gradle.internal.versionNumber
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -24,7 +21,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import javax.inject.Inject
 
-sealed class BugsnagUploadJsSourceMapTask @Inject constructor(
+open class BugsnagUploadJsSourceMapTask @Inject constructor(
     objects: ObjectFactory
 ) : DefaultTask(), AndroidManifestInfoReceiver {
 
@@ -54,7 +51,7 @@ sealed class BugsnagUploadJsSourceMapTask @Inject constructor(
     val requestOutputFile: RegularFileProperty = objects.fileProperty()
 
     @get:InputFiles
-    abstract val projectRootFileProvider: ConfigurableFileCollection
+    val projectRootFileProvider: ConfigurableFileCollection = objects.fileCollection()
 
     @get:Input
     val overwrite: Property<Boolean> = objects.property()
@@ -110,7 +107,10 @@ sealed class BugsnagUploadJsSourceMapTask @Inject constructor(
         requestOutputFile.asFile.get().writeText(cliResult)
     }
 
-    private fun generateUploadCommand(executable: String, manifestInfo: AndroidManifestInfo): ProcessBuilder {
+    private fun generateUploadCommand(
+        executable: String,
+        manifestInfo: AndroidManifestInfo
+    ): ProcessBuilder {
         val cmd = mutableListOf(
             executable,
             "upload-react-native",
@@ -176,14 +176,7 @@ sealed class BugsnagUploadJsSourceMapTask @Inject constructor(
             name: String,
             configurationAction: BugsnagUploadJsSourceMapTask.() -> Unit
         ): TaskProvider<out BugsnagUploadJsSourceMapTask> {
-            return when {
-                project.gradle.versionNumber() >= GradleVersions.VERSION_5_3 -> {
-                    project.tasks.register<BugsnagUploadJsSourceMapTaskGradle53Plus>(name, configurationAction)
-                }
-                else -> {
-                    project.tasks.register<BugsnagUploadJsSourceMapTaskLegacy>(name, configurationAction)
-                }
-            }
+            return project.tasks.register(name, configurationAction)
         }
     }
 }
@@ -201,24 +194,4 @@ internal fun findReactNativeSourcemapFile(project: Project, variant: ApkVariant)
     val bundleAssetName = react?.get("bundleAssetName") as String? ?: "index.android.bundle"
     val jsSourceMapsDir = "${project.buildDir}/generated/sourcemaps/react/${variant.dirName}"
     return "$jsSourceMapsDir/$bundleAssetName.map"
-}
-
-/**
- * Legacy [BugsnagUploadJsSourceMapTask] task that requires using [ProjectLayout.configurableFiles].
- */
-internal open class BugsnagUploadJsSourceMapTaskLegacy @Inject constructor(
-    objects: ObjectFactory,
-    projectLayout: ProjectLayout
-) : BugsnagUploadJsSourceMapTask(objects) {
-
-    @get:InputFiles
-    override val projectRootFileProvider: ConfigurableFileCollection = projectLayout.configurableFiles()
-}
-
-internal open class BugsnagUploadJsSourceMapTaskGradle53Plus @Inject constructor(
-    objects: ObjectFactory
-) : BugsnagUploadJsSourceMapTask(objects) {
-
-    @get:InputFiles
-    override val projectRootFileProvider: ConfigurableFileCollection = objects.fileCollection()
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/MappingFileProvider.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/MappingFileProvider.kt
@@ -52,11 +52,12 @@ private fun findMappingFiles(
  * Use AGP supplied value, preferring the new "getMappingFileProvider" API but falling back
  * to the old "mappingFile" API if necessary
  */
+@Suppress("SwallowedException")
 internal fun findMappingFileAgp(
     variant: ApkVariant,
     project: Project
 ) = try {
     variant.mappingFileProvider
 } catch (exc: Throwable) {
-    project.provider { project.layout.files(variant.mappingFile) }
+    project.provider { project.layout.files(variant.mappingFileProvider.orNull) }
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
@@ -46,6 +46,7 @@ internal object AgpVersions {
     val VERSION_4_0: VersionNumber = VersionNumber.parse("4.0.0")
     val VERSION_4_1: VersionNumber = VersionNumber.parse("4.1.0")
     val VERSION_4_2: VersionNumber = VersionNumber.parse("4.2.0")
+    val VERSION_7_0: VersionNumber = VersionNumber.parse("7.0.0")
 }
 
 /** A fast file hash that don't load the entire file contents into memory at once. */

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/ManifestUuidTaskV2Compat.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/ManifestUuidTaskV2Compat.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android.gradle.internal
 
-import com.android.build.api.artifact.ArtifactType
 import com.android.build.api.artifact.Artifacts
+import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.extension.AndroidComponentsExtension
 import com.android.build.gradle.AppExtension
 import com.bugsnag.android.gradle.BugsnagManifestUuidTaskV2
@@ -109,7 +109,7 @@ internal fun wireManifestUpdaterTask(
             taskInput = BugsnagManifestUuidTaskV2::inputManifest,
             taskOutput = BugsnagManifestUuidTaskV2::outputManifest
         )
-        .toTransform(ArtifactType.MERGED_MANIFEST)
+        .toTransform(SingleArtifact.MERGED_MANIFEST)
 }
 
 internal fun isVariantEnabled(


### PR DESCRIPTION
## Goal
Change the bugsnag-android-gradle-plugin to be compatible with Android Gradle Plugin 7. The plugin is now compiled against the AGP 7 API, all backwards compatible code has been removed.

## Testing
The maze-runner tests are not expected to pass yet, although they will now build and can run if run using AGP 7 and Gradle 7.