### PR TITLE
Emit compatibility error and warning

### DIFF
--- a/features/agp_compatibility_check.feature
+++ b/features/agp_compatibility_check.feature
@@ -1,0 +1,31 @@
+Feature: AGP7 Emits Compatibility Error
+
+Scenario: Compatibility Error Emitted when AGP 3.4.0 is used
+    When I build the failing "default_app" on AGP "3.4.0" using the "standard" bugsnag config
+    And I wait for 3 seconds
+    Then I should receive no requests
+
+Scenario: Compatibility Error Emitted when AGP 3.5.0 is used
+    When I build the failing "default_app" on AGP "3.5.0" using the "standard" bugsnag config
+    And I wait for 3 seconds
+    Then I should receive no requests
+
+Scenario: Compatibility Error Emitted when AGP 3.6.0 is used
+    When I build the failing "default_app" on AGP "3.6.0" using the "standard" bugsnag config
+    And I wait for 3 seconds
+    Then I should receive no requests
+
+Scenario: Compatibility Error Emitted when AGP 4.0.0 is used
+    When I build the failing "default_app" on AGP "4.0.0" using the "standard" bugsnag config
+    And I wait for 3 seconds
+    Then I should receive no requests
+
+Scenario: Compatibility Error Emitted when AGP 4.1.0 is used
+    When I build the failing "default_app" on AGP "4.1.0" using the "standard" bugsnag config
+    And I wait for 3 seconds
+    Then I should receive no requests
+
+Scenario: Compatibility Error Emitted when AGP 4.2.0 is used
+    When I build the failing "default_app" on AGP "4.2.0" using the "standard" bugsnag config
+    And I wait for 3 seconds
+    Then I should receive no requests

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -53,6 +53,13 @@ steps %Q{
 }
 end
 
+When("I build the failing {string} on AGP {string} using the {string} bugsnag config") do |module_config, agp_version, bugsnag_config|
+steps %Q{
+    When I set environment variable "AGP_VERSION" to "#{agp_version}"
+    And I build the failing "#{module_config}" using the "#{bugsnag_config}" bugsnag config
+}
+end
+
 When("I build the failing {string} using the {string} bugsnag config") do |module_config, bugsnag_config|
   Runner.environment["MODULE_CONFIG"] = module_config
   Runner.environment["BUGSNAG_CONFIG"] = bugsnag_config

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -5,6 +5,7 @@ import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.bugsnag.android.gradle.BugsnagInstallJniLibsTask.Companion.resolveBugsnagArtifacts
+import com.bugsnag.android.gradle.internal.AgpVersions
 import com.bugsnag.android.gradle.internal.BugsnagHttpClientHelper
 import com.bugsnag.android.gradle.internal.NDK_SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.TASK_JNI_LIBS
@@ -38,6 +39,7 @@ import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
 
@@ -64,6 +66,23 @@ class BugsnagPlugin : Plugin<Project> {
 
     @Suppress("LongMethod")
     override fun apply(project: Project) {
+        if (AgpVersions.CURRENT < AgpVersions.VERSION_7_0) {
+            throw StopExecutionException(
+                "Using com.bugsnag.android.gradle:7+ with Android Gradle Plugin < 7 " +
+                    "is not supported. Either upgrade the Android Gradle Plugin to 7, or use an " +
+                    "earlier version of the BugSnag Gradle Plugin. " +
+                    "For more information about this change, see " +
+                    "https://docs.bugsnag.com/build-integrations/gradle/"
+            )
+        } else if (AgpVersions.CURRENT >= AgpVersions.VERSION_8_0) {
+            project.logger.warn(
+                "Using com.bugsnag.android.gradle:7+ with Android Gradle Plugin 8+ is not " +
+                    "formally supported, and may lead to compatibility errors. " +
+                    "For more information, please see " +
+                    "https://docs.bugsnag.com/build-integrations/gradle/"
+            )
+        }
+
         // After Gradle 5.2, this can use service injection for injecting ObjectFactory
         val bugsnag = project.extensions.create(
             "bugsnag",

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
@@ -47,6 +47,7 @@ internal object AgpVersions {
     val VERSION_4_1: VersionNumber = VersionNumber.parse("4.1.0")
     val VERSION_4_2: VersionNumber = VersionNumber.parse("4.2.0")
     val VERSION_7_0: VersionNumber = VersionNumber.parse("7.0.0")
+    val VERSION_8_0: VersionNumber = VersionNumber.parse("8.0.0")
 }
 
 /** A fast file hash that don't load the entire file contents into memory at once. */


### PR DESCRIPTION
## Goal
When using bugsnag-android-gradle-plugin:7 with any version of the Android Gradle Plugin other than 7 we emit either an error or warning regarding the version compatibility. If the AGP version is less-than 7 we emit an error, while future major releases will trigger a warning that there may be incompatibilities.

## Testing
New automated test features are added testing all previously tested versions of AGP to ensure a build-failure.