### PR TITLE
Update Maze-runner to version 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', tag: 'v5.3.0'
+gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', branch: 'cawl/update-multipart-requests'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', branch: 'cawl/update-multipart-requests'
+gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', tag: 'v5.5.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.7.4'
+gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', tag: 'v5.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 67a22f49bc5c31a144fc72892f8cfafd0289010e
-  tag: v5.3.0
+  revision: eea928bc06926bbe8e647c6981959c3c86807bd5
+  tag: v5.5.0
   specs:
-    bugsnag-maze-runner (5.3.0)
+    bugsnag-maze-runner (5.5.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,10 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 06d2a4d4e07fe78e67d94eb757ea85c2f8747533
-  tag: v3.7.4
+  revision: 67a22f49bc5c31a144fc72892f8cfafd0289010e
+  tag: v5.3.0
   specs:
-    bugsnag-maze-runner (3.7.4)
-      appium_lib (~> 10.2)
-      boring (~> 0.1.0)
+    bugsnag-maze-runner (5.3.0)
+      appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
       curb (~> 0.9.6)
@@ -20,15 +19,14 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    appium_lib (10.6.0)
-      appium_lib_core (~> 3.3)
+    appium_lib (11.2.0)
+      appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (3.11.1)
+    appium_lib_core (4.6.0)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     backports (3.21.0)
-    boring (0.1.0)
     builder (3.2.4)
     childprocess (3.0.0)
     cucumber (3.1.2)
@@ -54,32 +52,34 @@ GEM
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     gherkin (5.1.0)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.6-x86_64-darwin)
+    nokogiri (1.11.7)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
     power_assert (2.0.0)
     racc (1.5.2)
     rake (12.3.3)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     test-unit (3.3.9)
       power_assert
     tomlrb (1.3.0)
-    websocket-driver (0.7.4)
+    websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
 
 PLATFORMS
-  x86_64-darwin-19
+  ruby
 
 DEPENDENCIES
   bugsnag-maze-runner!
 
 BUNDLED WITH
-   2.2.18
+   2.1.4

--- a/features/abi_apk_splits.feature
+++ b/features/abi_apk_splits.feature
@@ -40,7 +40,7 @@ Scenario: ABI Splits manual upload of build API
     When I build the "Armeabi-release" variantOutput for "abi_splits" using the "all_disabled" bugsnag config
     And I wait to receive a build
     Then the build request is valid for the Android Mapping API
-    And the field "apiKey" for multipart request equals "TEST_API_KEY"
-    And the field "versionCode" for multipart request equals "3"
-    And the field "versionName" for multipart request equals "1.0"
-    And the field "appId" for multipart request equals "com.bugsnag.android.example"
+    And the build payload field "apiKey" equals "TEST_API_KEY"
+    And the build payload field "versionCode" equals "3"
+    And the build payload field "versionName" equals "1.0"
+    And the build payload field "appId" equals "com.bugsnag.android.example"

--- a/features/abi_apk_splits.feature
+++ b/features/abi_apk_splits.feature
@@ -2,7 +2,7 @@ Feature: Plugin integrated in project with ABI APK splits
 
 Scenario: ABI Splits project builds successfully
     When I build "abi_splits" using the "standard" bugsnag config
-    And I wait to receive 16 requests
+    And I wait to receive 16 builds
 
     Then 8 requests are valid for the build API and match the following:
       | appVersionCode | appVersion |
@@ -34,12 +34,12 @@ Scenario: ABI Splits project builds successfully
 Scenario: ABI Splits automatic upload disabled
     When I build "abi_splits" using the "all_disabled" bugsnag config
     And I wait for 3 seconds
-    Then I should receive no requests
+    Then I should receive no builds
 
 Scenario: ABI Splits manual upload of build API
     When I build the "Armeabi-release" variantOutput for "abi_splits" using the "all_disabled" bugsnag config
-    And I wait to receive a request
-    Then the request is valid for the Android Mapping API
+    And I wait to receive a build
+    Then the build request is valid for the Android Mapping API
     And the field "apiKey" for multipart request equals "TEST_API_KEY"
     And the field "versionCode" for multipart request equals "3"
     And the field "versionName" for multipart request equals "1.0"

--- a/features/agp7_emits_error.feature
+++ b/features/agp7_emits_error.feature
@@ -3,5 +3,5 @@ Feature: AGP7 Emits Compatibility Error
 Scenario: Compatibility Error Emitted when AGP7 is used
     When I build the failing "default_app" on AGP7 using the "standard" bugsnag config
     And I wait for 3 seconds
-    Then I should receive no requests
+    Then I should receive no builds
 

--- a/features/apk_splits_same_version.feature
+++ b/features/apk_splits_same_version.feature
@@ -2,7 +2,7 @@ Feature: Plugin integrated in project with APK splits
 
 Scenario: APK splits avoid uploading duplicate requests for same version information
     When I build "apk_splits" using the "standard" bugsnag config
-    And I wait to receive 2 requests
+    And I wait to receive 2 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion |

--- a/features/app_bundle.feature
+++ b/features/app_bundle.feature
@@ -2,7 +2,7 @@ Feature: Generating Android app bundles
 
 Scenario: Single-module default app bundles successfully
     When I bundle "default_app" using the "standard" bugsnag config
-    And I wait to receive 2 requests
+    And I wait to receive 2 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      | sourceControl.provider | sourceControl.repository                                     |
@@ -19,7 +19,7 @@ Scenario: Single-module default app bundles successfully
 
 Scenario: Bundling multiple flavors automatically
     When I bundle "flavors" using the "standard" bugsnag config
-    And I wait to receive 4 requests
+    And I wait to receive 4 builds
 
     Then 2 requests are valid for the build API and match the following:
       | appVersion | appVersionCode |
@@ -33,7 +33,7 @@ Scenario: Bundling multiple flavors automatically
 
 Scenario: Bundling single flavor
     When I bundle the "Foo" variantOutput for "flavors" using the "standard" bugsnag config
-    And I wait to receive 2 requests
+    And I wait to receive 2 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersion | appVersionCode |
@@ -46,4 +46,4 @@ Scenario: Bundling single flavor
 Scenario: Auto upload disabled
     When I bundle "default_app" using the "all_disabled" bugsnag config
     And I wait for 3 seconds
-    Then I should receive no requests
+    Then I should receive no builds

--- a/features/default_app.feature
+++ b/features/default_app.feature
@@ -2,7 +2,7 @@ Feature: Plugin integrated in default app
 
 Scenario: Single-module default app builds successfully
     When I build "default_app" using the "standard" bugsnag config
-    And I wait to receive 2 requests
+    And I wait to receive 2 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      | sourceControl.provider | sourceControl.repository                                     |

--- a/features/density_abi_splits.feature
+++ b/features/density_abi_splits.feature
@@ -2,7 +2,7 @@ Feature: Plugin integrated in project with Density + ABI APK splits
 
 Scenario: Density ABI Splits project builds successfully
     When I build "density_abi_splits" using the "standard" bugsnag config
-    And I wait to receive 26 requests
+    And I wait to receive 26 builds
 
     Then 13 requests are valid for the build API and match the following:
       | appVersionCode |
@@ -39,10 +39,10 @@ Scenario: Density ABI Splits project builds successfully
 Scenario: Density ABI Splits automatic upload disabled
     When I build "density_abi_splits" using the "all_disabled" bugsnag config
     And I wait for 3 seconds
-    Then I should receive no requests
+    Then I should receive no builds
 
 Scenario: Density ABI Splits manual upload of build API
     When I build the "XxxhdpiArmeabi-release" variantOutput for "density_abi_splits" using the "all_disabled" bugsnag config
-    And I wait to receive a request
+    And I wait to receive a build
     Then the request is valid for the Android Mapping API
     And the field "versionCode" for multipart request equals "33"

--- a/features/density_abi_splits.feature
+++ b/features/density_abi_splits.feature
@@ -44,5 +44,5 @@ Scenario: Density ABI Splits automatic upload disabled
 Scenario: Density ABI Splits manual upload of build API
     When I build the "XxxhdpiArmeabi-release" variantOutput for "density_abi_splits" using the "all_disabled" bugsnag config
     And I wait to receive a build
-    Then the request is valid for the Android Mapping API
-    And the field "versionCode" for multipart request equals "33"
+    Then the build request is valid for the Android Mapping API
+    And the build payload field "versionCode" equals "33"

--- a/features/density_splits.feature
+++ b/features/density_splits.feature
@@ -2,7 +2,7 @@ Feature: Plugin integrated in project with Density APK splits
 
 Scenario: Density Splits project builds successfully
     When I build "density_splits" using the "standard" bugsnag config
-    And I wait to receive 14 requests
+    And I wait to receive 14 builds
 
     Then 7 requests are valid for the build API and match the following:
       | appVersionCode | appVersion |
@@ -27,11 +27,11 @@ Scenario: Density Splits project builds successfully
 Scenario: Density Splits automatic upload disabled
     When I build "density_splits" using the "all_disabled" bugsnag config
     And I wait for 3 seconds
-    Then I should receive no requests
+    Then I should receive no builds
 
 Scenario: Density Splits manual upload of build API
     When I build the "Hdpi-release" variantOutput for "density_splits" using the "all_disabled" bugsnag config
-    And I wait to receive a request
+    And I wait to receive a build
     Then the request is valid for the Android Mapping API
     And the field "apiKey" for multipart request equals "TEST_API_KEY"
     And the field "versionCode" for multipart request equals "4"

