### PR TITLE
Use new MazeRunner /uploads endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
-gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', tag: 'v5.5.0'
+#gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', tag: 'v5.5.0'
 
+gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/uploads-endpoint'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
-#gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', tag: 'v5.5.0'
-
-gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/uploads-endpoint'
+gem "bugsnag-maze-runner", git: 'https://github.com/bugsnag/maze-runner', tag: 'v5.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: eea928bc06926bbe8e647c6981959c3c86807bd5
-  tag: v5.5.0
+  revision: 4f3d0a5818942abb6727a3fee4b2c4223f5705fa
+  branch: tms/uploads-endpoint
   specs:
-    bugsnag-maze-runner (5.5.0)
+    bugsnag-maze-runner (5.5.1)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -82,4 +82,4 @@ DEPENDENCIES
   bugsnag-maze-runner!
 
 BUNDLED WITH
-   2.1.4
+   2.2.20

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 4f3d0a5818942abb6727a3fee4b2c4223f5705fa
-  branch: tms/uploads-endpoint
+  revision: 626bbe9d8e72e46fc8cae757a032bea88b6e3829
+  tag: v5.6.0
   specs:
-    bugsnag-maze-runner (5.5.1)
+    bugsnag-maze-runner (5.6.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/features/abi_apk_splits.feature
+++ b/features/abi_apk_splits.feature
@@ -2,9 +2,10 @@ Feature: Plugin integrated in project with ABI APK splits
 
 Scenario: ABI Splits project builds successfully
     When I build "abi_splits" using the "standard" bugsnag config
-    And I wait to receive 16 builds
+    And I wait to receive 8 builds
+    And I wait to receive 8 uploads
 
-    Then 8 requests are valid for the build API and match the following:
+    Then 8 builds are valid for the build API and match the following:
       | appVersionCode | appVersion |
       | 1              | 1.0        |
       | 2              | 1.0        |
@@ -15,7 +16,7 @@ Scenario: ABI Splits project builds successfully
       | 7              | 1.0        |
       | 8              | 1.0        |
 
-    And 8 requests are valid for the android mapping API and match the following:
+    And 8 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                       |
       | 1           | 1.0         | com.bugsnag.android.example |
       | 2           | 1.0         | com.bugsnag.android.example |
@@ -26,7 +27,7 @@ Scenario: ABI Splits project builds successfully
       | 7           | 1.0         | com.bugsnag.android.example |
       | 8           | 1.0         | com.bugsnag.android.example |
 
-    And 8 requests have an R8 mapping file with the following symbols:
+    And 8 uploads have an R8 mapping file with the following symbols:
       | jvmSymbols |
       | com.Bar |
       | void doSomething() |
@@ -38,9 +39,9 @@ Scenario: ABI Splits automatic upload disabled
 
 Scenario: ABI Splits manual upload of build API
     When I build the "Armeabi-release" variantOutput for "abi_splits" using the "all_disabled" bugsnag config
-    And I wait to receive a build
-    Then the build request is valid for the Android Mapping API
-    And the build payload field "apiKey" equals "TEST_API_KEY"
-    And the build payload field "versionCode" equals "3"
-    And the build payload field "versionName" equals "1.0"
-    And the build payload field "appId" equals "com.bugsnag.android.example"
+    And I wait to receive an upload
+    Then the upload is valid for the Android Mapping API
+    And the upload payload field "apiKey" equals "TEST_API_KEY"
+    And the upload payload field "versionCode" equals "3"
+    And the upload payload field "versionName" equals "1.0"
+    And the upload payload field "appId" equals "com.bugsnag.android.example"

--- a/features/apk_splits_same_version.feature
+++ b/features/apk_splits_same_version.feature
@@ -2,12 +2,13 @@ Feature: Plugin integrated in project with APK splits
 
 Scenario: APK splits avoid uploading duplicate requests for same version information
     When I build "apk_splits" using the "standard" bugsnag config
-    And I wait to receive 2 builds
+    And I wait to receive a build
+    And I wait to receive an upload
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersionCode | appVersion |
       | 1              | 1.0        |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
       | buildUUID                 |
       | same-build-uuid           |

--- a/features/app_bundle.feature
+++ b/features/app_bundle.feature
@@ -2,44 +2,47 @@ Feature: Generating Android app bundles
 
 Scenario: Single-module default app bundles successfully
     When I bundle "default_app" using the "standard" bugsnag config
-    And I wait to receive 2 builds
+    And I wait to receive a build
+    And I wait to receive an upload
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      | sourceControl.provider | sourceControl.repository                                     |
       | 1              | 1.0        | gradle-android | github                 | https://github.com/bugsnag/bugsnag-android-gradle-plugin.git |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                       | overwrite |
       | 1           | 1.0         | com.bugsnag.android.example | null      |
 
-    And 1 requests have an R8 mapping file with the following symbols:
+    And 1 uploads have an R8 mapping file with the following symbols:
       | jvmSymbols |
       | com.Bar |
       | void doSomething() |
 
 Scenario: Bundling multiple flavors automatically
     When I bundle "flavors" using the "standard" bugsnag config
-    And I wait to receive 4 builds
+    And I wait to receive 2 builds
+    And I wait to receive 2 uploads
 
-    Then 2 requests are valid for the build API and match the following:
+    Then 2 builds are valid for the build API and match the following:
       | appVersion | appVersionCode |
       | 1.0        | 1              |
       | 1.0        | 1              |
 
-    And 2 requests are valid for the android mapping API and match the following:
+    And 2 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                           |
       | 1           | 1.0         | com.bugsnag.android.example.foo |
       | 1           | 1.0         | com.bugsnag.android.example.bar |
 
 Scenario: Bundling single flavor
     When I bundle the "Foo" variantOutput for "flavors" using the "standard" bugsnag config
-    And I wait to receive 2 builds
+    And I wait to receive a build
+    And I wait to receive an upload
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersion | appVersionCode |
       | 1.0        | 1              |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                           |
       | 1           | 1.0         | com.bugsnag.android.example.foo |
 
@@ -47,3 +50,4 @@ Scenario: Auto upload disabled
     When I bundle "default_app" using the "all_disabled" bugsnag config
     And I wait for 3 seconds
     Then I should receive no builds
+    And I should receive no uploads

--- a/features/default_app.feature
+++ b/features/default_app.feature
@@ -2,17 +2,18 @@ Feature: Plugin integrated in default app
 
 Scenario: Single-module default app builds successfully
     When I build "default_app" using the "standard" bugsnag config
-    And I wait to receive 2 builds
+    And I wait to receive a build
+    And I wait to receive an upload
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      | sourceControl.provider | sourceControl.repository                                     |
       | 1              | 1.0        | gradle-android | github                 | https://github.com/bugsnag/bugsnag-android-gradle-plugin.git |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                       | overwrite |
       | 1           | 1.0         | com.bugsnag.android.example | null      |
 
-    And 1 requests have an R8 mapping file with the following symbols:
+    And 1 uploads have an R8 mapping file with the following symbols:
       | jvmSymbols |
       | com.Bar |
       | void doSomething() |

--- a/features/density_abi_splits.feature
+++ b/features/density_abi_splits.feature
@@ -2,9 +2,10 @@ Feature: Plugin integrated in project with Density + ABI APK splits
 
 Scenario: Density ABI Splits project builds successfully
     When I build "density_abi_splits" using the "standard" bugsnag config
-    And I wait to receive 26 builds
+    And I wait to receive 13 builds
+    And I wait to receive 13 uploads
 
-    Then 13 requests are valid for the build API and match the following:
+    Then 13 builds are valid for the build API and match the following:
       | appVersionCode |
       | 11             |
       | 21             |
@@ -20,7 +21,7 @@ Scenario: Density ABI Splits project builds successfully
       | 43             |
       | 53             |
 
-    And 13 requests are valid for the android mapping API and match the following:
+    And 13 uploads are valid for the android mapping API and match the following:
       | versionCode |
       | 11          |
       | 21          |
@@ -43,6 +44,6 @@ Scenario: Density ABI Splits automatic upload disabled
 
 Scenario: Density ABI Splits manual upload of build API
     When I build the "XxxhdpiArmeabi-release" variantOutput for "density_abi_splits" using the "all_disabled" bugsnag config
-    And I wait to receive a build
-    Then the build request is valid for the Android Mapping API
-    And the build payload field "versionCode" equals "33"
+    And I wait to receive an upload
+    Then the upload is valid for the Android Mapping API
+    And the upload payload field "versionCode" equals "33"

--- a/features/density_splits.feature
+++ b/features/density_splits.feature
@@ -2,9 +2,10 @@ Feature: Plugin integrated in project with Density APK splits
 
 Scenario: Density Splits project builds successfully
     When I build "density_splits" using the "standard" bugsnag config
-    And I wait to receive 14 builds
+    And I wait to receive 7 builds
+    And I wait to receive 7 uploads
 
-    Then 7 requests are valid for the build API and match the following:
+    Then 7 builds are valid for the build API and match the following:
       | appVersionCode | appVersion |
       | 1              | 1.0        |
       | 2              | 1.0        |
@@ -14,7 +15,7 @@ Scenario: Density Splits project builds successfully
       | 6              | 1.0        |
       | 7              | 1.0        |
 
-    And 7 requests are valid for the android mapping API and match the following:
+    And 7 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName |
       | 1           | 1.0         |
       | 2           | 1.0         |
@@ -31,9 +32,9 @@ Scenario: Density Splits automatic upload disabled
 
 Scenario: Density Splits manual upload of build API
     When I build the "Hdpi-release" variantOutput for "density_splits" using the "all_disabled" bugsnag config
-    And I wait to receive a build
-    Then the build request is valid for the Android Mapping API
-    And the build payload field "apiKey" equals "TEST_API_KEY"
-    And the build payload field "versionCode" equals "4"
-    And the build payload field "versionName" equals "1.0"
-    And the build payload field "appId" equals "com.bugsnag.android.example"
+    And I wait to receive an upload
+    Then the upload is valid for the Android Mapping API
+    And the upload payload field "apiKey" equals "TEST_API_KEY"
+    And the upload payload field "versionCode" equals "4"
+    And the upload payload field "versionName" equals "1.0"
+    And the upload payload field "appId" equals "com.bugsnag.android.example"

--- a/features/disabled_product_flavor.feature
+++ b/features/disabled_product_flavor.feature
@@ -2,12 +2,13 @@ Feature: Disabling plugin for product flavors
 
 Scenario: Disabled product flavor makes no requests
     When I build "flavors" using the "disabled_product_flavor" bugsnag config
-    And I wait to receive 2 builds
+    And I wait to receive a build
+    And I wait to receive an upload
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersionCode | appVersion |
       | 1              | 1.0        |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                           |
       | 1           | 1.0         | com.bugsnag.android.example.bar |

--- a/features/extension_properties.feature
+++ b/features/extension_properties.feature
@@ -2,28 +2,29 @@ Feature: Extension properties control plugin behaviour
 
 Scenario: Disable autoReportBuilds
     When I build "default_app" using the "auto_report_builds_disabled" bugsnag config
-    And I wait to receive a build
-    Then the build request is valid for the Android Mapping API
+    And I wait to receive a upload
+    Then the upload is valid for the Android Mapping API
 
 Scenario: Enable debug mapping upload
     When I build "debug_proguard" using the "upload_debug_enabled" bugsnag config
-    And I wait to receive 4 builds
+    And I wait to receive 2 builds
+    And I wait to receive 2 uploads
 
-    Then 2 requests are valid for the build API and match the following:
+    Then 2 builds are valid for the build API and match the following:
       | appVersionCode |
       | 1              |
       | 1              |
 
-    And 2 requests are valid for the android mapping API and match the following:
+    And 2 uploads are valid for the android mapping API and match the following:
       | versionCode |
       | 1           |
       | 1           |
 
 Scenario: Enable overwrite
     When I build "default_app" using the "overwrite_enabled" bugsnag config
-    And I wait to receive a build
-    Then the build request is valid for the Android Mapping API
-    And the build payload field "overwrite" equals "true"
+    And I wait to receive an upload
+    Then the upload is valid for the Android Mapping API
+    And the upload payload field "overwrite" equals "true"
 
 Scenario: Alter build API values
     When I build "default_app" using the "custom_build_info" bugsnag config

--- a/features/fail_on_upload_error.feature
+++ b/features/fail_on_upload_error.feature
@@ -2,7 +2,8 @@ Feature: Build stops when mapping file upload fails
 
 Scenario: Upload successfully with API key, mapping file, and correct endpoint
     When I build "default_app" using the "standard" bugsnag config
-    And I wait to receive 2 builds
+    And I wait to receive a build
+    And I wait to receive an upload
 
 Scenario: No uploads or build failures when obfuscation is disabled
     When I build "disabled_obfuscation" using the "standard" bugsnag config

--- a/features/fixtures/config/bugsnag/all_disabled.gradle
+++ b/features/fixtures/config/bugsnag/all_disabled.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/builds"
+    endpoint = "http://localhost:9339/uploads"
     releasesEndpoint = "http://localhost:9339/builds"
     uploadJvmMappings = false
     reportBuilds = false

--- a/features/fixtures/config/bugsnag/auto_report_builds_disabled.gradle
+++ b/features/fixtures/config/bugsnag/auto_report_builds_disabled.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/builds"
+    endpoint = "http://localhost:9339/uploads"
     releasesEndpoint = "http://localhost:9339/builds"
     reportBuilds = false
 }

