### PR TITLE
Add clearer error messages if the node_modules directory is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Address task dependency warning when using APK splits
   [#407](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/407)
 
+* Added clear error messages when node_modules cannot be located in ReactNative projects
+
 ## 7.0.0-beta01 (2021-06-23)
 
 Support for Android Gradle Plugin 7.0.0-beta04 added. This version introduces no new features and

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -351,9 +351,25 @@ class BugsnagPlugin : Plugin<Project> {
             project.rootProject.allprojects { subProj ->
                 val defaultNodeModulesDir = File("${subProj.rootDir}/../node_modules")
                 val nodeModulesDir = bugsnag.nodeModulesDir.getOrElse(defaultNodeModulesDir)
+                if (!nodeModulesDir.exists()) {
+                    throw StopExecutionException(
+                        "Cannot find node_modules directory at: ${nodeModulesDir.absolutePath} " +
+                            "To set this to the correct path manually, please see: " +
+                            "https://docs.bugsnag.com/build-integrations/gradle/#custom-node_modules-directory"
+                    )
+                }
+
+                val bugsnagModuleDir = File(nodeModulesDir, "@bugsnag/react-native/android")
+                if (!bugsnagModuleDir.exists()) {
+                    throw StopExecutionException(
+                        "Cannot find the @bugsnag/react-native module in your node_modules directory. " +
+                            "Manual installation instructions can be found here: " +
+                            "https://docs.bugsnag.com/platforms/react-native/react-native/manual-setup/#installation"
+                    )
+                }
 
                 subProj.repositories.maven { repo ->
-                    repo.setUrl("$nodeModulesDir/@bugsnag/react-native/android")
+                    repo.setUrl(bugsnagModuleDir.toString())
                 }
             }
         }


### PR DESCRIPTION
## Goal
Emit a clear error message when the node_modules directory cannot be located by the plugin, or if the Bugsnag react-native module cannot be found. Previously the plugin would create an invalid Maven reference, potentially leading to compiler errors.

## Testing
Manually tested by removing the `node_modules` directory and running the Gradle build