--- a/features/density_splits.feature
+++ b/features/density_splits.feature
@@ -32,8 +32,8 @@ Scenario: Density Splits automatic upload disabled
 Scenario: Density Splits manual upload of build API
     When I build the "Hdpi-release" variantOutput for "density_splits" using the "all_disabled" bugsnag config
     And I wait to receive a build
-    Then the request is valid for the Android Mapping API
-    And the field "apiKey" for multipart request equals "TEST_API_KEY"
-    And the field "versionCode" for multipart request equals "4"
-    And the field "versionName" for multipart request equals "1.0"
-    And the field "appId" for multipart request equals "com.bugsnag.android.example"
+    Then the build request is valid for the Android Mapping API
+    And the build payload field "apiKey" equals "TEST_API_KEY"
+    And the build payload field "versionCode" equals "4"
+    And the build payload field "versionName" equals "1.0"
+    And the build payload field "appId" equals "com.bugsnag.android.example"

--- a/features/disabled_bugsnag.feature
+++ b/features/disabled_bugsnag.feature
@@ -3,4 +3,4 @@ Feature: Bugsnag disabled
 Scenario: No requests are received when bugsnag is disabled
     When I build "default_app" using the "disabled_bugsnag" bugsnag config
     And I wait for 3 seconds
-    Then I should receive no requests
+    Then I should receive no builds

--- a/features/disabled_build_type.feature
+++ b/features/disabled_build_type.feature
@@ -3,4 +3,4 @@ Feature: Disabling plugin for build type
 Scenario: Disabled build type makes no requests
     When I build "default_app" using the "disabled_build_type" bugsnag config
     And I wait for 3 seconds
-    Then I should receive no requests
+    Then I should receive no builds

--- a/features/disabled_product_flavor.feature
+++ b/features/disabled_product_flavor.feature
@@ -2,7 +2,7 @@ Feature: Disabling plugin for product flavors
 
 Scenario: Disabled product flavor makes no requests
     When I build "flavors" using the "disabled_product_flavor" bugsnag config
-    And I wait to receive 2 requests
+    And I wait to receive 2 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion |

--- a/features/extension_properties.feature
+++ b/features/extension_properties.feature
@@ -3,7 +3,7 @@ Feature: Extension properties control plugin behaviour
 Scenario: Disable autoReportBuilds
     When I build "default_app" using the "auto_report_builds_disabled" bugsnag config
     And I wait to receive a build
-    Then the request is valid for the Android Mapping API
+    Then the build request is valid for the Android Mapping API
 
 Scenario: Enable debug mapping upload
     When I build "debug_proguard" using the "upload_debug_enabled" bugsnag config
@@ -22,8 +22,8 @@ Scenario: Enable debug mapping upload
 Scenario: Enable overwrite
     When I build "default_app" using the "overwrite_enabled" bugsnag config
     And I wait to receive a build
-    Then the request is valid for the Android Mapping API
-    And the field "overwrite" for multipart request equals "true"
+    Then the build request is valid for the Android Mapping API
+    And the build payload field "overwrite" equals "true"
 
 Scenario: Alter build API values
     When I build "default_app" using the "custom_build_info" bugsnag config

--- a/features/extension_properties.feature
+++ b/features/extension_properties.feature
@@ -2,12 +2,12 @@ Feature: Extension properties control plugin behaviour
 
 Scenario: Disable autoReportBuilds
     When I build "default_app" using the "auto_report_builds_disabled" bugsnag config
-    And I wait to receive a request
+    And I wait to receive a build
     Then the request is valid for the Android Mapping API
 
 Scenario: Enable debug mapping upload
     When I build "debug_proguard" using the "upload_debug_enabled" bugsnag config
-    And I wait to receive 4 requests
+    And I wait to receive 4 builds
 
     Then 2 requests are valid for the build API and match the following:
       | appVersionCode |
@@ -21,17 +21,17 @@ Scenario: Enable debug mapping upload
 
 Scenario: Enable overwrite
     When I build "default_app" using the "overwrite_enabled" bugsnag config
-    And I wait to receive a request
+    And I wait to receive a build
     Then the request is valid for the Android Mapping API
     And the field "overwrite" for multipart request equals "true"
 
 Scenario: Alter build API values
     When I build "default_app" using the "custom_build_info" bugsnag config
-    And I wait to receive a request
-    Then the payload field "builderName" equals "Mark Twain"
-    And the payload field "buildTool" equals "gradle-android"
-    And the payload field "sourceControl.provider" equals "bitbucket"
-    And the payload field "sourceControl.repository" equals "https://example.com/bar/foo.git"
-    And the payload field "sourceControl.revision" equals "fab8721"
-    And the payload field "metadata.MyKey" equals "MyValue"
-    And the payload field "metadata.os_version" equals "BeOS"
+    And I wait to receive a build
+    Then the build payload field "builderName" equals "Mark Twain"
+    And the build payload field "buildTool" equals "gradle-android"
+    And the build payload field "sourceControl.provider" equals "bitbucket"
+    And the build payload field "sourceControl.repository" equals "https://example.com/bar/foo.git"
+    And the build payload field "sourceControl.revision" equals "fab8721"
+    And the build payload field "metadata.MyKey" equals "MyValue"
+    And the build payload field "metadata.os_version" equals "BeOS"

--- a/features/fail_on_upload_error.feature
+++ b/features/fail_on_upload_error.feature
@@ -2,21 +2,21 @@ Feature: Build stops when mapping file upload fails
 
 Scenario: Upload successfully with API key, mapping file, and correct endpoint
     When I build "default_app" using the "standard" bugsnag config
-    And I wait to receive 2 requests
+    And I wait to receive 2 builds
     Then the exit code equals 0
 
 Scenario: No uploads or build failures when obfuscation is disabled
     When I build "disabled_obfuscation" using the "standard" bugsnag config
     And I wait for 3 seconds
-    Then I should receive no requests
+    Then I should receive no builds
     Then the exit code equals 0
 
 Scenario: Upload failure due to empty API key
     When I build the failing "default_app" using the "empty_api_key" bugsnag config
     And I wait for 3 seconds
-    Then I should receive no requests
+    Then I should receive no builds
 
 Scenario: Upload failure due to connectivity failure
     When I build the failing "default_app" using the "wrong_endpoint" bugsnag config
     And I wait for 3 seconds
-    Then I should receive no requests
+    Then I should receive no builds

--- a/features/fail_on_upload_error.feature
+++ b/features/fail_on_upload_error.feature
@@ -3,13 +3,11 @@ Feature: Build stops when mapping file upload fails
 Scenario: Upload successfully with API key, mapping file, and correct endpoint
     When I build "default_app" using the "standard" bugsnag config
     And I wait to receive 2 builds
-    Then the exit code equals 0
 
 Scenario: No uploads or build failures when obfuscation is disabled
     When I build "disabled_obfuscation" using the "standard" bugsnag config
     And I wait for 3 seconds
     Then I should receive no builds
-    Then the exit code equals 0
 
 Scenario: Upload failure due to empty API key
     When I build the failing "default_app" using the "empty_api_key" bugsnag config

--- a/features/fixtures/config/bugsnag/all_disabled.gradle
+++ b/features/fixtures/config/bugsnag/all_disabled.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/notify"
+    endpoint = "http://localhost:9339/builds"
     releasesEndpoint = "http://localhost:9339/builds"
     uploadJvmMappings = false
     reportBuilds = false

--- a/features/fixtures/config/bugsnag/all_disabled.gradle
+++ b/features/fixtures/config/bugsnag/all_disabled.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339"
-    releasesEndpoint = "http://localhost:9339"
+    endpoint = "http://localhost:9339/notify"
+    releasesEndpoint = "http://localhost:9339/builds"
     uploadJvmMappings = false
     reportBuilds = false
 }

--- a/features/fixtures/config/bugsnag/auto_report_builds_disabled.gradle
+++ b/features/fixtures/config/bugsnag/auto_report_builds_disabled.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/notify"
+    endpoint = "http://localhost:9339/builds"
     releasesEndpoint = "http://localhost:9339/builds"
     reportBuilds = false
 }

--- a/features/fixtures/config/bugsnag/auto_report_builds_disabled.gradle
+++ b/features/fixtures/config/bugsnag/auto_report_builds_disabled.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339"
-    releasesEndpoint = "http://localhost:9339"
+    endpoint = "http://localhost:9339/notify"
+    releasesEndpoint = "http://localhost:9339/builds"
     reportBuilds = false
 }

--- a/features/fixtures/config/bugsnag/custom_build_info.gradle
+++ b/features/fixtures/config/bugsnag/custom_build_info.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339"
-    releasesEndpoint = "http://localhost:9339"
+    endpoint = "http://localhost:9339/notify"
+    releasesEndpoint = "http://localhost:9339/builds"
     uploadJvmMappings = false
 
     builderName = "Mark Twain"

--- a/features/fixtures/config/bugsnag/custom_build_info.gradle
+++ b/features/fixtures/config/bugsnag/custom_build_info.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/notify"
+    endpoint = "http://localhost:9339/builds"
     releasesEndpoint = "http://localhost:9339/builds"
     uploadJvmMappings = false
 

--- a/features/fixtures/config/bugsnag/disabled_bugsnag.gradle
+++ b/features/fixtures/config/bugsnag/disabled_bugsnag.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339"
-    releasesEndpoint = "http://localhost:9339"
+    endpoint = "http://localhost:9339/notify"
+    releasesEndpoint = "http://localhost:9339/builds"
     enabled = false
 }

