### PR TITLE
Address task dependency warning when using APK splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Address task dependency warning when using APK splits
+  [#407](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/407)
+
 ## 7.0.0-beta01 (2021-06-23)
 
 Support for Android Gradle Plugin 7.0.0-beta04 added. This version introduces no new features and

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.ApkVariantOutput
-import com.bugsnag.android.gradle.internal.NDK_SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.clearDir
 import com.bugsnag.android.gradle.internal.includesAbi
 import com.bugsnag.android.gradle.internal.mapProperty
@@ -11,7 +10,6 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
@@ -33,8 +31,7 @@ import javax.inject.Inject
  * Task that generates NDK shared object mapping files for upload to Bugsnag.
  */
 open class BugsnagGenerateNdkSoMappingTask @Inject constructor(
-    objects: ObjectFactory,
-    projectLayout: ProjectLayout
+    objects: ObjectFactory
 ) : DefaultTask(), AndroidManifestInfoReceiver {
 
     init {
@@ -55,7 +52,6 @@ open class BugsnagGenerateNdkSoMappingTask @Inject constructor(
 
     @get:OutputDirectory
     val intermediateOutputDir: DirectoryProperty = objects.directoryProperty()
-        .convention(projectLayout.buildDirectory.dir(NDK_SO_MAPPING_DIR))
 
     @get:Input
     val objDumpPaths: MapProperty<String, String> = objects.mapProperty()

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
@@ -1,8 +1,6 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.ApkVariantOutput
-import com.bugsnag.android.gradle.internal.UNITY_SO_COPY_DIR
-import com.bugsnag.android.gradle.internal.UNITY_SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.clearDir
 import com.bugsnag.android.gradle.internal.includesAbi
 import com.bugsnag.android.gradle.internal.mapProperty
@@ -15,7 +13,6 @@ import okio.source
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
@@ -37,8 +34,7 @@ import javax.inject.Inject
  * Task that generates Unity shared object mapping files for upload to Bugsnag.
  */
 internal open class BugsnagGenerateUnitySoMappingTask @Inject constructor(
-    objects: ObjectFactory,
-    projectLayout: ProjectLayout
+    objects: ObjectFactory
 ) : DefaultTask(), AndroidManifestInfoReceiver {
 
     init {
@@ -62,11 +58,9 @@ internal open class BugsnagGenerateUnitySoMappingTask @Inject constructor(
 
     @get:OutputDirectory
     val intermediateOutputDir: DirectoryProperty = objects.directoryProperty()
-        .convention(projectLayout.buildDirectory.dir(UNITY_SO_MAPPING_DIR))
 
     @get:OutputDirectory
     val unitySharedObjectDir: DirectoryProperty = objects.directoryProperty()
-        .convention(projectLayout.buildDirectory.dir(UNITY_SO_COPY_DIR))
 
     @get:Internal
     val rootProjectDir: DirectoryProperty = objects.directoryProperty()


### PR DESCRIPTION
## Goal

Addresses a warning about implicit [task dependencies](https://docs.gradle.org/7.0.2/userguide/validation_problems.html#implicit_dependency) that is displayed when using Gradle 7 with APK splits. This is caused by the outputs of tasks that generate mapping files being the same directory for several tasks - the fix has been to alter this so the directory is based on the variant output's name.

This will also need porting to the v5 branch once it has been reviewed.

## Testing

Verified the message shows in an example app using AGP 7 with splits, then tested with the local changes and confirmed that the error message is no longer displayed. Otherwise relied on existing test coverage.