--- a/features/fixtures/config/bugsnag/custom_build_info.gradle
+++ b/features/fixtures/config/bugsnag/custom_build_info.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/builds"
+    endpoint = "http://localhost:9339/uploads"
     releasesEndpoint = "http://localhost:9339/builds"
     uploadJvmMappings = false
 

--- a/features/fixtures/config/bugsnag/disabled_bugsnag.gradle
+++ b/features/fixtures/config/bugsnag/disabled_bugsnag.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/builds"
+    endpoint = "http://localhost:9339/uploads"
     releasesEndpoint = "http://localhost:9339/builds"
     enabled = false
 }

--- a/features/fixtures/config/bugsnag/disabled_build_type.gradle
+++ b/features/fixtures/config/bugsnag/disabled_build_type.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/builds"
+    endpoint = "http://localhost:9339/uploads"
     releasesEndpoint = "http://localhost:9339/builds"
 
     // disable bugsnag plugin for 'release' buildType

--- a/features/fixtures/config/bugsnag/disabled_product_flavor.gradle
+++ b/features/fixtures/config/bugsnag/disabled_product_flavor.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/builds"
+    endpoint = "http://localhost:9339/uploads"
     releasesEndpoint = "http://localhost:9339/builds"
 
     // disable bugsnag plugin for 'foo' productFlavor

