### PR TITLE
Work around the new shared-object location in AGP7

### DIFF
--- a/features/fixtures/ndkapp/app/CMakeLists.txt
+++ b/features/fixtures/ndkapp/app/CMakeLists.txt
@@ -19,19 +19,6 @@ add_library( # Sets the name of the library.
              # Provides a relative path to your source file(s).
              src/main/cpp/native-lib.cpp )
 
-# Searches for a specified prebuilt library and stores the path as a
-# variable. Because CMake includes system libraries in the search path by
-# default, you only need to specify the name of the public NDK library
-# you want to add. CMake verifies that the library exists before
-# completing its build.
-
-find_library( # Sets the name of the path variable.
-              log-lib
-
-              # Specifies the name of the NDK library that
-              # you want CMake to locate.
-              log )
-
 # Specifies libraries CMake should link to your target library. You
 # can link multiple libraries, such as libraries you define in this
 # build script, prebuilt third-party libraries, or system libraries.
@@ -41,4 +28,4 @@ target_link_libraries( # Specifies the target library.
 
                        # Links the target library to the log library
                        # included in the NDK.
-                       ${log-lib} )
+                       log )

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -61,7 +61,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.bugsnag:bugsnag-android:5.0.0'
+    implementation 'com.bugsnag:bugsnag-android:5.9.4'
 }
 
 bugsnag {

--- a/features/fixtures/unity_2018/example/build.gradle
+++ b/features/fixtures/unity_2018/example/build.gradle
@@ -67,13 +67,15 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
-//            useProguard false
+            // useProguard is not compatible with Android Gradle Plugin 7+
+            // useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-unity.txt'
             jniDebuggable true
         }
         release {
             minifyEnabled true
-//            useProguard false
+            // useProguard is not compatible with Android Gradle Plugin 7+
+            // useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-unity.txt'
             signingConfig signingConfigs.debug
         }

--- a/features/fixtures/unity_2018/example/build.gradle
+++ b/features/fixtures/unity_2018/example/build.gradle
@@ -67,15 +67,11 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
-            // useProguard is not compatible with Android Gradle Plugin 7+
-            // useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-unity.txt'
             jniDebuggable true
         }
         release {
             minifyEnabled true
-            // useProguard is not compatible with Android Gradle Plugin 7+
-            // useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-unity.txt'
             signingConfig signingConfigs.debug
         }

--- a/features/fixtures/unity_2018/example/build.gradle
+++ b/features/fixtures/unity_2018/example/build.gradle
@@ -5,53 +5,41 @@ buildscript {
         mavenLocal()
         mavenCentral()
         google()
-        jcenter()
     }
 
     dependencies {
         def agpVersion = System.env.AGP_VERSION ?: "7.0.0-beta03"
         classpath "com.android.tools.build:gradle:${agpVersion}"
-
-        if (!System.env.UPDATING_GRADLEW) {
-            dependencies {
-                classpath "com.bugsnag:bugsnag-android-gradle-plugin:9000.0.0-test"
-            }
-        }
+        classpath "com.bugsnag:bugsnag-android-gradle-plugin:9000.0.0-test"
     }
 }
+
+apply plugin: 'com.android.application'
+apply plugin: 'com.bugsnag.android.gradle'
 
 allprojects {
     repositories {
         mavenCentral()
         google()
-        jcenter()
         flatDir {
             dirs 'libs'
         }
     }
 }
 
-apply plugin: 'com.android.application'
-
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation(name: 'android-lib-release', ext:'aar')
-    implementation(name: 'bugsnag-android-ndk-release', ext:'aar')
-    implementation(name: 'bugsnag-android-release', ext:'aar')
-    implementation(name: 'bugsnag-android-unity-release', ext:'aar')
-    implementation(name: 'bugsnag-plugin-android-anr-release', ext:'aar')
+    implementation(name: 'android-lib-release', ext: 'aar')
+    implementation(name: 'bugsnag-android-ndk-release', ext: 'aar')
+    implementation(name: 'bugsnag-android-release', ext: 'aar')
+    implementation(name: 'bugsnag-android-unity-release', ext: 'aar')
+    implementation(name: 'bugsnag-plugin-android-anr-release', ext: 'aar')
 }
 
 android {
     compileSdkVersion 29
     ndkVersion "16.1.4479499"
     buildToolsVersion '30.0.2'
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 
     defaultConfig {
         minSdkVersion 16
@@ -79,13 +67,13 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
-            useProguard false
+//            useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-unity.txt'
             jniDebuggable true
         }
         release {
             minifyEnabled true
-            useProguard false
+//            useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-unity.txt'
             signingConfig signingConfigs.debug
         }
@@ -133,11 +121,7 @@ android {
     }
 }
 
