### PR TITLE
Access version code lazily via provider

### DIFF
--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -187,7 +187,7 @@ class BugsnagPlugin : Plugin<Project> {
             val manifestInfoFileProvider = registerManifestUuidTask(project, variant)
             val mappingFilesProvider = createMappingFileProvider(project, variant, output)
 
-            val versionCodeProvider = DefaultProvider { output.versionCode }
+            val versionCodeProvider = project.providers.provider { output.versionCode }
 
             val generateProguardTaskProvider = when {
                 jvmMinificationEnabled -> registerGenerateProguardTask(

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -38,7 +38,6 @@ import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
-import org.gradle.api.internal.provider.DefaultProvider
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskProvider


### PR DESCRIPTION
Closes #384.

## Goal

To unblock consumers (such as Square/CashApp) to use the Bugsnag Android plugin with AGP 7.0 final.

## Design

The inevitable fix would be to switch from using the now-legacy variant api:
```
            val android = project.extensions.getByType(AppExtension::class.java)
            android.applicationVariants.configureEach { variant ->
```

to the new provider api, a la:
```
            val android = project.extensions.getByType(ApplicationAndroidComponentsExtension::class.java)
            android.onVariants { variant -> 
                variant.outputs.map { output -> output.versionCode }
            }
```

but that would have been a more substantial change.

## Changeset

Wrapping output.versionCode in a Callable which can be passed to a DefaultProvider for lazy initialization.

## Testing

I pushed to our internal Artifactory instance and ran the following command successfully:

```
./gradlew publishInternalReleaseBundle --dry-run
```

as outlined in https://github.com/Triple-T/gradle-play-publisher/issues/940#issue-862925799


cc: @egorand @SUPERCILEX