--- a/features/fixtures/config/bugsnag/empty_api_key.gradle
+++ b/features/fixtures/config/bugsnag/empty_api_key.gradle
@@ -9,6 +9,6 @@ android {
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/builds"
+    endpoint = "http://localhost:9339/uploads"
     releasesEndpoint = "http://localhost:9339/builds"
 }

--- a/features/fixtures/config/bugsnag/overwrite_enabled.gradle
+++ b/features/fixtures/config/bugsnag/overwrite_enabled.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/builds"
+    endpoint = "http://localhost:9339/uploads"
     releasesEndpoint = "http://localhost:9339/builds"
     reportBuilds = false
     overwrite = true

--- a/features/fixtures/config/bugsnag/standard.gradle
+++ b/features/fixtures/config/bugsnag/standard.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/builds"
+    endpoint = "http://localhost:9339/uploads"
     releasesEndpoint = "http://localhost:9339/builds"
 }

--- a/features/fixtures/config/bugsnag/upload_debug_enabled.gradle
+++ b/features/fixtures/config/bugsnag/upload_debug_enabled.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.bugsnag.android.gradle'
 
 bugsnag {
-    endpoint = "http://localhost:9339/builds"
+    endpoint = "http://localhost:9339/uploads"
     releasesEndpoint = "http://localhost:9339/builds"
     variantFilter {}
 }

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -68,7 +68,7 @@ if (!System.env.UPDATING_GRADLEW) {
 
     bugsnag {
         uploadNdkMappings = true
-        endpoint = "http://localhost:9339/builds"
+        endpoint = "http://localhost:9339/uploads"
         releasesEndpoint = "http://localhost:9339/builds"
 
         def customPath = System.env.PROJECT_ROOT

--- a/features/fixtures/rn-monorepo/abc/android/app/build.gradle
+++ b/features/fixtures/rn-monorepo/abc/android/app/build.gradle
@@ -227,7 +227,7 @@ if (!System.env.UPDATING_GRADLEW) {
     bugsnag {
         uploadReactNativeMappings = true
         nodeModulesDir = project.layout.projectDirectory.dir("../../../node_modules/").asFile
-        endpoint = "http://localhost:9339/builds"
+        endpoint = "http://localhost:9339/uploads"
         releasesEndpoint = "http://localhost:9339/builds"
     }
 }

--- a/features/fixtures/rn060/android/app/build.gradle
+++ b/features/fixtures/rn060/android/app/build.gradle
@@ -226,7 +226,7 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339/builds"
+        endpoint = "http://localhost:9339/uploads"
         releasesEndpoint = "http://localhost:9339/builds"
         uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 

--- a/features/fixtures/rn061/android/app/build.gradle
+++ b/features/fixtures/rn061/android/app/build.gradle
@@ -217,7 +217,7 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339/builds"
+        endpoint = "http://localhost:9339/uploads"
         releasesEndpoint = "http://localhost:9339/builds"
         uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 

--- a/features/fixtures/rn062/android/app/build.gradle
+++ b/features/fixtures/rn062/android/app/build.gradle
@@ -241,7 +241,7 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339/builds"
+        endpoint = "http://localhost:9339/uploads"
         releasesEndpoint = "http://localhost:9339/builds"
         uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 

--- a/features/fixtures/rn063/android/app/build.gradle
+++ b/features/fixtures/rn063/android/app/build.gradle
@@ -235,7 +235,7 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339/builds"
+        endpoint = "http://localhost:9339/uploads"
         releasesEndpoint = "http://localhost:9339/builds"
         uploadReactNativeMappings = "false" != System.env.UPLOAD_RN_MAPPINGS
 

--- a/features/fixtures/unity_2018/example/build.gradle
+++ b/features/fixtures/unity_2018/example/build.gradle
@@ -137,7 +137,7 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339/builds"
+        endpoint = "http://localhost:9339/uploads"
         releasesEndpoint = "http://localhost:9339/builds"
     }
 }