-if (!System.env.UPDATING_GRADLEW) {
-    apply plugin: 'com.bugsnag.android.gradle'
-
-    bugsnag {
-        endpoint = "http://localhost:9339"
-        releasesEndpoint = "http://localhost:9339"
-    }
+bugsnag {
+    endpoint = "http://localhost:9339"
+    releasesEndpoint = "http://localhost:9339"
 }

--- a/features/fixtures/unity_2019/build.gradle
+++ b/features/fixtures/unity_2019/build.gradle
@@ -11,12 +11,7 @@ allprojects {
         dependencies {
             def agpVersion = System.env.AGP_VERSION ?: "7.0.0-beta03"
             classpath "com.android.tools.build:gradle:${agpVersion}"
-
-            if (!System.env.UPDATING_GRADLEW) {
-                dependencies {
-                    classpath "com.bugsnag:bugsnag-android-gradle-plugin:9000.0.0-test"
-                }
-            }
+            classpath "com.bugsnag:bugsnag-android-gradle-plugin:9000.0.0-test"
         }
     }
 

--- a/features/fixtures/unity_2019/launcher/build.gradle
+++ b/features/fixtures/unity_2019/launcher/build.gradle
@@ -39,14 +39,14 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
-            useProguard false
+//            useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt')
             signingConfig signingConfigs.debug
             jniDebuggable true
         }
         release {
             minifyEnabled true
-            useProguard false
+//            useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt')
             signingConfig signingConfigs.debug
         }

--- a/features/fixtures/unity_2019/launcher/build.gradle
+++ b/features/fixtures/unity_2019/launcher/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.android.application'
 
 dependencies {
     implementation project(':unityLibrary')
-    }
+}
 
 android {
     compileSdkVersion 28
@@ -39,14 +39,16 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
-//            useProguard false
+            // useProguard is not compatible with Android Gradle Plugin 7+
+            // useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt')
             signingConfig signingConfigs.debug
             jniDebuggable true
         }
         release {
             minifyEnabled true
-//            useProguard false
+            // useProguard is not compatible with Android Gradle Plugin 7+
+            // useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt')
             signingConfig signingConfigs.debug
         }

--- a/features/fixtures/unity_2019/launcher/build.gradle
+++ b/features/fixtures/unity_2019/launcher/build.gradle
@@ -39,16 +39,12 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
-            // useProguard is not compatible with Android Gradle Plugin 7+
-            // useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt')
             signingConfig signingConfigs.debug
             jniDebuggable true
         }
         release {
             minifyEnabled true
-            // useProguard is not compatible with Android Gradle Plugin 7+
-            // useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt')
             signingConfig signingConfigs.debug
         }

