### PR TITLE
Support DexGuard with AGP 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Support extracting SO files from bugsnag AARs for library modules
   [#423](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/423)
 
+* Support DexGuard with AGP 7
+  [#426](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/426)
+
 ## 7.0.0 (2021-08-12)
 
 * Address task dependency warning when using APK splits

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -342,11 +342,9 @@ class BugsnagPlugin : Plugin<Project> {
                 // so need to alter task dependency so that BAGP always runs
                 // after DexGuard
                 if (project.hasDexguardPlugin()) {
-                    generateProguardTaskProvider.configure { bagpTask ->
-                        val taskName = getDexguardAabTaskName(variant)
-                        project.tasks.findByName(taskName)?.let { dexguardTask ->
-                            bagpTask.mustRunAfter(dexguardTask)
-                        }
+                    val taskName = getDexguardAabTaskName(variant)
+                    project.tasks.named(taskName).configure { dexguardTask ->
+                        generateProguardTaskProvider.get().mustRunAfter(dexguardTask)
                     }
                 }
             }


### PR DESCRIPTION
## Goal

Supports the DexGuard plugin with AGP 7. This avoids eager configuration of the DexGuard task that the Bugsnag plugin needs to rely upon, which was triggering an exception in projects using DexGuard 9.1.12.

## Testing

Manually verified that an example app using DexGuard can upload mapping information to Bugsnag when assembling + bundling.