--- a/features/fixtures/config/bugsnag/disabled_bugsnag.gradle
+++ b/features/fixtures/config/bugsnag/disabled_bugsnag.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/notify"
+    endpoint = "http://localhost:9339/builds"
     releasesEndpoint = "http://localhost:9339/builds"
     enabled = false
 }

--- a/features/fixtures/config/bugsnag/disabled_build_type.gradle
+++ b/features/fixtures/config/bugsnag/disabled_build_type.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339"
-    releasesEndpoint = "http://localhost:9339"
+    endpoint = "http://localhost:9339/notify"
+    releasesEndpoint = "http://localhost:9339/builds"
 
     // disable bugsnag plugin for 'release' buildType
     variantFilter { variant ->

--- a/features/fixtures/config/bugsnag/disabled_build_type.gradle
+++ b/features/fixtures/config/bugsnag/disabled_build_type.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/notify"
+    endpoint = "http://localhost:9339/builds"
     releasesEndpoint = "http://localhost:9339/builds"
 
     // disable bugsnag plugin for 'release' buildType

--- a/features/fixtures/config/bugsnag/disabled_product_flavor.gradle
+++ b/features/fixtures/config/bugsnag/disabled_product_flavor.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/notify"
+    endpoint = "http://localhost:9339/builds"
     releasesEndpoint = "http://localhost:9339/builds"
 
     // disable bugsnag plugin for 'foo' productFlavor

--- a/features/fixtures/config/bugsnag/disabled_product_flavor.gradle
+++ b/features/fixtures/config/bugsnag/disabled_product_flavor.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339"
-    releasesEndpoint = "http://localhost:9339"
+    endpoint = "http://localhost:9339/notify"
+    releasesEndpoint = "http://localhost:9339/builds"
 
     // disable bugsnag plugin for 'foo' productFlavor
     variantFilter { variant ->

--- a/features/fixtures/config/bugsnag/empty_api_key.gradle
+++ b/features/fixtures/config/bugsnag/empty_api_key.gradle
@@ -9,6 +9,6 @@ android {
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339"
-    releasesEndpoint = "http://localhost:9339"
+    endpoint = "http://localhost:9339/notify"
+    releasesEndpoint = "http://localhost:9339/builds"
 }

--- a/features/fixtures/config/bugsnag/empty_api_key.gradle
+++ b/features/fixtures/config/bugsnag/empty_api_key.gradle
@@ -9,6 +9,6 @@ android {
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/notify"
+    endpoint = "http://localhost:9339/builds"
     releasesEndpoint = "http://localhost:9339/builds"
 }

--- a/features/fixtures/config/bugsnag/overwrite_enabled.gradle
+++ b/features/fixtures/config/bugsnag/overwrite_enabled.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/notify"
+    endpoint = "http://localhost:9339/builds"
     releasesEndpoint = "http://localhost:9339/builds"
     reportBuilds = false
     overwrite = true

--- a/features/fixtures/config/bugsnag/overwrite_enabled.gradle
+++ b/features/fixtures/config/bugsnag/overwrite_enabled.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339"
-    releasesEndpoint = "http://localhost:9339"
+    endpoint = "http://localhost:9339/notify"
+    releasesEndpoint = "http://localhost:9339/builds"
     reportBuilds = false
     overwrite = true
 }

--- a/features/fixtures/config/bugsnag/standard.gradle
+++ b/features/fixtures/config/bugsnag/standard.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339"
-    releasesEndpoint = "http://localhost:9339"
+    endpoint = "http://localhost:9339/notify"
+    releasesEndpoint = "http://localhost:9339/builds"
 }

--- a/features/fixtures/config/bugsnag/standard.gradle
+++ b/features/fixtures/config/bugsnag/standard.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/notify"
+    endpoint = "http://localhost:9339/builds"
     releasesEndpoint = "http://localhost:9339/builds"
 }

--- a/features/fixtures/config/bugsnag/upload_debug_enabled.gradle
+++ b/features/fixtures/config/bugsnag/upload_debug_enabled.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/notify"
+    endpoint = "http://localhost:9339/builds"
     releasesEndpoint = "http://localhost:9339/builds"
     variantFilter {}
 }

