### PR TITLE
Rescue the JS bundle from being overwritten by Hermes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Upload correct bundle when Hermes is enabled
+  [404](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/404)
+
 ## 5.7.7 (2021-06-23)
 
 * Emit a helpful compatibility error when Android Gradle Plugin 7 or higher is detected

--- a/features/fixtures/rn060/android/app/build.gradle
+++ b/features/fixtures/rn060/android/app/build.gradle
@@ -77,7 +77,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "index.js",
-    enableHermes: System.env.RN_ENABLE_HERMES == true,  // clean and rebuild if changing
+    enableHermes: !!System.env.RN_ENABLE_HERMES // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/features/fixtures/rn061/android/app/build.gradle
+++ b/features/fixtures/rn061/android/app/build.gradle
@@ -77,7 +77,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "index.js",
-    enableHermes: System.env.RN_ENABLE_HERMES == true,  // clean and rebuild if changing
+    enableHermes: !!System.env.RN_ENABLE_HERMES // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/features/fixtures/rn062/android/app/build.gradle
+++ b/features/fixtures/rn062/android/app/build.gradle
@@ -78,7 +78,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: System.env.RN_ENABLE_HERMES == true,  // clean and rebuild if changing
+    enableHermes: !!System.env.RN_ENABLE_HERMES // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/features/fixtures/rn063/android/app/build.gradle
+++ b/features/fixtures/rn063/android/app/build.gradle
@@ -77,7 +77,7 @@ import com.android.build.OutputFile
  * ]
  */
 project.ext.react = [
-    enableHermes: System.env.RN_ENABLE_HERMES == true // clean and rebuild if changing
+    enableHermes: !!System.env.RN_ENABLE_HERMES // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/features/react_native.feature
+++ b/features/react_native.feature
@@ -102,6 +102,8 @@ Scenario: Manually invoking source map upload task
 
 # blocked by PLAT-6305
 @skip_gradle_7_or_higher
+# Hermes driver cannot build rn_60 fixture
+@skip_rn60_fixture
 Scenario: Source maps are uploaded in an app using Hermes
     When I set environment variable "RN_ENABLE_HERMES" to "true"
     When I build the React Native app

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -41,6 +41,10 @@ Before('@skip_agp3_4_0') do |scenario|
   skip_this_scenario if equals_target(340)
 end
 
+Before('@skip_rn60_fixture') do |scenario|
+  skip_this_scenario if equals_rn_fixture('rn060')
+end
+
 def equals_target(target)
   version = ENV["AGP_VERSION"].slice(0, 5)
   version = version.gsub(".", "")
@@ -51,6 +55,11 @@ def is_above_or_equal_to_target(target)
   version = ENV["AGP_VERSION"].slice(0, 5)
   version = version.gsub(".", "")
   return version.to_i >= target
+end
+
+def equals_rn_fixture(target)
+    fixture_name = ENV["RN_FIXTURE_DIR"].split('/')[-2]
+    return fixture_name == target
 end
 
 def get_requests_with_field(name)

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -475,12 +475,22 @@ class BugsnagPlugin : Plugin<Project> {
         val rnTaskName = "bundle${variant.name.capitalize()}JsAndAssets"
         val rnTask: Task = project.tasks.findByName(rnTaskName) ?: return null
         val rnSourceMap = findReactNativeSourcemapFile(project, variant)
-        val rnBundle = BugsnagUploadJsSourceMapTask.findReactNativeTaskArg(rnTask, "--bundle-output")
+        var rnBundle = BugsnagUploadJsSourceMapTask.findReactNativeTaskArg(rnTask, "--bundle-output")
         val dev = BugsnagUploadJsSourceMapTask.findReactNativeTaskArg(rnTask, "--dev")
 
         if (rnBundle == null || dev == null) {
             project.logger.error("Bugsnag: unable to upload JS sourcemaps. Please enable sourcemap + bundle output.")
             return null
+        }
+
+        val enabledHermes = BugsnagUploadJsSourceMapTask.isHermesEnabled(project)
+        if (enabledHermes) {
+            rnBundle = BugsnagUploadJsSourceMapTask.rescueReactNativeSourceBundle(
+                rnTask,
+                rnBundle,
+                project,
+                output
+            )
         }
 
         return BugsnagUploadJsSourceMapTask.register(project, taskName) {

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagIntermediates.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagIntermediates.kt
@@ -4,6 +4,7 @@ import com.android.build.gradle.api.ApkVariantOutput
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
+import java.io.File
 
 /**
  * Intermediate path where libunity and other Unity SO files are copied
@@ -61,6 +62,11 @@ internal fun intermediateForGenerateJvmMapping(project: Project, output: ApkVari
 internal fun intermediateForUploadSourcemaps(project: Project, output: ApkVariantOutput): Provider<RegularFile> {
     val path = "intermediates/bugsnag/requests/sourceMapFor${output.taskNameSuffix()}"
     return project.layout.buildDirectory.file(path)
+}
+
+internal fun intermediateForRescuedReactNativeBundle(project: Project, output: ApkVariantOutput): File {
+    val path = "intermediates/bugsnag/rescued/${output.taskNameSuffix()}.android.bundle"
+    return project.layout.buildDirectory.file(path).get().asFile
 }
 
 internal fun Project.computeManifestInfoOutputV2(variant: String): Provider<RegularFile> {


### PR DESCRIPTION
## Goal
Upload the JS bundle instead of the Hermes bundle - when Hermes is enabled.

## Design
The Hermes stage of the `react.gradle` script is part of the standard ReactNative bundle task, but is in a `doLast` block (which produces an additional `Action` in the task). When Hermes is enabled for the project this change inserts a "rescue" action before the first `doLast` action it finds in the task. The rescue action copies the JS source bundle to the `intermediates/bugsnag/rescue` directory before the Hermes job can overwrite it.

## Testing
Manually tested and relied on existing tests to ensure no regressions.