--- a/features/ndk_app.feature
+++ b/features/ndk_app.feature
@@ -1,89 +1,87 @@
-#Feature: Plugin integrated in NDK app
-#
-#Scenario: NDK apps send requests
-#    When I build the NDK app
-#    And I wait to receive 6 requests
-#
-#    Then 1 requests are valid for the build API and match the following:
-#      | appVersionCode | appVersion | buildTool      |
-#      | 1              | 1.0        | gradle-android |
-#
-#    And 4 requests are valid for the android NDK mapping API and match the following:
-#      | arch        | projectRoot | sharedObjectName |
-#      | arm64-v8a   | /\S+/       | libnative-lib.so |
-#      | armeabi-v7a | /\S+/       | libnative-lib.so |
-#      | x86         | /\S+/       | libnative-lib.so |
-#      | x86_64      | /\S+/       | libnative-lib.so |
-#
-#    And 1 requests are valid for the android mapping API and match the following:
-#      | appId                      |
-#      | com.bugsnag.android.ndkapp |
-#
-#    And 1 requests have an R8 mapping file with the following symbols:
-#      | jvmSymbols |
-#      | com.bugsnag.android.ndkapp.MainActivity |
-#
-#Scenario: Custom projectRoot is added to payload
-#    When I set environment variable "PROJECT_ROOT" to "/repos/custom/my-app"
-#    And I build the NDK app
-#    And I wait to receive 6 requests
-#
-#    Then 1 requests are valid for the build API and match the following:
-#      | appVersionCode | appVersion | buildTool      |
-#      | 1              | 1.0        | gradle-android |
-#
-#    And 4 requests are valid for the android NDK mapping API and match the following:
-#      | arch        | projectRoot          |
-#      | arm64-v8a   | /repos/custom/my-app |
-#      | armeabi-v7a | /repos/custom/my-app |
-#      | x86         | /repos/custom/my-app |
-#      | x86_64      | /repos/custom/my-app |
-#
-#    And 1 requests are valid for the android mapping API and match the following:
-#        | appId                      |
-#        | com.bugsnag.android.ndkapp |
-#
-## Sets a non-existent objdump location for x86 and arm64-v8a, delivery should proceed as normal for other files
-#Scenario: Custom objdump location
-#    When I set environment variable "OBJDUMP_LOCATION" to "/fake/objdump"
-#    And I build the NDK app
-#    And I wait to receive 6 requests
-#
-#    Then 1 requests are valid for the build API and match the following:
-#      | appVersionCode | appVersion | buildTool      |
-#      | 1              | 1.0        | gradle-android |
-#
-#    And 4 requests are valid for the android NDK mapping API and match the following:
-#      | arch           |
-#      | armeabi-v7a    |
-#      | armeabi-v7a    |
-#      | x86_64         |
-#      | x86_64         |
-#
-#    And 1 requests are valid for the android mapping API and match the following:
-#        | appId                      |
-#        | com.bugsnag.android.ndkapp |
-#
-#Scenario: Mapping files uploaded for custom sharedObjectPaths
-#    When I set environment variable "USE_SHARED_OBJECT_PATH" to "true"
-#    When I build the NDK app
-#    And I wait to receive 10 requests
-#
-#    Then 1 requests are valid for the build API and match the following:
-#        | appVersionCode | appVersion | buildTool      |
-#        | 1              | 1.0        | gradle-android |
-#
-#    And 8 requests are valid for the android NDK mapping API and match the following:
-#        | arch        | projectRoot | sharedObjectName |
-#        | arm64-v8a   | /\S+/       | libnative-lib.so |
-#        | arm64-v8a   | /\S+/       | libmonochrome.so |
-#        | armeabi-v7a | /\S+/       | libnative-lib.so |
-#        | armeabi-v7a | /\S+/       | libmonochrome.so |
-#        | x86         | /\S+/       | libnative-lib.so |
-#        | x86         | /\S+/       | libmonochrome.so |
-#        | x86_64      | /\S+/       | libnative-lib.so |
-#        | x86_64      | /\S+/       | libmonochrome.so |
-#
-#    And 1 requests are valid for the android mapping API and match the following:
-#        | appId                      |
-#        | com.bugsnag.android.ndkapp |
+Feature: Plugin integrated in NDK app
+
+Scenario: NDK apps send requests
+    When I build the NDK app
+    And I wait to receive 6 requests
+
+    Then 1 requests are valid for the build API and match the following:
+      | appVersionCode | appVersion | buildTool      |
+      | 1              | 1.0        | gradle-android |
+
+    And 4 requests are valid for the android NDK mapping API and match the following:
+      | arch        | projectRoot | sharedObjectName |
+      | arm64-v8a   | /\S+/       | libnative-lib.so |
+      | armeabi-v7a | /\S+/       | libnative-lib.so |
+      | x86         | /\S+/       | libnative-lib.so |
+      | x86_64      | /\S+/       | libnative-lib.so |
+
+    And 1 requests are valid for the android mapping API and match the following:
+      | appId                      |
+      | com.bugsnag.android.ndkapp |
+
+    And 1 requests have an R8 mapping file with the following symbols:
+      | jvmSymbols |
+      | com.bugsnag.android.ndkapp.MainActivity |
+
+Scenario: Custom projectRoot is added to payload
+    When I set environment variable "PROJECT_ROOT" to "/repos/custom/my-app"
+    And I build the NDK app
+    And I wait to receive 6 requests
+
+    Then 1 requests are valid for the build API and match the following:
+      | appVersionCode | appVersion | buildTool      |
+      | 1              | 1.0        | gradle-android |
+
+    And 4 requests are valid for the android NDK mapping API and match the following:
+      | arch        | projectRoot          |
+      | arm64-v8a   | /repos/custom/my-app |
+      | armeabi-v7a | /repos/custom/my-app |
+      | x86         | /repos/custom/my-app |
+      | x86_64      | /repos/custom/my-app |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | appId                      |
+        | com.bugsnag.android.ndkapp |
+
+# Sets a non-existent objdump location for x86 and arm64-v8a, delivery should proceed as normal for other files
+Scenario: Custom objdump location
+    When I set environment variable "OBJDUMP_LOCATION" to "/fake/objdump"
+    And I build the NDK app
+    And I wait to receive 4 requests
+
+    Then 1 requests are valid for the build API and match the following:
+      | appVersionCode | appVersion | buildTool      |
+      | 1              | 1.0        | gradle-android |
+
+    And 2 requests are valid for the android NDK mapping API and match the following:
+      | arch           |
+      | armeabi-v7a    |
+      | x86_64         |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | appId                      |
+        | com.bugsnag.android.ndkapp |
+
+Scenario: Mapping files uploaded for custom sharedObjectPaths
+    When I set environment variable "USE_SHARED_OBJECT_PATH" to "true"
+    When I build the NDK app
+    And I wait to receive 10 requests
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 8 requests are valid for the android NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | arm64-v8a   | /\S+/       | libnative-lib.so |
+        | arm64-v8a   | /\S+/       | libmonochrome.so |
+        | armeabi-v7a | /\S+/       | libnative-lib.so |
+        | armeabi-v7a | /\S+/       | libmonochrome.so |
+        | x86         | /\S+/       | libnative-lib.so |
+        | x86         | /\S+/       | libmonochrome.so |
+        | x86_64      | /\S+/       | libnative-lib.so |
+        | x86_64      | /\S+/       | libmonochrome.so |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | appId                      |
+        | com.bugsnag.android.ndkapp |