--- a/features/fixtures/config/bugsnag/upload_debug_enabled.gradle
+++ b/features/fixtures/config/bugsnag/upload_debug_enabled.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339"
-    releasesEndpoint = "http://localhost:9339"
+    endpoint = "http://localhost:9339/notify"
+    releasesEndpoint = "http://localhost:9339/builds"
     variantFilter {}
 }

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -68,8 +68,8 @@ if (!System.env.UPDATING_GRADLEW) {
 
     bugsnag {
         uploadNdkMappings = true
-        endpoint = "http://localhost:9339"
-        releasesEndpoint = "http://localhost:9339"
+        endpoint = "http://localhost:9339/notify"
+        releasesEndpoint = "http://localhost:9339/builds"
 
         def customPath = System.env.PROJECT_ROOT
         def objdumpLocation = System.env.OBJDUMP_LOCATION

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -68,7 +68,7 @@ if (!System.env.UPDATING_GRADLEW) {
 
     bugsnag {
         uploadNdkMappings = true
-        endpoint = "http://localhost:9339/notify"
+        endpoint = "http://localhost:9339/builds"
         releasesEndpoint = "http://localhost:9339/builds"
 
         def customPath = System.env.PROJECT_ROOT

--- a/features/fixtures/rn-monorepo/abc/android/app/build.gradle
+++ b/features/fixtures/rn-monorepo/abc/android/app/build.gradle
@@ -227,7 +227,7 @@ if (!System.env.UPDATING_GRADLEW) {
     bugsnag {
         uploadReactNativeMappings = true
         nodeModulesDir = project.layout.projectDirectory.dir("../../../node_modules/").asFile
-        endpoint = "http://localhost:9339/notify"
+        endpoint = "http://localhost:9339/builds"
         releasesEndpoint = "http://localhost:9339/builds"
     }
 }

--- a/features/fixtures/rn-monorepo/abc/android/app/build.gradle
+++ b/features/fixtures/rn-monorepo/abc/android/app/build.gradle
@@ -227,7 +227,7 @@ if (!System.env.UPDATING_GRADLEW) {
     bugsnag {
         uploadReactNativeMappings = true
         nodeModulesDir = project.layout.projectDirectory.dir("../../../node_modules/").asFile
-        endpoint = "http://localhost:9339"
-        releasesEndpoint = "http://localhost:9339"
+        endpoint = "http://localhost:9339/notify"
+        releasesEndpoint = "http://localhost:9339/builds"
     }
 }

--- a/features/fixtures/rn-monorepo/abc/android/app/src/main/AndroidManifest.xml
+++ b/features/fixtures/rn-monorepo/abc/android/app/src/main/AndroidManifest.xml
@@ -24,8 +24,8 @@
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
 
       <meta-data android:name="com.bugsnag.android.API_KEY" android:value="TEST_API_KEY" />
-      <meta-data android:name="com.bugsnag.android.ENDPOINT_NOTIFY" android:value="http://localhost:9339" />
-      <meta-data android:name="com.bugsnag.android.ENDPOINT_SESSIONS" android:value="http://localhost:9339" />
+      <meta-data android:name="com.bugsnag.android.ENDPOINT_NOTIFY" android:value="http://localhost:9339/notify" />
+      <meta-data android:name="com.bugsnag.android.ENDPOINT_SESSIONS" android:value="http://localhost:9339/sessions" />
     </application>
 
 </manifest>

--- a/features/fixtures/rn060/android/app/build.gradle
+++ b/features/fixtures/rn060/android/app/build.gradle
@@ -226,7 +226,7 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339/notify"
+        endpoint = "http://localhost:9339/builds"
         releasesEndpoint = "http://localhost:9339/builds"
         uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 

--- a/features/fixtures/rn060/android/app/build.gradle
+++ b/features/fixtures/rn060/android/app/build.gradle
@@ -226,8 +226,8 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339"
-        releasesEndpoint = "http://localhost:9339"
+        endpoint = "http://localhost:9339/notify"
+        releasesEndpoint = "http://localhost:9339/builds"
         uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 
         if (System.env.CUSTOM_NODE_MODULES_DIR == "true") {

--- a/features/fixtures/rn061/android/app/build.gradle
+++ b/features/fixtures/rn061/android/app/build.gradle
@@ -217,7 +217,7 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339/notify"
+        endpoint = "http://localhost:9339/builds"
         releasesEndpoint = "http://localhost:9339/builds"
         uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 

--- a/features/fixtures/rn061/android/app/build.gradle
+++ b/features/fixtures/rn061/android/app/build.gradle
@@ -217,8 +217,8 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339"
-        releasesEndpoint = "http://localhost:9339"
+        endpoint = "http://localhost:9339/notify"
+        releasesEndpoint = "http://localhost:9339/builds"
         uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 
         if (System.env.CUSTOM_NODE_MODULES_DIR == "true") {

--- a/features/fixtures/rn062/android/app/build.gradle
+++ b/features/fixtures/rn062/android/app/build.gradle
@@ -241,7 +241,7 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339/notify"
+        endpoint = "http://localhost:9339/builds"
         releasesEndpoint = "http://localhost:9339/builds"
         uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 

--- a/features/fixtures/rn062/android/app/build.gradle
+++ b/features/fixtures/rn062/android/app/build.gradle
@@ -241,8 +241,8 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339"
-        releasesEndpoint = "http://localhost:9339"
+        endpoint = "http://localhost:9339/notify"
+        releasesEndpoint = "http://localhost:9339/builds"
         uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 
         if (System.env.CUSTOM_NODE_MODULES_DIR == "true") {

--- a/features/fixtures/rn063/android/app/build.gradle
+++ b/features/fixtures/rn063/android/app/build.gradle
@@ -235,8 +235,8 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339"
-        releasesEndpoint = "http://localhost:9339"
+        endpoint = "http://localhost:9339/notify"
+        releasesEndpoint = "http://localhost:9339/builds"
         uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 
         if (System.env.CUSTOM_NODE_MODULES_DIR == "true") {

--- a/features/fixtures/rn063/android/app/build.gradle
+++ b/features/fixtures/rn063/android/app/build.gradle
@@ -235,7 +235,7 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339/notify"
+        endpoint = "http://localhost:9339/builds"
         releasesEndpoint = "http://localhost:9339/builds"
         uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 

--- a/features/fixtures/unity_2018/example/build.gradle
+++ b/features/fixtures/unity_2018/example/build.gradle
@@ -137,7 +137,7 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339"
-        releasesEndpoint = "http://localhost:9339"
+        endpoint = "http://localhost:9339/notify"
+        releasesEndpoint = "http://localhost:9339/builds"
     }
 }

--- a/features/fixtures/unity_2018/example/build.gradle
+++ b/features/fixtures/unity_2018/example/build.gradle
@@ -137,7 +137,7 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339/notify"
+        endpoint = "http://localhost:9339/builds"
         releasesEndpoint = "http://localhost:9339/builds"
     }
 }

--- a/features/fixtures/unity_2019/launcher/build.gradle
+++ b/features/fixtures/unity_2019/launcher/build.gradle
@@ -73,8 +73,8 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339"
-        releasesEndpoint = "http://localhost:9339"
+        endpoint = "http://localhost:9339/notify"
+        releasesEndpoint = "http://localhost:9339/builds"
 
         if ("false" == System.env.UNITY_SO_UPLOAD) {
             uploadNdkUnityLibraryMappings = false

--- a/features/fixtures/unity_2019/launcher/build.gradle
+++ b/features/fixtures/unity_2019/launcher/build.gradle
@@ -73,7 +73,7 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339/notify"
+        endpoint = "http://localhost:9339/builds"
         releasesEndpoint = "http://localhost:9339/builds"
 
         if ("false" == System.env.UNITY_SO_UPLOAD) {

--- a/features/flavor_apk_splits.feature
+++ b/features/flavor_apk_splits.feature
@@ -30,8 +30,8 @@ Scenario: Flavor Density Split automatic upload disabled
 Scenario: Flavor Density Split manual upload of build API
     When I build the "Bar-xxhdpi-release" variantOutput for "flavor_apk_splits" using the "all_disabled" bugsnag config
     And I wait to receive a build
-    Then the request is valid for the Android Mapping API
-    And the field "apiKey" for multipart request equals "TEST_API_KEY"
-    And the field "versionCode" for multipart request equals "3"
-    And the field "versionName" for multipart request equals "1.0"
-    And the field "appId" for multipart request equals "com.bugsnag.android.example.bar"
+    Then the build request is valid for the Android Mapping API
+    And the build payload field "apiKey" equals "TEST_API_KEY"
+    And the build payload field "versionCode" equals "3"
+    And the build payload field "versionName" equals "1.0"
+    And the build payload field "appId" equals "com.bugsnag.android.example.bar"

--- a/features/flavor_apk_splits.feature
+++ b/features/flavor_apk_splits.feature
@@ -2,7 +2,7 @@ Feature: Plugin integrated in project with Density APK splits and productFlavors
 
 Scenario: Flavor Density Split project builds successfully
     When I build "flavor_apk_splits" using the "standard" bugsnag config
-    And I wait to receive 12 requests
+    And I wait to receive 12 builds
 
     Then 6 requests are valid for the build API and match the following:
       | appVersionCode |
@@ -25,11 +25,11 @@ Scenario: Flavor Density Split project builds successfully
 Scenario: Flavor Density Split automatic upload disabled
     When I build "flavor_apk_splits" using the "all_disabled" bugsnag config
     And I wait for 3 seconds
-    Then I should receive no requests
+    Then I should receive no builds
 
 Scenario: Flavor Density Split manual upload of build API
     When I build the "Bar-xxhdpi-release" variantOutput for "flavor_apk_splits" using the "all_disabled" bugsnag config
-    And I wait to receive a request
+    And I wait to receive a build
     Then the request is valid for the Android Mapping API
     And the field "apiKey" for multipart request equals "TEST_API_KEY"
     And the field "versionCode" for multipart request equals "3"

--- a/features/flavors.feature
+++ b/features/flavors.feature
@@ -2,7 +2,7 @@ Feature: Plugin integrated in project with productFlavors
 
 Scenario: Flavors automatic upload on build
     When I build "flavors" using the "standard" bugsnag config
-    And I wait to receive 4 requests
+    And I wait to receive 4 builds
 
     Then 2 requests are valid for the build API and match the following:
       | appVersionCode | appVersion |
@@ -22,11 +22,11 @@ Scenario: Flavors automatic upload on build
 Scenario: Flavors automatic upload disabled
     When I build "flavors" using the "all_disabled" bugsnag config
     And I wait for 5 seconds
-    Then I should receive no requests
+    Then I should receive no builds
 
 Scenario: Flavors manual upload of build API
     When I build the "Foo-release" variantOutput for "flavors" using the "all_disabled" bugsnag config
-    And I wait to receive 1 requests
+    And I wait to receive 1 build
     Then the request is valid for the Android Mapping API
     And the field "apiKey" for multipart request equals "TEST_API_KEY"
     And the field "versionCode" for multipart request equals "1"

--- a/features/flavors.feature
+++ b/features/flavors.feature
@@ -27,8 +27,8 @@ Scenario: Flavors automatic upload disabled
 Scenario: Flavors manual upload of build API
     When I build the "Foo-release" variantOutput for "flavors" using the "all_disabled" bugsnag config
     And I wait to receive 1 build
-    Then the request is valid for the Android Mapping API
-    And the field "apiKey" for multipart request equals "TEST_API_KEY"
-    And the field "versionCode" for multipart request equals "1"
-    And the field "versionName" for multipart request equals "1.0"
-    And the field "appId" for multipart request equals "com.bugsnag.android.example.foo"
+    Then the build request is valid for the Android Mapping API
+    And the build payload field "apiKey" equals "TEST_API_KEY"
+    And the build payload field "versionCode" equals "1"
+    And the build payload field "versionName" equals "1.0"
+    And the build payload field "appId" equals "com.bugsnag.android.example.foo"

--- a/features/manual_build_uuid.feature
+++ b/features/manual_build_uuid.feature
@@ -2,7 +2,7 @@ Feature: Auto update build UUID flag
 
 Scenario: Build UUID excluded from request when set to false
     When I build "manual_build_uuid" using the "standard" bugsnag config
-    And I wait to receive 2 requests
+    And I wait to receive 2 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      | sourceControl.provider | sourceControl.repository                                     |

--- a/features/manual_upload.feature
+++ b/features/manual_upload.feature
@@ -3,7 +3,7 @@ Feature: Manual invocation of upload task
 Scenario: Manually invoking upload task sends requests
     When I build "default_app" using the "all_disabled" bugsnag config
     And I run the script "features/scripts/manual_upload.sh" synchronously
-    And I wait to receive 2 requests
+    And I wait to receive 2 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode |

--- a/features/ndk_app_agp400.feature
+++ b/features/ndk_app_agp400.feature
@@ -6,7 +6,7 @@ Feature: Plugin integrated in NDK app
 @requires_agp4_0_or_higher
 Scenario: NDK apps send requests
     When I build the NDK app
-    And I wait to receive 10 requests
+    And I wait to receive 10 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
@@ -35,7 +35,7 @@ Scenario: NDK apps send requests
 Scenario: Custom projectRoot is added to payload
     When I set environment variable "PROJECT_ROOT" to "/repos/custom/my-app"
     And I build the NDK app
-    And I wait to receive 10 requests
+    And I wait to receive 10 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
@@ -61,7 +61,7 @@ Scenario: Custom projectRoot is added to payload
 Scenario: Custom objdump location
     When I set environment variable "OBJDUMP_LOCATION" to "/fake/objdump"
     And I build the NDK app
-    And I wait to receive 6 requests
+    And I wait to receive 6 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
@@ -82,7 +82,7 @@ Scenario: Custom objdump location
 Scenario: Mapping files uploaded for custom sharedObjectPaths
     When I set environment variable "USE_SHARED_OBJECT_PATH" to "true"
     When I build the NDK app
-    And I wait to receive 14 requests
+    And I wait to receive 14 builds
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |

--- a/features/ndk_app_legacy.feature
+++ b/features/ndk_app_legacy.feature
@@ -4,7 +4,7 @@ Feature: Plugin integrated in NDK app
 @skip_agp3_4_0
 Scenario: NDK apps send requests
     When I build the NDK app
-    And I wait to receive 6 requests
+    And I wait to receive 6 builds
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
@@ -31,7 +31,7 @@ Scenario: NDK apps send requests
 Scenario: Custom projectRoot is added to payload
     When I set environment variable "PROJECT_ROOT" to "/repos/custom/my-app"
     And I build the NDK app
-    And I wait to receive 6 requests
+    And I wait to receive 6 builds
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
@@ -54,7 +54,7 @@ Scenario: Custom projectRoot is added to payload
 Scenario: Custom objdump location
     When I set environment variable "OBJDUMP_LOCATION" to "/fake/objdump"
     And I build the NDK app
-    And I wait to receive 4 requests
+    And I wait to receive 4 builds
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
@@ -74,7 +74,7 @@ Scenario: Custom objdump location
 Scenario: Mapping files uploaded for custom sharedObjectPaths
     When I set environment variable "USE_SHARED_OBJECT_PATH" to "true"
     When I build the NDK app
-    And I wait to receive 10 requests
+    And I wait to receive 10 builds
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |

--- a/features/proxy.feature
+++ b/features/proxy.feature
@@ -35,7 +35,7 @@ Scenario: Authenticated HTTP proxy with creds
 Scenario: Authenticated HTTP proxy without creds
     When I start an authenticated http proxy
     And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
-    And I build the failing "default_app" using the "standard" bugsnag config
+    And I build "default_app" using the "standard" bugsnag config
     Then I wait for 5 seconds
     And I should receive no builds
 

--- a/features/proxy.feature
+++ b/features/proxy.feature
@@ -6,7 +6,7 @@ Scenario: Basic HTTP proxy
     When I start an http proxy
     And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
     And I build "default_app" using the "standard" bugsnag config
-    And I wait to receive 2 requests
+    And I wait to receive 2 builds
     Then the proxy handled a request for "localhost:9339"
 
     And 1 requests are valid for the build API and match the following:
@@ -21,7 +21,7 @@ Scenario: Authenticated HTTP proxy with creds
     When I start an authenticated http proxy
     And I set the fixture JVM arguments to "-Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=9000 -Dhttp.proxyUser=user -Dhttp.proxyPassword=password -Dhttp.nonProxyHosts="
     And I build "default_app" using the "standard" bugsnag config
-    And I wait to receive 2 requests
+    And I wait to receive 2 builds
     Then the proxy handled a request for "localhost:9339"
 
     And 1 requests are valid for the build API and match the following:
@@ -37,7 +37,7 @@ Scenario: Authenticated HTTP proxy without creds
     And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
     And I build "default_app" using the "standard" bugsnag config
     Then I wait for 5 seconds
-    And I should receive no requests
+    And I should receive no builds
 
 @skip_agp4_0_or_higher
 @skip_agp3_4_0
@@ -45,7 +45,7 @@ Scenario: NDK request for basic HTTP proxy AGP < 4
     When I start an http proxy
     And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
     When I build the NDK app
-    And I wait to receive 6 requests
+    And I wait to receive 6 builds
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
@@ -67,7 +67,7 @@ Scenario: NDK request for basic HTTP proxy AGP >= 4
     When I start an http proxy
     And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
     When I build the NDK app
-    And I wait to receive 10 requests
+    And I wait to receive 10 builds
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |

--- a/features/proxy.feature
+++ b/features/proxy.feature
@@ -35,7 +35,7 @@ Scenario: Authenticated HTTP proxy with creds
 Scenario: Authenticated HTTP proxy without creds
     When I start an authenticated http proxy
     And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
-    And I build "default_app" using the "standard" bugsnag config
+    And I build the failing "default_app" using the "standard" bugsnag config
     Then I wait for 5 seconds
     And I should receive no builds
 

--- a/features/react_native.feature
+++ b/features/react_native.feature
@@ -4,7 +4,7 @@ Feature: Plugin integrated in React Native app
 @skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when assembling an app with the default project structure
     When I build the React Native app
-    And I wait to receive 3 requests
+    And I wait to receive 3 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
@@ -22,7 +22,7 @@ Scenario: Source maps are uploaded when assembling an app with the default proje
 @skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when bundling an app with the default project structure
     And I run the script "features/scripts/bundle_react_native_app.sh" synchronously
-    And I wait to receive 3 requests
+    And I wait to receive 3 builds
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
@@ -41,7 +41,7 @@ Scenario: Source maps are uploaded when bundling an app with the default project
 Scenario: Source maps are uploaded when assembling an app which uses productFlavors
     When I set environment variable "USE_RN_FLAVORS" to "true"
     When I build the React Native app
-    And I wait to receive 6 requests
+    And I wait to receive 6 builds
 
     Then 2 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
@@ -62,7 +62,7 @@ Scenario: Source maps are uploaded when assembling an app which uses productFlav
 @skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when assembling an app within a monorepo
     When I run the script "features/scripts/build_react_native_monorepo_app.sh" synchronously
-    And I wait to receive 3 requests
+    And I wait to receive 3 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
@@ -81,7 +81,7 @@ Scenario: Source maps are uploaded when assembling an app within a monorepo
 Scenario: Setting uploadReactNativeMappings to false will prevent any source map upload
     When I set environment variable "UPLOAD_RN_MAPPINGS" to "false"
     When I build the React Native app
-    And I wait to receive 2 requests
+    And I wait to receive 2 builds
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
@@ -95,7 +95,7 @@ Scenario: Setting uploadReactNativeMappings to false will prevent any source map
 @skip_gradle_7_or_higher
 Scenario: Manually invoking source map upload task
     And I run the script "features/scripts/manual_upload_react_native.sh" synchronously
-    And I wait to receive 1 requests
+    And I wait to receive 1 build
     And 1 requests are valid for the JS source map API and match the following:
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
@@ -107,7 +107,7 @@ Scenario: Manually invoking source map upload task
 Scenario: Source maps are uploaded in an app using Hermes
     When I set environment variable "RN_ENABLE_HERMES" to "true"
     When I build the React Native app
-    And I wait to receive 3 requests
+    And I wait to receive 3 builds
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
@@ -126,7 +126,7 @@ Scenario: Source maps are uploaded in an app using Hermes
 Scenario: Plugin handles server failure gracefully
     When I set the HTTP status code to 500
     And I run the script "features/scripts/manual_upload_react_native.sh" synchronously
-    And I wait to receive 5 requests
+    And I wait to receive 5 builds
     And 5 requests are valid for the JS source map API and match the following:
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
@@ -141,7 +141,7 @@ Scenario: Plugin handles server failure gracefully
 Scenario: Source maps are uploaded when assembling an app with a custom nodeModulesDir
     When I set environment variable "CUSTOM_NODE_MODULES_DIR" to "true"
     When I build the React Native app
-    And I wait to receive 3 requests
+    And I wait to receive 3 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |

--- a/features/react_native.feature
+++ b/features/react_native.feature
@@ -134,7 +134,6 @@ Scenario: Plugin handles server failure gracefully
         | 5              | 2.45.beta  | false     | false |
         | 5              | 2.45.beta  | false     | false |
         | 5              | 2.45.beta  | false     | false |
-    And the exit code equals 0
 
 # blocked by PLAT-6305
 @skip_gradle_7_or_higher

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -208,7 +208,7 @@ end
 
 def get_requests_with_field(request_type, name)
   all_requests = Maze::Server.list_for(request_type).clone
-  all_requests.reject do |request|
+  all_requests.all.reject do |request|
     value = Maze::Helper.read_key_path(request[:body], name)
     value.nil?
   end

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -41,15 +41,13 @@ def setup_and_run_script(module_config, bugsnag_config, script_path, variant = n
 end
 
 When('I build the React Native app') do
-  steps %(
-    And I run the script "features/scripts/build_react_native_app.sh" synchronously
-  )
+  _, exit_code = Maze::Runner.run_script('features/scripts/build_react_native_app.sh', blocking: true)
+  assert(exit_code.zero?, "Expected script to complete with 0 exit code, got #{exit_code}")
 end
 
 When('I build the NDK app') do
-  steps %(
-    And I run the script "features/scripts/build_ndk_app.sh" synchronously
-  )
+  _, exit_code = Maze::Runner.run_script('features/scripts/build_ndk_app.sh', blocking: true)
+  assert(exit_code.zero?, "Expected script to complete with 0 exit code, got #{exit_code}")
 end
 
 When('I set the fixture JVM arguments to {string}') do |jvm_args|

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -1,69 +1,62 @@
 require 'zlib'
 require 'stringio'
 
-When("I build {string} using the {string} bugsnag config") do |module_config, bugsnag_config|
-steps %Q{
-  When I set environment variable "MODULE_CONFIG" to "#{module_config}"
-  When I set environment variable "BUGSNAG_CONFIG" to "#{bugsnag_config}"
-  And I run the script "features/scripts/build_project_module.sh" synchronously
-}
+When('I build {string} using the {string} bugsnag config') do |module_config, bugsnag_config|
+  steps %(
+    When I set environment variable "MODULE_CONFIG" to "#{module_config}"
+    When I set environment variable "BUGSNAG_CONFIG" to "#{bugsnag_config}"
+    And I run the script "features/scripts/build_project_module.sh" synchronously
+  )
 end
 
-When("I build the {string} variantOutput for {string} using the {string} bugsnag config") do |variant, module_config, bugsnag_config|
-steps %Q{
-  When I set environment variable "VARIANT_OUTPUT_NAME" to "#{variant}"
-  When I set environment variable "MODULE_CONFIG" to "#{module_config}"
-  When I set environment variable "BUGSNAG_CONFIG" to "#{bugsnag_config}"
-  And I run the script "features/scripts/upload_variant_mapping.sh" synchronously
-}
+When('I build the {string} variantOutput for {string} using the {string} bugsnag config') do |variant, module_config, bugsnag_config|
+  steps %(
+    When I set environment variable "VARIANT_OUTPUT_NAME" to "#{variant}"
+    When I set environment variable "MODULE_CONFIG" to "#{module_config}"
+    When I set environment variable "BUGSNAG_CONFIG" to "#{bugsnag_config}"
+    And I run the script "features/scripts/upload_variant_mapping.sh" synchronously
+  )
 end
 
-When("I bundle {string} using the {string} bugsnag config") do |module_config, bugsnag_config|
-steps %Q{
-  When I set environment variable "MODULE_CONFIG" to "#{module_config}"
-  When I set environment variable "BUGSNAG_CONFIG" to "#{bugsnag_config}"
-  And I run the script "features/scripts/bundle_project_module.sh" synchronously
-}
+When('I bundle {string} using the {string} bugsnag config') do |module_config, bugsnag_config|
+  steps %(
+    When I set environment variable "MODULE_CONFIG" to "#{module_config}"
+    When I set environment variable "BUGSNAG_CONFIG" to "#{bugsnag_config}"
+    And I run the script "features/scripts/bundle_project_module.sh" synchronously
+  )
 end
 
-When("I bundle the {string} variantOutput for {string} using the {string} bugsnag config") do |variant, module_config, bugsnag_config|
-steps %Q{
-  When I set environment variable "VARIANT_OUTPUT_NAME" to "#{variant}"
-  When I set environment variable "MODULE_CONFIG" to "#{module_config}"
-  When I set environment variable "BUGSNAG_CONFIG" to "#{bugsnag_config}"
-  And I run the script "features/scripts/bundle_one_flavor.sh" synchronously
-}
+When('I bundle the {string} variantOutput for {string} using the {string} bugsnag config') do |variant, module_config, bugsnag_config|
+  steps %(
+    When I set environment variable "VARIANT_OUTPUT_NAME" to "#{variant}"
+    When I set environment variable "MODULE_CONFIG" to "#{module_config}"
+    When I set environment variable "BUGSNAG_CONFIG" to "#{bugsnag_config}"
+    And I run the script "features/scripts/bundle_one_flavor.sh" synchronously
+  )
 end
 
-When("I build the React Native app") do
-steps %Q{
-  And I run the script "features/scripts/build_react_native_app.sh" synchronously
-}
+When('I build the React Native app') do
+  steps %(
+    And I run the script "features/scripts/build_react_native_app.sh" synchronously
+  )
 end
 
-When("I build the NDK app") do
-steps %Q{
-  And I run the script "features/scripts/build_ndk_app.sh" synchronously
-}
+When('I build the NDK app') do
+  steps %(
+    And I run the script "features/scripts/build_ndk_app.sh" synchronously
+  )
 end
 
-When("I set the fixture JVM arguments to {string}") do |jvm_args|
-steps %Q{
-  When I set environment variable "CUSTOM_JVM_ARGS" to "#{jvm_args}"
-}
+When('I set the fixture JVM arguments to {string}') do |jvm_args|
+  steps %(
+    When I set environment variable "CUSTOM_JVM_ARGS" to "#{jvm_args}"
+  )
 end
 
-When("I build the failing {string} on AGP7 using the {string} bugsnag config") do |module_config, bugsnag_config|
-steps %Q{
-    When I set environment variable "AGP_VERSION" to "7.0.0-alpha15"
-    And I build the failing "#{module_config}" using the "#{bugsnag_config}" bugsnag config
-}
-end
-
-When("I build the failing {string} using the {string} bugsnag config") do |module_config, bugsnag_config|
-  Runner.environment["MODULE_CONFIG"] = module_config
-  Runner.environment["BUGSNAG_CONFIG"] = bugsnag_config
-  _, exit_code = Runner.run_script("features/scripts/bundle_project_module.sh", blocking: true)
+When('I build the failing {string} using the {string} bugsnag config') do |module_config, bugsnag_config|
+  Maze::Runner.environment['MODULE_CONFIG'] = module_config
+  Maze::Runner.environment['BUGSNAG_CONFIG'] = bugsnag_config
+  _, exit_code = Runner.run_script('features/scripts/bundle_project_module.sh', blocking: true)
   assert(exit_code != 0, "Expected script to fail with non-zero exit code, got #{exit_code}")
 end
 
@@ -72,9 +65,9 @@ Then(/^the exit code equals (\d+)$/) do |exit_code|
 end
 
 Then('{int} requests are valid for the build API and match the following:') do |request_count, data_table|
-  requests = get_requests_with_field('builderName')
+  requests = get_requests_with_field('build', 'builderName')
   assert_equal(request_count, requests.length, 'Wrong number of build API requests')
-  RequestSetAssertions.assert_requests_match requests, data_table
+  Maze::Assertions::RequestSetAssertions.assert_requests_match requests, data_table
 
   requests.each do |request|
     valid_build_api?(request[:body])
@@ -82,9 +75,9 @@ Then('{int} requests are valid for the build API and match the following:') do |
 end
 
 Then('{int} requests are valid for the android mapping API and match the following:') do |request_count, data_table|
-  requests = get_requests_with_field('proguard')
+  requests = get_requests_with_field('build', 'proguard')
   assert_equal(request_count, requests.length, 'Wrong number of mapping API requests')
-  RequestSetAssertions.assert_requests_match requests, data_table
+  Maze::Assertions::RequestSetAssertions.assert_requests_match requests, data_table
 
   requests.each do |request|
     valid_android_mapping_api?(request[:body])
@@ -92,9 +85,9 @@ Then('{int} requests are valid for the android mapping API and match the followi
 end
 
 Then('{int} requests are valid for the android NDK mapping API and match the following:') do |request_count, data_table|
-  requests = get_requests_with_field('soSymbolFile')
+  requests = get_requests_with_field('build', 'soSymbolFile')
   assert_equal(request_count, requests.length, 'Wrong number of NDK mapping API requests')
-  RequestSetAssertions.assert_requests_match requests, data_table
+  Maze::Assertions::RequestSetAssertions.assert_requests_match requests, data_table
 
   requests.each do |request|
     valid_android_ndk_mapping_api?(request[:body])
@@ -102,20 +95,19 @@ Then('{int} requests are valid for the android NDK mapping API and match the fol
 end
 
 Then('{int} requests are valid for the android unity NDK mapping API and match the following:') do |request_count, data_table|
-  requests = get_requests_with_field('soSymbolTableFile')
+  requests = get_requests_with_field('build', 'soSymbolTableFile')
   assert_equal(request_count, requests.length, 'Wrong number of android unity NDK mapping API requests')
-  RequestSetAssertions.assert_requests_match requests, data_table
+  Maze::Assertions::RequestSetAssertions.assert_requests_match requests, data_table
 
   requests.each do |request|
     valid_android_unity_ndk_mapping_api?(request[:body])
   end
 end
 
-
 Then('{int} requests are valid for the JS source map API and match the following:') do |request_count, data_table|
-  requests = get_requests_with_field('sourceMap')
+  requests = get_requests_with_field('build', 'sourceMap')
   assert_equal(request_count, requests.length, 'Wrong number of JS source map API requests')
-  RequestSetAssertions.assert_requests_match requests, data_table
+  Maze::Assertions::RequestSetAssertions.assert_requests_match requests, data_table
 
   requests.each do |request|
     valid_js_source_map_api?(request[:body])
@@ -123,7 +115,7 @@ Then('{int} requests are valid for the JS source map API and match the following
 end
 
 Then('{int} requests have an R8 mapping file with the following symbols:') do |request_count, data_table|
-  requests = get_requests_with_field('proguard')
+  requests = get_requests_with_field('build', 'proguard')
   assert_equal(request_count, requests.length, 'Wrong number of mapping API requests')
 
   # inflate gzipped proguard mapping file & verify contents
@@ -134,6 +126,17 @@ Then('{int} requests have an R8 mapping file with the following symbols:') do |r
     mapping_file_lines = archive.read.split("\n")
     valid_r8_mapping_contents?(mapping_file_lines, data_table.rows)
   end
+end
+
+Then('the build request is valid for the Android Mapping API') do
+  steps %(
+    And the build payload field "apiKey" equals "#{$api_key}"
+    And the build payload field "proguard" is not null
+    And the build payload field "appId" is not null
+    And the build payload field "versionCode" is not null
+    And the build payload field "buildUUID" is not null
+    And the build payload field "versionName" is not null
+  )
 end
 
 def valid_r8_mapping_contents?(mapping_file_lines, expected_entries)
@@ -149,16 +152,16 @@ def valid_r8_mapping_contents?(mapping_file_lines, expected_entries)
 end
 
 def valid_build_api?(request_body)
-  assert_equal($api_key, read_key_path(request_body, 'apiKey'))
-  assert_not_nil(read_key_path(request_body, 'appVersion'))
-  assert_not_nil(read_key_path(request_body, 'builderName'))
-  assert_not_nil(read_key_path(request_body, 'sourceControl.revision'))
-  assert_not_nil(read_key_path(request_body, 'metadata.os_name'))
-  assert_not_nil(read_key_path(request_body, 'metadata.os_arch'))
-  assert_not_nil(read_key_path(request_body, 'metadata.os_version'))
-  assert_not_nil(read_key_path(request_body, 'metadata.java_version'))
-  assert_not_nil(read_key_path(request_body, 'metadata.gradle_version'))
-  assert_not_nil(read_key_path(request_body, 'metadata.git_version'))
+  assert_equal($api_key, Maze::Helper.read_key_path(request_body, 'apiKey'))
+  assert_not_nil(Maze::Helper.read_key_path(request_body, 'appVersion'))
+  assert_not_nil(Maze::Helper.read_key_path(request_body, 'builderName'))
+  assert_not_nil(Maze::Helper.read_key_path(request_body, 'sourceControl.revision'))
+  assert_not_nil(Maze::Helper.read_key_path(request_body, 'metadata.os_name'))
+  assert_not_nil(Maze::Helper.read_key_path(request_body, 'metadata.os_arch'))
+  assert_not_nil(Maze::Helper.read_key_path(request_body, 'metadata.os_version'))
+  assert_not_nil(Maze::Helper.read_key_path(request_body, 'metadata.java_version'))
+  assert_not_nil(Maze::Helper.read_key_path(request_body, 'metadata.gradle_version'))
+  assert_not_nil(Maze::Helper.read_key_path(request_body, 'metadata.git_version'))
 end
 
 def valid_android_mapping_api?(request_body)
@@ -189,4 +192,24 @@ def valid_js_source_map_api?(request_body)
   assert_equal('android', request_body['platform'])
   assert_not_nil(request_body['sourceMap'])
   assert_not_nil(request_body['bundle'])
+end
+
+def equals_target(target)
+  version = ENV['AGP_VERSION'].slice(0, 5)
+  version = version.gsub('.', '')
+  version.to_i == target
+end
+
+def above_or_equal_to_target(target)
+  version = ENV['AGP_VERSION'].slice(0, 5)
+  version = version.gsub('.', '')
+  version.to_i >= target
+end
+
+def get_requests_with_field(request_type, name)
+  all_requests = Maze::Server.list_for(request_type).clone
+  all_requests.reject do |request|
+    value = Maze::Helper.read_key_path(request[:body], name)
+    value.nil?
+  end
 end

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -2,19 +2,28 @@ require 'zlib'
 require 'stringio'
 
 When('I build {string} using the {string} bugsnag config') do |module_config, bugsnag_config|
-  setup_and_run_script(module_config, bugsnag_config, 'features/scripts/build_project_module.sh')
+  exit_code = setup_and_run_script(module_config, bugsnag_config, 'features/scripts/build_project_module.sh')
+  assert(exit_code.zero?, "Expected script to complete with 0 exit code, got #{exit_code}")
 end
 
 When('I build the {string} variantOutput for {string} using the {string} bugsnag config') do |variant, module_config, bugsnag_config|
-  setup_and_run_script(module_config, bugsnag_config, 'features/scripts/upload_variant_mapping.sh', variant)
+  exit_code = setup_and_run_script(module_config, bugsnag_config, 'features/scripts/upload_variant_mapping.sh', variant)
+  assert(exit_code.zero?, "Expected script to complete with 0 exit code, got #{exit_code}")
 end
 
 When('I bundle {string} using the {string} bugsnag config') do |module_config, bugsnag_config|
-  setup_and_run_script(module_config, bugsnag_config, 'features/scripts/bundle_project_module.sh')
+  exit_code = setup_and_run_script(module_config, bugsnag_config, 'features/scripts/bundle_project_module.sh')
+  assert(exit_code.zero?, "Expected script to complete with 0 exit code, got #{exit_code}")
 end
 
 When('I bundle the {string} variantOutput for {string} using the {string} bugsnag config') do |variant, module_config, bugsnag_config|
-  setup_and_run_script(module_config, bugsnag_config, 'features/scripts/bundle_one_flavor.sh', variant)
+  exit_code = setup_and_run_script(module_config, bugsnag_config, 'features/scripts/bundle_one_flavor.sh', variant)
+  assert(exit_code.zero?, "Expected script to complete with 0 exit code, got #{exit_code}")
+end
+
+When('I build the failing {string} using the {string} bugsnag config') do |module_config, bugsnag_config|
+  exit_code = setup_and_run_script(module_config, bugsnag_config, 'features/scripts/bundle_project_module.sh')
+  assert(exit_code != 0, "Expected script to fail with non-zero exit code, got #{exit_code}")
 end
 
 def setup_and_run_script(module_config, bugsnag_config, script_path, variant = nil)
@@ -22,7 +31,7 @@ def setup_and_run_script(module_config, bugsnag_config, script_path, variant = n
   Maze::Runner.environment['BUGSNAG_CONFIG'] = bugsnag_config
   Maze::Runner.environment['VARIANT_OUTPUT_NAME'] = variant unless variant.nil?
   _, exit_code = Maze::Runner.run_script(script_path, blocking: true)
-  assert(exit_code.zero?, "Expected script to complete with 0 exit code, got #{exit_code}")
+  exit_code
 end
 
 When('I build the React Native app') do
@@ -43,12 +52,7 @@ When('I set the fixture JVM arguments to {string}') do |jvm_args|
   )
 end
 
-When('I build the failing {string} using the {string} bugsnag config') do |module_config, bugsnag_config|
-  Maze::Runner.environment['MODULE_CONFIG'] = module_config
-  Maze::Runner.environment['BUGSNAG_CONFIG'] = bugsnag_config
-  _, exit_code = Maze::Runner.run_script('features/scripts/bundle_project_module.sh', blocking: true)
-  assert(exit_code != 0, "Expected script to fail with non-zero exit code, got #{exit_code}")
-end
+
 
 Then('{int} requests are valid for the build API and match the following:') do |request_count, data_table|
   requests = get_requests_with_field('build', 'builderName')

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -46,7 +46,7 @@ end
 When('I build the failing {string} using the {string} bugsnag config') do |module_config, bugsnag_config|
   Maze::Runner.environment['MODULE_CONFIG'] = module_config
   Maze::Runner.environment['BUGSNAG_CONFIG'] = bugsnag_config
-  _, exit_code = Runner.run_script('features/scripts/bundle_project_module.sh', blocking: true)
+  _, exit_code = Maze::Runner.run_script('features/scripts/bundle_project_module.sh', blocking: true)
   assert(exit_code != 0, "Expected script to fail with non-zero exit code, got #{exit_code}")
 end
 

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -61,7 +61,9 @@ When('I build the failing {string} using the {string} bugsnag config') do |modul
 end
 
 Then(/^the exit code equals (\d+)$/) do |exit_code|
-  assert_equal(exit_code, $?.exitstatus.to_i)
+  assert_not_nil($?, 'The last process status is not available')
+  exit_status = $?.exitstatus
+  assert_equal(exit_code, exit_status.to_i)
 end
 
 Then('{int} requests are valid for the build API and match the following:') do |request_count, data_table|

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -21,7 +21,7 @@ def setup_and_run_script(module_config, bugsnag_config, script_path, variant = n
   Maze::Runner.environment['MODULE_CONFIG'] = module_config
   Maze::Runner.environment['BUGSNAG_CONFIG'] = bugsnag_config
   Maze::Runner.environment['VARIANT_OUTPUT_NAME'] = variant unless variant.nil?
-  _, exit_code = Maze::Runner.run_script(script_path, true)
+  _, exit_code = Maze::Runner.run_script(script_path, blocking: true)
   assert(exit_code.zero?, "Expected script to complete with 0 exit code, got #{exit_code}")
 end
 

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -180,18 +180,6 @@ def valid_js_source_map_api?(request_body)
   assert_not_nil(request_body['bundle'])
 end
 
-def equals_target(target)
-  version = ENV['AGP_VERSION'].slice(0, 5)
-  version = version.gsub('.', '')
-  version.to_i == target
-end
-
-def above_or_equal_to_target(target)
-  version = ENV['AGP_VERSION'].slice(0, 5)
-  version = version.gsub('.', '')
-  version.to_i >= target
-end
-
 def get_requests_with_field(request_type, name)
   all_requests = Maze::Server.list_for(request_type).clone
   all_requests.all.reject do |request|

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -52,8 +52,6 @@ When('I set the fixture JVM arguments to {string}') do |jvm_args|
   )
 end
 
-
-
 Then('{int} requests are valid for the build API and match the following:') do |request_count, data_table|
   requests = get_requests_with_field('build', 'builderName')
   assert_equal(request_count, requests.length, 'Wrong number of build API requests')

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -26,6 +26,12 @@ When('I build the failing {string} using the {string} bugsnag config') do |modul
   assert(exit_code != 0, "Expected script to fail with non-zero exit code, got #{exit_code}")
 end
 
+When('I build the failing {string} on AGP7 using the {string} bugsnag config') do |module_config, bugsnag_config|
+  Maze::Runner.environment['AGP_VERSION'] = '7.0.0-alpha15'
+  exit_code = setup_and_run_script(module_config, bugsnag_config, 'features/scripts/build_project_module.sh')
+  assert(exit_code != 0, "Expected script to fail with non-zero exit code, got #{exit_code}")
+end
+
 def setup_and_run_script(module_config, bugsnag_config, script_path, variant = nil)
   Maze::Runner.environment['MODULE_CONFIG'] = module_config
   Maze::Runner.environment['BUGSNAG_CONFIG'] = bugsnag_config

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -22,7 +22,7 @@ When('I bundle the {string} variantOutput for {string} using the {string} bugsna
 end
 
 When('I build the failing {string} using the {string} bugsnag config') do |module_config, bugsnag_config|
-  exit_code = setup_and_run_script(module_config, bugsnag_config, 'features/scripts/bundle_project_module.sh')
+  exit_code = setup_and_run_script(module_config, bugsnag_config, 'features/scripts/build_project_module.sh')
   assert(exit_code != 0, "Expected script to fail with non-zero exit code, got #{exit_code}")
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -47,6 +47,10 @@ Before('@skip_agp3_4_0') do |scenario|
   skip_this_scenario if equals_target(340)
 end
 
+Before('@skip_rn60_fixture') do |scenario|
+  skip_this_scenario if equals_rn_fixture('rn060')
+end
+
 def equals_target(target)
   version = ENV['AGP_VERSION'].slice(0, 5)
   version = version.gsub('.', '')
@@ -57,4 +61,9 @@ def above_or_equal_to_target(target)
   version = ENV['AGP_VERSION'].slice(0, 5)
   version = version.gsub('.', '')
   version.to_i >= target
+end
+
+def equals_rn_fixture(target)
+  fixture_name = ENV["RN_FIXTURE_DIR"].split('/')[-2]
+  return fixture_name == target
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -14,9 +14,13 @@ ENV['UNITY_2019_FIXTURE_DIR'] ||= 'features/fixtures/unity_2019'
 ENV['AGP_VERSION'] ||= '4.1.0' # default to latest
 ENV['GRADLE_WRAPPER_VERSION'] ||= '6.5.1'
 
-`./features/scripts/clear_local_maven_repo.sh`
-`./features/scripts/setup_gradle_wrapper.sh`
-`./features/scripts/install_gradle_plugin.sh`
+AfterConfiguration do |_config|
+  Maze.config.enforce_bugsnag_integrity = false
+
+  Maze::Runner.run_command('./features/scripts/clear_local_maven_repo.sh')
+  Maze::Runner.run_command('./features/scripts/setup_gradle_wrapper.sh')
+  Maze::Runner.run_command('./features/scripts/install_gradle_plugin.sh')
+end
 
 Before('@requires_agp4_0_or_higher') do |scenario|
   skip_this_scenario unless is_above_or_equal_to_target(400)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -23,19 +23,19 @@ AfterConfiguration do |_config|
 end
 
 Before('@requires_agp4_0_or_higher') do |scenario|
-  skip_this_scenario unless is_above_or_equal_to_target(400)
+  skip_this_scenario unless above_or_equal_to_target(400)
 end
 
 Before('@requires_agp4_1_or_higher') do |scenario|
-  skip_this_scenario unless is_above_or_equal_to_target(410)
+  skip_this_scenario unless above_or_equal_to_target(410)
 end
 
 Before('@skip_agp4_0_or_higher') do |scenario|
-  skip_this_scenario if is_above_or_equal_to_target(400)
+  skip_this_scenario if above_or_equal_to_target(400)
 end
 
 Before('@skip_agp4_1_or_higher') do |scenario|
-  skip_this_scenario if is_above_or_equal_to_target(410)
+  skip_this_scenario if above_or_equal_to_target(410)
 end
 
 Before('@skip_gradle_7_or_higher') do |scenario|
@@ -45,4 +45,16 @@ end
 
 Before('@skip_agp3_4_0') do |scenario|
   skip_this_scenario if equals_target(340)
+end
+
+def equals_target(target)
+  version = ENV['AGP_VERSION'].slice(0, 5)
+  version = version.gsub('.', '')
+  version.to_i == target
+end
+
+def above_or_equal_to_target(target)
+  version = ENV['AGP_VERSION'].slice(0, 5)
+  version = version.gsub('.', '')
+  version.to_i >= target
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,16 +1,18 @@
 # Configure app environment
+# Set this explicitly
+$api_key = 'TEST_API_KEY'
 
 # Set which test fixture should be used
-ENV["APP_FIXTURE_DIR"] ||= "features/fixtures/app"
-ENV["NDK_FIXTURE_DIR"] ||= "features/fixtures/ndkapp"
-ENV["RN_FIXTURE_DIR"] ||= "features/fixtures/rn063/android"
-ENV["RN_MONOREPO_FIXTURE_DIR"] ||= "features/fixtures/rn-monorepo/abc/android"
-ENV["UNITY_2018_FIXTURE_DIR"] ||= "features/fixtures/unity_2018/example"
-ENV["UNITY_2019_FIXTURE_DIR"] ||= "features/fixtures/unity_2019"
+ENV['APP_FIXTURE_DIR'] ||= 'features/fixtures/app'
+ENV['NDK_FIXTURE_DIR'] ||= 'features/fixtures/ndkapp'
+ENV['RN_FIXTURE_DIR'] ||= 'features/fixtures/rn063/android'
+ENV['RN_MONOREPO_FIXTURE_DIR'] ||= 'features/fixtures/rn-monorepo/abc/android'
+ENV['UNITY_2018_FIXTURE_DIR'] ||= 'features/fixtures/unity_2018/example'
+ENV['UNITY_2019_FIXTURE_DIR'] ||= 'features/fixtures/unity_2019'
 
 # set defaults for versions
-ENV["AGP_VERSION"] ||= "4.1.0" # default to latest
-ENV["GRADLE_WRAPPER_VERSION"] ||= "6.5.1"
+ENV['AGP_VERSION'] ||= '4.1.0' # default to latest
+ENV['GRADLE_WRAPPER_VERSION'] ||= '6.5.1'
 
 `./features/scripts/clear_local_maven_repo.sh`
 `./features/scripts/setup_gradle_wrapper.sh`
@@ -33,44 +35,10 @@ Before('@skip_agp4_1_or_higher') do |scenario|
 end
 
 Before('@skip_gradle_7_or_higher') do |scenario|
-  version = ENV["GRADLE_WRAPPER_VERSION"].slice(0, 1)
+  version = ENV['GRADLE_WRAPPER_VERSION'].slice(0, 1)
   skip_this_scenario if version.to_i >= 7
 end
 
 Before('@skip_agp3_4_0') do |scenario|
   skip_this_scenario if equals_target(340)
-end
-
-Before('@skip_rn60_fixture') do |scenario|
-  skip_this_scenario if equals_rn_fixture('rn060')
-end
-
-def equals_target(target)
-  version = ENV["AGP_VERSION"].slice(0, 5)
-  version = version.gsub(".", "")
-  return version.to_i == target
-end
-
-def is_above_or_equal_to_target(target)
-  version = ENV["AGP_VERSION"].slice(0, 5)
-  version = version.gsub(".", "")
-  return version.to_i >= target
-end
-
-def equals_rn_fixture(target)
-    fixture_name = ENV["RN_FIXTURE_DIR"].split('/')[-2]
-    return fixture_name == target
-end
-
-def get_requests_with_field(name)
-  Server.stored_requests.reject do |request|
-    value = read_key_path(request[:body], name)
-    value.nil?
-  end
-end
-
-$api_key = "TEST_API_KEY"
-
-AfterConfiguration do |_config|
-  MazeRunner.config.enforce_bugsnag_integrity = false
 end

--- a/features/unity.feature
+++ b/features/unity.feature
@@ -2,7 +2,7 @@ Feature: Exported Unity project uploads mapping files
 
 Scenario: Unity 2018 exported gradle project uploads JVM/release/Unity information
     When I run the script "features/scripts/build_unity_2018.sh" synchronously
-    And I wait to receive 8 requests
+    And I wait to receive 8 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
@@ -26,7 +26,7 @@ Scenario: Unity 2018 exported gradle project uploads JVM/release/Unity informati
 
 Scenario: Unity 2019 exported gradle project uploads JVM/release/Unity information
     When I run the script "features/scripts/build_unity_2019.sh" synchronously
-    And I wait to receive 5 requests
+    And I wait to receive 5 builds
 
     Then 1 requests are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
@@ -49,7 +49,7 @@ Scenario: Unity 2019 exported gradle project uploads JVM/release/Unity informati
 Scenario: Shared object files not uploaded when uploadNdkUnityLibraryMappings set to false
     When I set environment variable "UNITY_SO_UPLOAD" to "false"
     And I run the script "features/scripts/build_unity_2019.sh" synchronously
-    And I wait to receive 2 requests
+    And I wait to receive 2 builds
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
@@ -61,7 +61,7 @@ Scenario: Shared object files not uploaded when uploadNdkUnityLibraryMappings se
 
 Scenario: Bundling a Unity project uploads JVM/release/Unity information
     When I run the script "features/scripts/bundle_unity_2019.sh" synchronously
-    And I wait to receive 5 requests
+    And I wait to receive 5 builds
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
@@ -84,7 +84,7 @@ Scenario: Bundling a Unity project uploads JVM/release/Unity information
 Scenario: Building a Unity product flavor uploads Unity SO files
     When I set environment variable "UNITY_FLAVORS" to "true"
     When I run the script "features/scripts/build_unity_2018_flavors.sh" synchronously
-    And I wait to receive 8 requests
+    And I wait to receive 8 builds
 
     Then 1 requests are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
@@ -109,7 +109,7 @@ Scenario: Building a Unity product flavor uploads Unity SO files
 Scenario: Building a Unity product flavor uploads Unity SO files
     When I set environment variable "UNITY_ABI_SPLITS" to "true"
     When I run the script "features/scripts/build_unity_2018_abi_splits.sh" synchronously
-    And I wait to receive 2 requests
+    And I wait to receive 2 builds
 
     And 2 requests are valid for the android unity NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |


### PR DESCRIPTION
## Goal

- Updates Maze-runner to version 5, ensuring it can accept have any bug fixes or new features added when released, as well as being consistent with other repos
- Tidies up some of the request and environment logic
- Moves away from using unspecified payload queue steps to using type specific payload queue steps (requires https://github.com/bugsnag/maze-runner/pull/261 to be released)

## Todo:
- https://github.com/bugsnag/maze-runner/pull/261 needs to be released in next minor maze-runner version, with Gemfile moving back to targeting that release instead of a specific branch.