--- a/features/fixtures/unity_2019/launcher/build.gradle
+++ b/features/fixtures/unity_2019/launcher/build.gradle
@@ -73,7 +73,7 @@ if (!System.env.UPDATING_GRADLEW) {
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
-        endpoint = "http://localhost:9339/builds"
+        endpoint = "http://localhost:9339/uploads"
         releasesEndpoint = "http://localhost:9339/builds"
 
         if ("false" == System.env.UNITY_SO_UPLOAD) {

--- a/features/flavor_apk_splits.feature
+++ b/features/flavor_apk_splits.feature
@@ -2,9 +2,10 @@ Feature: Plugin integrated in project with Density APK splits and productFlavors
 
 Scenario: Flavor Density Split project builds successfully
     When I build "flavor_apk_splits" using the "standard" bugsnag config
-    And I wait to receive 12 builds
+    And I wait to receive 6 builds
+    And I wait to receive 6 uploads
 
-    Then 6 requests are valid for the build API and match the following:
+    Then 6 builds are valid for the build API and match the following:
       | appVersionCode |
       | 1              |
       | 2              |
@@ -13,7 +14,7 @@ Scenario: Flavor Density Split project builds successfully
       | 2              |
       | 3              |
 
-    And 6 requests are valid for the android mapping API and match the following:
+    And 6 uploads are valid for the android mapping API and match the following:
       | versionCode | appId                           |
       | 1           | com.bugsnag.android.example.bar |
       | 2           | com.bugsnag.android.example.bar |
@@ -29,9 +30,9 @@ Scenario: Flavor Density Split automatic upload disabled
 
 Scenario: Flavor Density Split manual upload of build API
     When I build the "Bar-xxhdpi-release" variantOutput for "flavor_apk_splits" using the "all_disabled" bugsnag config
-    And I wait to receive a build
-    Then the build request is valid for the Android Mapping API
-    And the build payload field "apiKey" equals "TEST_API_KEY"
-    And the build payload field "versionCode" equals "3"
-    And the build payload field "versionName" equals "1.0"
-    And the build payload field "appId" equals "com.bugsnag.android.example.bar"
+    And I wait to receive an upload
+    Then the upload is valid for the Android Mapping API
+    And the upload payload field "apiKey" equals "TEST_API_KEY"
+    And the upload payload field "versionCode" equals "3"
+    And the upload payload field "versionName" equals "1.0"
+    And the upload payload field "appId" equals "com.bugsnag.android.example.bar"

--- a/features/flavors.feature
+++ b/features/flavors.feature
@@ -2,19 +2,20 @@ Feature: Plugin integrated in project with productFlavors
 
 Scenario: Flavors automatic upload on build
     When I build "flavors" using the "standard" bugsnag config
-    And I wait to receive 4 builds
+    And I wait to receive 2 builds
+    And I wait to receive 2 uploads
 
-    Then 2 requests are valid for the build API and match the following:
+    Then 2 builds are valid for the build API and match the following:
       | appVersionCode | appVersion |
       | 1              | 1.0        |
       | 1              | 1.0        |
 
-    And 2 requests are valid for the android mapping API and match the following:
+    And 2 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                           |
       | 1           | 1.0         | com.bugsnag.android.example.bar |
       | 1           | 1.0         | com.bugsnag.android.example.foo |
 
-    And 2 requests have an R8 mapping file with the following symbols:
+    And 2 uploads have an R8 mapping file with the following symbols:
       | jvmSymbols |
       | com.Bar |
       | void doSomething() |
@@ -26,9 +27,9 @@ Scenario: Flavors automatic upload disabled
 
 Scenario: Flavors manual upload of build API
     When I build the "Foo-release" variantOutput for "flavors" using the "all_disabled" bugsnag config
-    And I wait to receive 1 build
-    Then the build request is valid for the Android Mapping API
-    And the build payload field "apiKey" equals "TEST_API_KEY"
-    And the build payload field "versionCode" equals "1"
-    And the build payload field "versionName" equals "1.0"
-    And the build payload field "appId" equals "com.bugsnag.android.example.foo"
+    And I wait to receive an upload
+    Then the upload is valid for the Android Mapping API
+    And the upload payload field "apiKey" equals "TEST_API_KEY"
+    And the upload payload field "versionCode" equals "1"
+    And the upload payload field "versionName" equals "1.0"
+    And the upload payload field "appId" equals "com.bugsnag.android.example.foo"

--- a/features/manual_build_uuid.feature
+++ b/features/manual_build_uuid.feature
@@ -2,12 +2,13 @@ Feature: Auto update build UUID flag
 
 Scenario: Build UUID excluded from request when set to false
     When I build "manual_build_uuid" using the "standard" bugsnag config
-    And I wait to receive 2 builds
+    And I wait to receive a build
+    And I wait to receive an upload
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      | sourceControl.provider | sourceControl.repository                                     |
       | 1              | 1.0        | gradle-android | github                 | https://github.com/bugsnag/bugsnag-android-gradle-plugin.git |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                       | overwrite | buildUUID       |
       | 1           | 1.0         | com.bugsnag.android.example | null      | same-build-uuid |

--- a/features/manual_upload.feature
+++ b/features/manual_upload.feature
@@ -3,12 +3,13 @@ Feature: Manual invocation of upload task
 Scenario: Manually invoking upload task sends requests
     When I build "default_app" using the "all_disabled" bugsnag config
     And I run the script "features/scripts/manual_upload.sh" synchronously
-    And I wait to receive 2 builds
+    And I wait to receive a build
+    And I wait to receive an upload
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersionCode |
       | 1              |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
       | versionCode |
       | 1           |

--- a/features/ndk_app_agp400.feature
+++ b/features/ndk_app_agp400.feature
@@ -6,13 +6,14 @@ Feature: Plugin integrated in NDK app
 @requires_agp4_0_or_higher
 Scenario: NDK apps send requests
     When I build the NDK app
-    And I wait to receive 10 builds
+    And I wait to receive a build
+    And I wait to receive 9 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
       | 1              | 1.0        | gradle-android |
 
-    And 8 requests are valid for the android NDK mapping API and match the following:
+    And 8 uploads are valid for the android NDK mapping API and match the following:
       | arch        | projectRoot | sharedObjectName |
       | arm64-v8a   | /\S+/       | liblog.so        |
       | arm64-v8a   | /\S+/       | libnative-lib.so |
@@ -23,11 +24,11 @@ Scenario: NDK apps send requests
       | x86_64      | /\S+/       | liblog.so        |
       | x86_64      | /\S+/       | libnative-lib.so |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
       | appId                      |
       | com.bugsnag.android.ndkapp |
 
-    And 1 requests have an R8 mapping file with the following symbols:
+    And 1 uploads have an R8 mapping file with the following symbols:
       | jvmSymbols |
       | com.bugsnag.android.ndkapp.MainActivity |
 
@@ -35,13 +36,14 @@ Scenario: NDK apps send requests
 Scenario: Custom projectRoot is added to payload
     When I set environment variable "PROJECT_ROOT" to "/repos/custom/my-app"
     And I build the NDK app
-    And I wait to receive 10 builds
+    And I wait to receive a build
+    And I wait to receive 9 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
       | 1              | 1.0        | gradle-android |
 
-    And 8 requests are valid for the android NDK mapping API and match the following:
+    And 8 uploads are valid for the android NDK mapping API and match the following:
       | arch        | projectRoot          |
       | arm64-v8a   | /repos/custom/my-app |
       | armeabi-v7a | /repos/custom/my-app |
@@ -52,7 +54,7 @@ Scenario: Custom projectRoot is added to payload
       | x86         | /repos/custom/my-app |
       | x86_64      | /repos/custom/my-app |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | appId                      |
         | com.bugsnag.android.ndkapp |
 
@@ -61,20 +63,21 @@ Scenario: Custom projectRoot is added to payload
 Scenario: Custom objdump location
     When I set environment variable "OBJDUMP_LOCATION" to "/fake/objdump"
     And I build the NDK app
-    And I wait to receive 6 builds
+    And I wait to receive a build
+    And I wait to receive 5 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
       | 1              | 1.0        | gradle-android |
 
-    And 4 requests are valid for the android NDK mapping API and match the following:
+    And 4 uploads are valid for the android NDK mapping API and match the following:
       | arch           |
       | armeabi-v7a    |
       | armeabi-v7a    |
       | x86_64         |
       | x86_64         |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | appId                      |
         | com.bugsnag.android.ndkapp |
 
@@ -82,13 +85,14 @@ Scenario: Custom objdump location
 Scenario: Mapping files uploaded for custom sharedObjectPaths
     When I set environment variable "USE_SHARED_OBJECT_PATH" to "true"
     When I build the NDK app
-    And I wait to receive 14 builds
+    And I wait to receive a build
+    And I wait to receive 13 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
         | 1              | 1.0        | gradle-android |
 
-    And 12 requests are valid for the android NDK mapping API and match the following:
+    And 12 uploads are valid for the android NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
         | arm64-v8a   | /\S+/       | liblog.so        |
         | arm64-v8a   | /\S+/       | libnative-lib.so |
@@ -103,6 +107,6 @@ Scenario: Mapping files uploaded for custom sharedObjectPaths
         | x86_64      | /\S+/       | libnative-lib.so |
         | x86_64      | /\S+/       | libmonochrome.so |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | appId                      |
         | com.bugsnag.android.ndkapp |

--- a/features/ndk_app_legacy.feature
+++ b/features/ndk_app_legacy.feature
@@ -4,24 +4,25 @@ Feature: Plugin integrated in NDK app
 @skip_agp3_4_0
 Scenario: NDK apps send requests
     When I build the NDK app
-    And I wait to receive 6 builds
+    And I wait to receive a build
+    And I wait to receive 5 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
         | 1              | 1.0        | gradle-android |
 
-    And 4 requests are valid for the android NDK mapping API and match the following:
+    And 4 uploads are valid for the android NDK mapping API and match the following:
         | arch        | sharedObjectName |
         | arm64-v8a   | libnative-lib.so |
         | armeabi-v7a | libnative-lib.so |
         | x86         | libnative-lib.so |
         | x86_64      | libnative-lib.so |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | appId                      |
         | com.bugsnag.android.ndkapp |
 
-    And 1 requests have an R8 mapping file with the following symbols:
+    And 1 uploads have an R8 mapping file with the following symbols:
         | jvmSymbols |
         | com.bugsnag.android.ndkapp.MainActivity |
         | java.lang.String doSomething() |
@@ -31,20 +32,21 @@ Scenario: NDK apps send requests
 Scenario: Custom projectRoot is added to payload
     When I set environment variable "PROJECT_ROOT" to "/repos/custom/my-app"
     And I build the NDK app
-    And I wait to receive 6 builds
+    And I wait to receive a build
+    And I wait to receive 5 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
         | 1              | 1.0        | gradle-android |
 
-    And 4 requests are valid for the android NDK mapping API and match the following:
+    And 4 uploads are valid for the android NDK mapping API and match the following:
         | arch        | projectRoot          |
         | arm64-v8a   | /repos/custom/my-app |
         | armeabi-v7a | /repos/custom/my-app |
         | x86         | /repos/custom/my-app |
         | x86_64      | /repos/custom/my-app |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | appId                      |
         | com.bugsnag.android.ndkapp |
 
@@ -54,18 +56,19 @@ Scenario: Custom projectRoot is added to payload
 Scenario: Custom objdump location
     When I set environment variable "OBJDUMP_LOCATION" to "/fake/objdump"
     And I build the NDK app
-    And I wait to receive 4 builds
+    And I wait to receive a build
+    And I wait to receive 3 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
         | 1              | 1.0        | gradle-android |
 
-    And 2 requests are valid for the android NDK mapping API and match the following:
+    And 2 uploads are valid for the android NDK mapping API and match the following:
         | arch           |
         | armeabi-v7a    |
         | x86_64         |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | appId                      |
         | com.bugsnag.android.ndkapp |
 
@@ -74,13 +77,14 @@ Scenario: Custom objdump location
 Scenario: Mapping files uploaded for custom sharedObjectPaths
     When I set environment variable "USE_SHARED_OBJECT_PATH" to "true"
     When I build the NDK app
-    And I wait to receive 10 builds
+    And I wait to receive a build
+    And I wait to receive 9 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
         | 1              | 1.0        | gradle-android |
 
-    And 8 requests are valid for the android NDK mapping API and match the following:
+    And 8 uploads are valid for the android NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
         | arm64-v8a   | /\S+/       | libnative-lib.so |
         | arm64-v8a   | /\S+/       | libmonochrome.so |
@@ -91,6 +95,6 @@ Scenario: Mapping files uploaded for custom sharedObjectPaths
         | x86_64      | /\S+/       | libnative-lib.so |
         | x86_64      | /\S+/       | libmonochrome.so |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | appId                      |
         | com.bugsnag.android.ndkapp |

--- a/features/proxy.feature
+++ b/features/proxy.feature
@@ -6,14 +6,16 @@ Scenario: Basic HTTP proxy
     When I start an http proxy
     And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
     And I build "default_app" using the "standard" bugsnag config
-    And I wait to receive 2 builds
+    And I wait to receive a build
+    And I wait to receive an upload
+
     Then the proxy handled a request for "localhost:9339"
 
-    And 1 requests are valid for the build API and match the following:
+    And 1 builds are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      | sourceControl.provider | sourceControl.repository                                     |
       | 1              | 1.0        | gradle-android | github                 | https://github.com/bugsnag/bugsnag-android-gradle-plugin.git |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                       | overwrite |
       | 1           | 1.0         | com.bugsnag.android.example | null      |
 
@@ -21,14 +23,16 @@ Scenario: Authenticated HTTP proxy with creds
     When I start an authenticated http proxy
     And I set the fixture JVM arguments to "-Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=9000 -Dhttp.proxyUser=user -Dhttp.proxyPassword=password -Dhttp.nonProxyHosts="
     And I build "default_app" using the "standard" bugsnag config
-    And I wait to receive 2 builds
+    And I wait to receive a build
+    And I wait to receive an upload
+
     Then the proxy handled a request for "localhost:9339"
 
-    And 1 requests are valid for the build API and match the following:
+    And 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      | sourceControl.provider | sourceControl.repository                                     |
         | 1              | 1.0        | gradle-android | github                 | https://github.com/bugsnag/bugsnag-android-gradle-plugin.git |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | versionCode | versionName | appId                       | overwrite |
         | 1           | 1.0         | com.bugsnag.android.example | null      |
 
@@ -45,20 +49,21 @@ Scenario: NDK request for basic HTTP proxy AGP < 4
     When I start an http proxy
     And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
     When I build the NDK app
-    And I wait to receive 6 builds
+    And I wait to receive a build
+    And I wait to receive 5 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
         | 1              | 1.0        | gradle-android |
 
-    And 4 requests are valid for the android NDK mapping API and match the following:
+    And 4 uploads are valid for the android NDK mapping API and match the following:
         | arch        |
         | arm64-v8a   |
         | armeabi-v7a |
         | x86         |
         | x86_64      |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | appId                      |
         | com.bugsnag.android.ndkapp |
 
@@ -67,13 +72,14 @@ Scenario: NDK request for basic HTTP proxy AGP >= 4
     When I start an http proxy
     And I set the fixture JVM arguments to "-Dhttp.proxyHost=localhost -Dhttp.proxyPort=9000 -Dhttp.nonProxyHosts="
     When I build the NDK app
-    And I wait to receive 10 builds
+    And I wait to receive a build
+    And I wait to receive 9 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
         | 1              | 1.0        | gradle-android |
 
-    And 8 requests are valid for the android NDK mapping API and match the following:
+    And 8 uploads are valid for the android NDK mapping API and match the following:
         | arch        |
         | arm64-v8a   |
         | arm64-v8a   |
@@ -84,6 +90,6 @@ Scenario: NDK request for basic HTTP proxy AGP >= 4
         | x86_64      |
         | x86_64      |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | appId                      |
         | com.bugsnag.android.ndkapp |

--- a/features/react_native.feature
+++ b/features/react_native.feature
@@ -4,17 +4,18 @@ Feature: Plugin integrated in React Native app
 @skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when assembling an app with the default project structure
     When I build the React Native app
-    And I wait to receive 3 builds
+    And I wait to receive a build
+    And I wait to receive 2 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
       | 5              | 2.45.beta  | gradle-android |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                     |
       | 5           | 2.45.beta  | com.bugsnag.android.rnapp |
 
-    And 1 requests are valid for the JS source map API and match the following:
+    And 1 uploads are valid for the JS source map API and match the following:
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
 
@@ -22,17 +23,18 @@ Scenario: Source maps are uploaded when assembling an app with the default proje
 @skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when bundling an app with the default project structure
     And I run the script "features/scripts/bundle_react_native_app.sh" synchronously
-    And I wait to receive 3 builds
+    And I wait to receive a build
+    And I wait to receive 2 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
         | 5              | 2.45.beta  | gradle-android |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | versionCode | versionName | appId                     |
         | 5           | 2.45.beta  | com.bugsnag.android.rnapp |
 
-    And 1 requests are valid for the JS source map API and match the following:
+    And 1 uploads are valid for the JS source map API and match the following:
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
 
@@ -41,19 +43,20 @@ Scenario: Source maps are uploaded when bundling an app with the default project
 Scenario: Source maps are uploaded when assembling an app which uses productFlavors
     When I set environment variable "USE_RN_FLAVORS" to "true"
     When I build the React Native app
-    And I wait to receive 6 builds
+    And I wait to receive 2 builds
+    And I wait to receive 4 uploads
 
-    Then 2 requests are valid for the build API and match the following:
+    Then 2 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
         | 5              | 2.45.beta  | gradle-android |
         | 5              | 2.45.beta  | gradle-android |
 
-    And 2 requests are valid for the android mapping API and match the following:
+    And 2 uploads are valid for the android mapping API and match the following:
         | versionCode | versionName | appId                         |
         | 5           | 2.45.beta  | com.bugsnag.android.rnapp.foo |
         | 5           | 2.45.beta  | com.bugsnag.android.rnapp.bar |
 
-    And 2 requests are valid for the JS source map API and match the following:
+    And 2 uploads are valid for the JS source map API and match the following:
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
         | 5              | 2.45.beta  | false     | false |
@@ -62,17 +65,18 @@ Scenario: Source maps are uploaded when assembling an app which uses productFlav
 @skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when assembling an app within a monorepo
     When I run the script "features/scripts/build_react_native_monorepo_app.sh" synchronously
-    And I wait to receive 3 builds
+    And I wait to receive a build
+    And I wait to receive 2 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
       | 5              | 2.45.beta  | gradle-android |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                     |
       | 5           | 2.45.beta   | com.bugsnag.android.rnapp |
 
-    And 1 requests are valid for the JS source map API and match the following:
+    And 1 uploads are valid for the JS source map API and match the following:
       | appVersionCode | appVersion | overwrite | dev   |
       | 5              | 2.45.beta  | true      | false |
 
@@ -81,13 +85,14 @@ Scenario: Source maps are uploaded when assembling an app within a monorepo
 Scenario: Setting uploadReactNativeMappings to false will prevent any source map upload
     When I set environment variable "UPLOAD_RN_MAPPINGS" to "false"
     When I build the React Native app
-    And I wait to receive 2 builds
+    And I wait to receive a build
+    And I wait to receive an upload
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
         | 5              | 2.45.beta  | gradle-android |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | versionCode | versionName | appId                     |
         | 5           | 2.45.beta  | com.bugsnag.android.rnapp |
 
@@ -95,8 +100,8 @@ Scenario: Setting uploadReactNativeMappings to false will prevent any source map
 @skip_gradle_7_or_higher
 Scenario: Manually invoking source map upload task
     And I run the script "features/scripts/manual_upload_react_native.sh" synchronously
-    And I wait to receive 1 build
-    And 1 requests are valid for the JS source map API and match the following:
+    And I wait to receive an upload
+    And 1 uploads are valid for the JS source map API and match the following:
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
 
@@ -107,17 +112,18 @@ Scenario: Manually invoking source map upload task
 Scenario: Source maps are uploaded in an app using Hermes
     When I set environment variable "RN_ENABLE_HERMES" to "true"
     When I build the React Native app
-    And I wait to receive 3 builds
+    And I wait to receive 1 build
+    And I wait to receive 2 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
         | 5              | 2.45.beta  | gradle-android |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | versionCode | versionName | appId                     |
         | 5           | 2.45.beta  | com.bugsnag.android.rnapp |
 
-    And 1 requests are valid for the JS source map API and match the following:
+    And 1 uploads are valid for the JS source map API and match the following:
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
 
@@ -126,8 +132,9 @@ Scenario: Source maps are uploaded in an app using Hermes
 Scenario: Plugin handles server failure gracefully
     When I set the HTTP status code to 500
     And I run the script "features/scripts/manual_upload_react_native.sh" synchronously
-    And I wait to receive 5 builds
-    And 5 requests are valid for the JS source map API and match the following:
+    And I wait to receive 5 uploads
+
+    Then 5 uploads are valid for the JS source map API and match the following:
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
         | 5              | 2.45.beta  | false     | false |
@@ -140,16 +147,17 @@ Scenario: Plugin handles server failure gracefully
 Scenario: Source maps are uploaded when assembling an app with a custom nodeModulesDir
     When I set environment variable "CUSTOM_NODE_MODULES_DIR" to "true"
     When I build the React Native app
-    And I wait to receive 3 builds
+    And I wait to receive a build
+    And I wait to receive 2 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
       | 5              | 2.45.beta  | gradle-android |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName | appId                     |
       | 5              | 2.45.beta  | com.bugsnag.android.rnapp |
 
-    And 1 requests are valid for the JS source map API and match the following:
+    And 1 uploads are valid for the JS source map API and match the following:
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -58,8 +58,8 @@ When('I set the fixture JVM arguments to {string}') do |jvm_args|
   )
 end
 
-Then('{int} requests are valid for the build API and match the following:') do |request_count, data_table|
-  requests = get_requests_with_field('build', 'builderName')
+Then('{int} builds are valid for the build API and match the following:') do |request_count, data_table|
+  requests = get_requests_with_field('builds', 'builderName')
   assert_equal(request_count, requests.length, 'Wrong number of build API requests')
   Maze::Assertions::RequestSetAssertions.assert_requests_match requests, data_table
 
@@ -68,8 +68,8 @@ Then('{int} requests are valid for the build API and match the following:') do |
   end
 end
 
-Then('{int} requests are valid for the android mapping API and match the following:') do |request_count, data_table|
-  requests = get_requests_with_field('build', 'proguard')
+Then('{int} uploads are valid for the android mapping API and match the following:') do |request_count, data_table|
+  requests = get_requests_with_field('uploads', 'proguard')
   assert_equal(request_count, requests.length, 'Wrong number of mapping API requests')
   Maze::Assertions::RequestSetAssertions.assert_requests_match requests, data_table
 
@@ -78,8 +78,8 @@ Then('{int} requests are valid for the android mapping API and match the followi
   end
 end
 
-Then('{int} requests are valid for the android NDK mapping API and match the following:') do |request_count, data_table|
-  requests = get_requests_with_field('build', 'soSymbolFile')
+Then('{int} uploads are valid for the android NDK mapping API and match the following:') do |request_count, data_table|
+  requests = get_requests_with_field('uploads', 'soSymbolFile')
   assert_equal(request_count, requests.length, 'Wrong number of NDK mapping API requests')
   Maze::Assertions::RequestSetAssertions.assert_requests_match requests, data_table
 
@@ -88,8 +88,8 @@ Then('{int} requests are valid for the android NDK mapping API and match the fol
   end
 end
 
-Then('{int} requests are valid for the android unity NDK mapping API and match the following:') do |request_count, data_table|
-  requests = get_requests_with_field('build', 'soSymbolTableFile')
+Then('{int} uploads are valid for the android unity NDK mapping API and match the following:') do |request_count, data_table|
+  requests = get_requests_with_field('uploads', 'soSymbolTableFile')
   assert_equal(request_count, requests.length, 'Wrong number of android unity NDK mapping API requests')
   Maze::Assertions::RequestSetAssertions.assert_requests_match requests, data_table
 
@@ -98,8 +98,8 @@ Then('{int} requests are valid for the android unity NDK mapping API and match t
   end
 end
 
-Then('{int} requests are valid for the JS source map API and match the following:') do |request_count, data_table|
-  requests = get_requests_with_field('build', 'sourceMap')
+Then('{int} uploads are valid for the JS source map API and match the following:') do |request_count, data_table|
+  requests = get_requests_with_field('uploads', 'sourceMap')
   assert_equal(request_count, requests.length, 'Wrong number of JS source map API requests')
   Maze::Assertions::RequestSetAssertions.assert_requests_match requests, data_table
 
@@ -108,8 +108,8 @@ Then('{int} requests are valid for the JS source map API and match the following
   end
 end
 
-Then('{int} requests have an R8 mapping file with the following symbols:') do |request_count, data_table|
-  requests = get_requests_with_field('build', 'proguard')
+Then('{int} uploads have an R8 mapping file with the following symbols:') do |request_count, data_table|
+  requests = get_requests_with_field('uploads', 'proguard')
   assert_equal(request_count, requests.length, 'Wrong number of mapping API requests')
 
   # inflate gzipped proguard mapping file & verify contents
@@ -122,14 +122,14 @@ Then('{int} requests have an R8 mapping file with the following symbols:') do |r
   end
 end
 
-Then('the build request is valid for the Android Mapping API') do
+Then('the upload is valid for the Android Mapping API') do
   steps %(
-    And the build payload field "apiKey" equals "#{$api_key}"
-    And the build payload field "proguard" is not null
-    And the build payload field "appId" is not null
-    And the build payload field "versionCode" is not null
-    And the build payload field "buildUUID" is not null
-    And the build payload field "versionName" is not null
+    And the upload payload field "apiKey" equals "#{$api_key}"
+    And the upload payload field "proguard" is not null
+    And the upload payload field "appId" is not null
+    And the upload payload field "versionCode" is not null
+    And the upload payload field "buildUUID" is not null
+    And the upload payload field "versionName" is not null
   )
 end
 

--- a/features/unity.feature
+++ b/features/unity.feature
@@ -65,7 +65,7 @@ Scenario: Shared object files not uploaded when uploadNdkUnityLibraryMappings se
 Scenario: Bundling a Unity project uploads JVM/release/Unity information
     When I run the script "features/scripts/bundle_unity_2019.sh" synchronously
     And I wait to receive a build
-    And I wait to receive 2 uploads
+    And I wait to receive 4 uploads
 
     Then 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |

--- a/features/unity.feature
+++ b/features/unity.feature
@@ -2,22 +2,23 @@ Feature: Exported Unity project uploads mapping files
 
 Scenario: Unity 2018 exported gradle project uploads JVM/release/Unity information
     When I run the script "features/scripts/build_unity_2018.sh" synchronously
-    And I wait to receive 8 builds
+    And I wait to receive a build
+    And I wait to receive 7 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
       | 1              | 1.0        | gradle-android |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName | appId               |
       | 1           | 1.0         | com.bugsnag.example |
 
-    And 2 requests are valid for the android NDK mapping API and match the following:
+    And 2 uploads are valid for the android NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
         | armeabi-v7a | /\S+/       | libmonochrome.so |
         | x86         | /\S+/       | libmonochrome.so |
 
-    And 4 requests are valid for the android unity NDK mapping API and match the following:
+    And 4 uploads are valid for the android unity NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
         | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
         | armeabi-v7a | /\S+/       | libunity.sym.so  |
@@ -26,22 +27,23 @@ Scenario: Unity 2018 exported gradle project uploads JVM/release/Unity informati
 
 Scenario: Unity 2019 exported gradle project uploads JVM/release/Unity information
     When I run the script "features/scripts/build_unity_2019.sh" synchronously
-    And I wait to receive 5 builds
+    And I wait to receive a build
+    And I wait to receive 4 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
       | appVersionCode | appVersion | buildTool      |
       | 1              | 1.0        | gradle-android |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
       | versionCode | versionName | appId               |
       | 1           | 1.0         | com.bugsnag.example |
 
-    And 1 requests are valid for the android NDK mapping API and match the following:
+    And 1 uploads are valid for the android NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
         | armeabi-v7a | /\S+/       | libmonochrome.so |
 
     # Unity 2019 doesn't contain symbols for x86
-    And 2 requests are valid for the android unity NDK mapping API and match the following:
+    And 2 uploads are valid for the android unity NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
         | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
         | armeabi-v7a | /\S+/       | libunity.sym.so  |
@@ -49,34 +51,36 @@ Scenario: Unity 2019 exported gradle project uploads JVM/release/Unity informati
 Scenario: Shared object files not uploaded when uploadNdkUnityLibraryMappings set to false
     When I set environment variable "UNITY_SO_UPLOAD" to "false"
     And I run the script "features/scripts/build_unity_2019.sh" synchronously
-    And I wait to receive 2 builds
+    And I wait to receive a build
+    And I wait to receive an upload
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
         | 1              | 1.0        | gradle-android |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | versionCode | versionName | appId               |
         | 1           | 1.0         | com.bugsnag.example |
 
 Scenario: Bundling a Unity project uploads JVM/release/Unity information
     When I run the script "features/scripts/bundle_unity_2019.sh" synchronously
-    And I wait to receive 5 builds
+    And I wait to receive a build
+    And I wait to receive 2 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
         | 1              | 1.0        | gradle-android |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | versionCode | versionName | appId               |
         | 1           | 1.0         | com.bugsnag.example |
 
-    And 1 requests are valid for the android NDK mapping API and match the following:
+    And 1 uploads are valid for the android NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
         | armeabi-v7a | /\S+/       | libmonochrome.so |
 
 # Unity 2019 doesn't contain symbols for x86
-    And 2 requests are valid for the android unity NDK mapping API and match the following:
+    And 2 uploads are valid for the android unity NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
         | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
         | armeabi-v7a | /\S+/       | libunity.sym.so  |
@@ -84,22 +88,23 @@ Scenario: Bundling a Unity project uploads JVM/release/Unity information
 Scenario: Building a Unity product flavor uploads Unity SO files
     When I set environment variable "UNITY_FLAVORS" to "true"
     When I run the script "features/scripts/build_unity_2018_flavors.sh" synchronously
-    And I wait to receive 8 builds
+    And I wait to receive a build
+    And I wait to receive 7 uploads
 
-    Then 1 requests are valid for the build API and match the following:
+    Then 1 builds are valid for the build API and match the following:
         | appVersionCode | appVersion | buildTool      |
         | 1              | 1.0        | gradle-android |
 
-    And 1 requests are valid for the android mapping API and match the following:
+    And 1 uploads are valid for the android mapping API and match the following:
         | versionCode | versionName | appId               |
         | 1           | 1.0         | com.bugsnag.example |
 
-    And 2 requests are valid for the android NDK mapping API and match the following:
+    And 2 uploads are valid for the android NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
         | armeabi-v7a | /\S+/       | libmonochrome.so |
         | x86         | /\S+/       | libmonochrome.so |
 
-    And 4 requests are valid for the android unity NDK mapping API and match the following:
+    And 4 uploads are valid for the android unity NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
         | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
         | armeabi-v7a | /\S+/       | libunity.sym.so  |
@@ -109,9 +114,9 @@ Scenario: Building a Unity product flavor uploads Unity SO files
 Scenario: Building a Unity product flavor uploads Unity SO files
     When I set environment variable "UNITY_ABI_SPLITS" to "true"
     When I run the script "features/scripts/build_unity_2018_abi_splits.sh" synchronously
-    And I wait to receive 2 builds
+    And I wait to receive 2 uploads
 
-    And 2 requests are valid for the android unity NDK mapping API and match the following:
+    And 2 uploads are valid for the android unity NDK mapping API and match the following:
         | arch        | projectRoot | sharedObjectName |
         | armeabi-v7a | /\S+/       | libil2cpp.sym.so |
         | armeabi-v7a | /\S+/       | libunity.sym.so  |


### PR DESCRIPTION
## Goal

Updates the e2e test configuration and scenarios to use the newly introduced "/uploads" endpoint (which is logically distinct from "/builds").

## Testing

Covered by CI.