### PR TITLE
Relative dexguard folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Address task dependency warning when using APK splits
   [#412](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/412)
 
+* Custom Dexguard paths are resolved correctly (relative to the project)
+  [#420](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/420)
+
 ## 5.7.8 (2021-07-22)
 
 * Upload correct bundle when Hermes is enabled

--- a/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
@@ -47,7 +47,7 @@ class GroovyCompat {
                     return null
                 }
 
-                File dexguardDir = Paths.get(dexguard.path).toFile()
+                File dexguardDir = project.file(dexguard.path).getCanonicalFile()
 
                 // Get the version from the dexguard.jar manifest
                 URL url = new URL("jar:file:$dexguardDir/lib/dexguard.jar!/")


### PR DESCRIPTION
## Goal
Dexguard paths configured relative to the project should be resolved correctly by the Bugsnag Android Gradle Plugin:
```groovy
dexguard {
    path '../DexGuard-9.1.10'
   ...
    }
}
```

## Changeset
Use the Gradle `project.file` function to resolve the path according to the Gradle project rules.

## Testing
Tested manually using the support-provided Dexguard9 example project.