### PR TITLE
Relative dexguard folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Custom Dexguard paths are resolved correctly (relative to the project)
+  [#421](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/421)
+
 ## 7.0.0 (2021-08-12)
 
 * Address task dependency warning when using APK splits

--- a/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
@@ -47,7 +47,7 @@ class GroovyCompat {
                     return null
                 }
 
-                File dexguardDir = Paths.get(dexguard.path).toFile()
+                File dexguardDir = project.file(dexguard.path).getCanonicalFile()
 
                 // Get the version from the dexguard.jar manifest
                 URL url = new URL("jar:file:$dexguardDir/lib/dexguard.jar!/")


### PR DESCRIPTION
## Goal
Dexguard paths configured relative to the project should be resolved correctly by the Bugsnag Android Gradle Plugin:
```groovy
dexguard {
    path '../DexGuard-9.1.10'
   ...
    }
}
```

## Changeset
Use the Gradle `project.file` function to resolve the path according to the Gradle project rules.

## Testing
Tested manually using the support-provided Dexguard9 example project.