--- a/features/proxy.feature
+++ b/features/proxy.feature
@@ -39,27 +39,23 @@ Scenario: Authenticated HTTP proxy without creds
     Then I wait for 5 seconds
     And I should receive no requests
 
-#Scenario: NDK request for basic HTTP proxy AGP >= 4
-#    When I start an http proxy
-#    And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
-#    When I build the NDK app
-#    And I wait to receive 10 requests
-#
-#    Then 1 requests are valid for the build API and match the following:
-#        | appVersionCode | appVersion | buildTool      |
-#        | 1              | 1.0        | gradle-android |
-#
-#    And 8 requests are valid for the android NDK mapping API and match the following:
-#        | arch        |
-#        | arm64-v8a   |
-#        | arm64-v8a   |
-#        | armeabi-v7a |
-#        | armeabi-v7a |
-#        | x86         |
-#        | x86         |
-#        | x86_64      |
-#        | x86_64      |
-#
-#    And 1 requests are valid for the android mapping API and match the following:
-#        | appId                      |
-#        | com.bugsnag.android.ndkapp |
+Scenario: NDK request for basic HTTP proxy
+    When I start an http proxy
+    And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
+    When I build the NDK app
+    And I wait to receive 6 requests
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 4 requests are valid for the android NDK mapping API and match the following:
+        | arch        |
+        | arm64-v8a   |
+        | armeabi-v7a |
+        | x86         |
+        | x86_64      |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | appId                      |
+        | com.bugsnag.android.ndkapp |

