### PR TITLE
Release-metadata tasks always available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Custom Dexguard paths are resolved correctly (relative to the project)
   [#420](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/420)
 
+* Release-metadata tasks are always available for configured projects
+  [#422](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/422)
+
 ## 5.7.8 (2021-07-22)
 
 * Upload correct bundle when Hermes is enabled

--- a/features/disabled_build_type.feature
+++ b/features/disabled_build_type.feature
@@ -3,4 +3,4 @@ Feature: Disabling plugin for build type
 Scenario: Disabled build type makes no requests
     When I build "default_app" using the "disabled_build_type" bugsnag config
     And I wait for 3 seconds
-    Then I should receive no builds
+    Then I wait to receive 1 builds

--- a/features/fail_on_upload_error.feature
+++ b/features/fail_on_upload_error.feature
@@ -5,10 +5,11 @@ Scenario: Upload successfully with API key, mapping file, and correct endpoint
     And I wait to receive a build
     And I wait to receive an upload
 
-Scenario: No uploads or build failures when obfuscation is disabled
+Scenario: No build failures when obfuscation is disabled
     When I build "disabled_obfuscation" using the "standard" bugsnag config
     And I wait for 3 seconds
-    Then I should receive no builds
+    Then I wait to receive a build
+    Then I should receive no uploads
 
 Scenario: Upload failure due to empty API key
     When I build the failing "default_app" using the "empty_api_key" bugsnag config

--- a/features/fixtures/config/bugsnag/disabled_product_flavor.gradle
+++ b/features/fixtures/config/bugsnag/disabled_product_flavor.gradle
@@ -6,7 +6,7 @@ bugsnag {
 
     // disable bugsnag plugin for 'foo' productFlavor
     variantFilter { variant ->
-        if (variant.name.toLowerCase().contains("foo")) {
+        if (variant.name.toLowerCase().contains("debug") || variant.name.toLowerCase().contains("foo")) {
             enabled = false
         }
     }


### PR DESCRIPTION
## Goal
Always allow build meta-data to be uploaded so that applications without obfuscation still have build meta-data on their errors.

## Changeset
Unconditionally register the release meta-data task in the `BugsnagPlugin` if it's enabled.

## Testing
Altered existing tests to either expect or filter the additional uploads.