--- a/features/unity.feature
+++ b/features/unity.feature
@@ -1,117 +1,117 @@
-#Feature: Exported Unity project uploads mapping files
-#
-#Scenario: Unity 2018 exported gradle project uploads JVM/release/Unity information
-#    When I run the script "features/scripts/build_unity_2018.sh" synchronously
-#    And I wait to receive 8 requests
-#
-#    Then 1 requests are valid for the build API and match the following:
-#      | appVersionCode | appVersion | buildTool      |
-#      | 1              | 1.0        | gradle-android |
-#
-#    And 1 requests are valid for the android mapping API and match the following:
-#      | versionCode | versionName | appId               |
-#      | 1           | 1.0         | com.bugsnag.example |
-#
-#    And 2 requests are valid for the android NDK mapping API and match the following:
-#        | arch        | projectRoot | sharedObjectName |
-#        | armeabi-v7a | /\S+/       | libmonochrome.so |
-#        | x86         | /\S+/       | libmonochrome.so |
-#
-#    And 4 requests are valid for the android unity NDK mapping API and match the following:
-#        | arch        | projectRoot | sharedObjectName |
-#        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
-#        | armeabi-v7a | /\S+/       | libunity.sym.so  |
-#        | x86         | /\S+/       | libil2cpp.sym.so |
-#        | x86         | /\S+/       | libunity.sym.so  |
-#
-#Scenario: Unity 2019 exported gradle project uploads JVM/release/Unity information
-#    When I run the script "features/scripts/build_unity_2019.sh" synchronously
-#    And I wait to receive 5 requests
-#
-#    Then 1 requests are valid for the build API and match the following:
-#      | appVersionCode | appVersion | buildTool      |
-#      | 1              | 1.0        | gradle-android |
-#
-#    And 1 requests are valid for the android mapping API and match the following:
-#      | versionCode | versionName | appId               |
-#      | 1           | 1.0         | com.bugsnag.example |
-#
-#    And 1 requests are valid for the android NDK mapping API and match the following:
-#        | arch        | projectRoot | sharedObjectName |
-#        | armeabi-v7a | /\S+/       | libmonochrome.so |
-#
-#    # Unity 2019 doesn't contain symbols for x86
-#    And 2 requests are valid for the android unity NDK mapping API and match the following:
-#        | arch        | projectRoot | sharedObjectName |
-#        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
-#        | armeabi-v7a | /\S+/       | libunity.sym.so  |
-#
-#Scenario: Shared object files not uploaded when uploadNdkUnityLibraryMappings set to false
-#    When I set environment variable "UNITY_SO_UPLOAD" to "false"
-#    And I run the script "features/scripts/build_unity_2019.sh" synchronously
-#    And I wait to receive 2 requests
-#
-#    Then 1 requests are valid for the build API and match the following:
-#        | appVersionCode | appVersion | buildTool      |
-#        | 1              | 1.0        | gradle-android |
-#
-#    And 1 requests are valid for the android mapping API and match the following:
-#        | versionCode | versionName | appId               |
-#        | 1           | 1.0         | com.bugsnag.example |
-#
-#Scenario: Bundling a Unity project uploads JVM/release/Unity information
-#    When I run the script "features/scripts/bundle_unity_2019.sh" synchronously
-#    And I wait to receive 5 requests
-#
-#    Then 1 requests are valid for the build API and match the following:
-#        | appVersionCode | appVersion | buildTool      |
-#        | 1              | 1.0        | gradle-android |
-#
-#    And 1 requests are valid for the android mapping API and match the following:
-#        | versionCode | versionName | appId               |
-#        | 1           | 1.0         | com.bugsnag.example |
-#
-#    And 1 requests are valid for the android NDK mapping API and match the following:
-#        | arch        | projectRoot | sharedObjectName |
-#        | armeabi-v7a | /\S+/       | libmonochrome.so |
-#
-## Unity 2019 doesn't contain symbols for x86
-#    And 2 requests are valid for the android unity NDK mapping API and match the following:
-#        | arch        | projectRoot | sharedObjectName |
-#        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
-#        | armeabi-v7a | /\S+/       | libunity.sym.so  |
-#
-#Scenario: Building a Unity product flavor uploads Unity SO files
-#    When I set environment variable "UNITY_FLAVORS" to "true"
-#    When I run the script "features/scripts/build_unity_2018_flavors.sh" synchronously
-#    And I wait to receive 8 requests
-#
-#    Then 1 requests are valid for the build API and match the following:
-#        | appVersionCode | appVersion | buildTool      |
-#        | 1              | 1.0        | gradle-android |
-#
-#    And 1 requests are valid for the android mapping API and match the following:
-#        | versionCode | versionName | appId               |
-#        | 1           | 1.0         | com.bugsnag.example |
-#
-#    And 2 requests are valid for the android NDK mapping API and match the following:
-#        | arch        | projectRoot | sharedObjectName |
-#        | armeabi-v7a | /\S+/       | libmonochrome.so |
-#        | x86         | /\S+/       | libmonochrome.so |
-#
-#    And 4 requests are valid for the android unity NDK mapping API and match the following:
-#        | arch        | projectRoot | sharedObjectName |
-#        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
-#        | armeabi-v7a | /\S+/       | libunity.sym.so  |
-#        | x86         | /\S+/       | libil2cpp.sym.so |
-#        | x86         | /\S+/       | libunity.sym.so  |
-#
-#Scenario: Building a Unity product flavor uploads Unity SO files
-#    When I set environment variable "UNITY_ABI_SPLITS" to "true"
-#    When I run the script "features/scripts/build_unity_2018_abi_splits.sh" synchronously
-#    And I wait to receive 2 requests
-#
-#    And 2 requests are valid for the android unity NDK mapping API and match the following:
-#        | arch        | projectRoot | sharedObjectName |
-#        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
-#        | armeabi-v7a | /\S+/       | libunity.sym.so  |
+Feature: Exported Unity project uploads mapping files
+
+Scenario: Unity 2018 exported gradle project uploads JVM/release/Unity information
+    When I run the script "features/scripts/build_unity_2018.sh" synchronously
+    And I wait to receive 8 requests
+
+    Then 1 requests are valid for the build API and match the following:
+      | appVersionCode | appVersion | buildTool      |
+      | 1              | 1.0        | gradle-android |
+
+    And 1 requests are valid for the android mapping API and match the following:
+      | versionCode | versionName | appId               |
+      | 1           | 1.0         | com.bugsnag.example |
+
+    And 2 requests are valid for the android NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | armeabi-v7a | /\S+/       | libmonochrome.so |
+        | x86         | /\S+/       | libmonochrome.so |
+
+    And 4 requests are valid for the android unity NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
+        | armeabi-v7a | /\S+/       | libunity.sym.so  |
+        | x86         | /\S+/       | libil2cpp.sym.so |
+        | x86         | /\S+/       | libunity.sym.so  |
+
+Scenario: Unity 2019 exported gradle project uploads JVM/release/Unity information
+    When I run the script "features/scripts/build_unity_2019.sh" synchronously
+    And I wait to receive 5 requests
+
+    Then 1 requests are valid for the build API and match the following:
+      | appVersionCode | appVersion | buildTool      |
+      | 1              | 1.0        | gradle-android |
+
+    And 1 requests are valid for the android mapping API and match the following:
+      | versionCode | versionName | appId               |
+      | 1           | 1.0         | com.bugsnag.example |
+
+    And 1 requests are valid for the android NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | armeabi-v7a | /\S+/       | libmonochrome.so |
+
+    # Unity 2019 doesn't contain symbols for x86
+    And 2 requests are valid for the android unity NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
+        | armeabi-v7a | /\S+/       | libunity.sym.so  |
+
+Scenario: Shared object files not uploaded when uploadNdkUnityLibraryMappings set to false
+    When I set environment variable "UNITY_SO_UPLOAD" to "false"
+    And I run the script "features/scripts/build_unity_2019.sh" synchronously
+    And I wait to receive 2 requests
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | versionCode | versionName | appId               |
+        | 1           | 1.0         | com.bugsnag.example |
+
+Scenario: Bundling a Unity project uploads JVM/release/Unity information
+    When I run the script "features/scripts/bundle_unity_2019.sh" synchronously
+    And I wait to receive 5 requests
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | versionCode | versionName | appId               |
+        | 1           | 1.0         | com.bugsnag.example |
+
+    And 1 requests are valid for the android NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | armeabi-v7a | /\S+/       | libmonochrome.so |
+
+# Unity 2019 doesn't contain symbols for x86
+    And 2 requests are valid for the android unity NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
+        | armeabi-v7a | /\S+/       | libunity.sym.so  |
+
+Scenario: Building a Unity product flavor uploads Unity SO files
+    When I set environment variable "UNITY_FLAVORS" to "true"
+    When I run the script "features/scripts/build_unity_2018_flavors.sh" synchronously
+    And I wait to receive 8 requests
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | versionCode | versionName | appId               |
+        | 1           | 1.0         | com.bugsnag.example |
+
+    And 2 requests are valid for the android NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | armeabi-v7a | /\S+/       | libmonochrome.so |
+        | x86         | /\S+/       | libmonochrome.so |
+
+    And 4 requests are valid for the android unity NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
+        | armeabi-v7a | /\S+/       | libunity.sym.so  |
+        | x86         | /\S+/       | libil2cpp.sym.so |
+        | x86         | /\S+/       | libunity.sym.so  |
+
+Scenario: Building a Unity product flavor uploads Unity SO files
+    When I set environment variable "UNITY_ABI_SPLITS" to "true"
+    When I run the script "features/scripts/build_unity_2018_abi_splits.sh" synchronously
+    And I wait to receive 2 requests
+
+    And 2 requests are valid for the android unity NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
+        | armeabi-v7a | /\S+/       | libunity.sym.so  |

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -493,10 +493,14 @@ class BugsnagPlugin : Plugin<Project> {
             val searchPaths = getSharedObjectSearchPaths(project, bugsnag, android)
             searchDirectories.from(searchPaths)
             variant.externalNativeBuildProviders.forEach { provider ->
-                searchDirectories.from(provider.map(ExternalNativeBuildTask::objFolder))
-                searchDirectories.from(provider.map(ExternalNativeBuildTask::soFolder))
+                searchDirectories.from(provider.map { fixNativeOutputPath(it.objFolder) })
+                searchDirectories.from(provider.map { fixNativeOutputPath(it.soFolder) })
             }
         }
+    }
+
+    private fun fixNativeOutputPath(taskFolder: File): File {
+        return taskFolder.parentFile.parentFile.takeIf { it.parentFile.name == "cxx" } ?: taskFolder
     }
 
     @Suppress("LongParameterList")
@@ -635,8 +639,8 @@ class BugsnagPlugin : Plugin<Project> {
             }
             if (checkSearchDirectories) {
                 variant.externalNativeBuildProviders.forEach { task ->
-                    ndkMappingFileProperty.from(task.map { it.objFolder })
-                    ndkMappingFileProperty.from(task.map { it.soFolder })
+                    ndkMappingFileProperty.from(task.map { fixNativeOutputPath(it.objFolder) })
+                    ndkMappingFileProperty.from(task.map { fixNativeOutputPath(it.soFolder) })
                 }
             }
             configureMetadata()


### PR DESCRIPTION
## Goal
Work around the new shared-object location in AGP7 by looking at the parent-of-parent (`$soFolder/../..`) directory and using the existing `so` file scanning to find all of the appropriate files.

The implementation will revert to the old approach if the parent-of-parent-of-parent (`$soFolder/../../..`) is not named `cxx` as a sanity check.

## Testing
Re-enabled the NDK test features, and modified the NDK fixture app to not include the `liblog.so` on Travis.

The Unity tests have also been enabled, and the fixture build scripts have been modified to work with AGP 7 (as this is a trivial and appears to be a reasonable change to make).