### PR TITLE
Reject versionCodeOverride being used with VERSION_CODE meta-data

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -10,7 +10,7 @@
     <ID>MagicNumber:MappingFileProvider.kt$9</ID>
     <ID>MaxLineLength:BugsnagManifestUuidTask.kt$BugsnagManifestUuidTask$private</ID>
     <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ @Suppress("SENSELESS_COMPARISON") internal fun isUnityLibraryUploadEnabled( bugsnag: BugsnagPluginExtension, android: BaseExtension ): Boolean</ID>
-    <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ private fun registerUploadSourceMapTask( project: Project, variant: BaseVariant, output: BaseVariantOutput, bugsnag: BugsnagPluginExtension, manifestInfoFileProvider: Provider&lt;RegularFile&gt; ): TaskProvider&lt;out BugsnagUploadJsSourceMapTask&gt;?</ID>
+    <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ private fun registerUploadSourceMapTask( project: Project, variant: BaseVariant, output: BaseVariantOutput, bugsnag: BugsnagPluginExtension, manifestInfoProvider: Provider&lt;AndroidManifestInfo&gt; ): TaskProvider&lt;out BugsnagUploadJsSourceMapTask&gt;?</ID>
     <ID>ReturnCount:ManifestUuidTaskV2Compat.kt$internal fun createManifestUpdateTask( bugsnag: BugsnagPluginExtension, project: Project, variantName: String ): TaskProvider&lt;BugsnagManifestUuidTaskV2&gt;?</ID>
     <ID>ReturnCount:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$ fun generateSoMappingFile(project: Project, params: Params): File?</ID>
     <ID>SpreadOperator:DexguardCompat.kt$(buildDir, *path, variant.dirName, outputDir, "mapping.txt")</ID>
@@ -23,5 +23,6 @@
     <ID>TooGenericExceptionCaught:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$e: Exception</ID>
     <ID>TooGenericExceptionCaught:SharedObjectMappingFileFactory.kt$SharedObjectMappingFileFactory$ex: Throwable</ID>
     <ID>TooManyFunctions:BugsnagPlugin.kt$BugsnagPlugin : Plugin</ID>
+    <ID>UnusedPrivateMember:BugsnagPlugin.kt$BugsnagPlugin$private fun BaseVariantOutput.findVersionCode(): Int</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/features/fixtures/app/module/src/main/AndroidManifestVersionCode.xml
+++ b/features/fixtures/app/module/src/main/AndroidManifestVersionCode.xml
@@ -1,0 +1,17 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.bugsnag.libvanilla" >
+  <application android:name="com.example.android.gradle.plugin.FooApp">
+
+    <meta-data
+      android:name="com.bugsnag.android.API_KEY"
+      android:value="${BUGSNAG_API_KEY}" />
+
+    <meta-data
+      android:name="com.bugsnag.android.VERSION_CODE"
+      android:value="101" />
+
+    <meta-data
+      android:name="com.bugsnag.android.APP_VERSION"
+      android:value="3.5" />
+  </application>
+</manifest>

--- a/features/fixtures/config/android/manual_version.gradle
+++ b/features/fixtures/config/android/manual_version.gradle
@@ -1,0 +1,10 @@
+apply plugin: 'com.android.application'
+apply from: "../../config/android/common.gradle"
+
+android {
+    sourceSets {
+        main {
+            manifest.srcFile "src/main/AndroidManifestVersionCode.xml"
+        }
+    }
+}

--- a/features/fixtures/config/android/splits_and_manual_version.gradle
+++ b/features/fixtures/config/android/splits_and_manual_version.gradle
@@ -1,0 +1,27 @@
+apply plugin: 'com.android.application'
+apply from: "../../config/android/common.gradle"
+
+ext.densityCodes = [ldpi:2, mdpi:3, hdpi:4, xhdpi:5, xxhdpi:6, xxxhdpi:7]
+
+android {
+    sourceSets {
+        main {
+            manifest.srcFile "src/main/AndroidManifestVersionCode.xml"
+        }
+    }
+    splits {
+        density {
+            enable true
+        }
+    }
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            def densityVersionCode =
+                project.ext.densityCodes.get(output.getFilter("DENSITY"))
+
+            if (densityVersionCode != null) {
+                output.versionCodeOverride = densityVersionCode
+            }
+        }
+    }
+}

--- a/features/manifest_overrides.feature
+++ b/features/manifest_overrides.feature
@@ -1,0 +1,16 @@
+Feature: Manifest meta-data overrides
+
+# ApkVariantOutput level manifest processing for AGP < 4.1.0 means we can't do these tests
+@requires_agp4_1_or_higher
+Scenario: Invalid Split Overrides
+    When I build the failing "splits_and_manual_version" using the "standard" bugsnag config
+    And I wait for 3 seconds
+    Then I should receive no requests
+
+Scenario: Manual versionCode overrides default
+    When I build "manual_version" using the "standard" bugsnag config
+    And I wait to receive 2 requests
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      | sourceControl.provider | sourceControl.repository                                     |
+        | 101            | 3.5        | gradle-android | github                 | https://github.com/bugsnag/bugsnag-android-gradle-plugin.git |

--- a/src/main/kotlin/com/bugsnag/android/gradle/AndroidManifestInfo.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/AndroidManifestInfo.kt
@@ -1,11 +1,13 @@
 package com.bugsnag.android.gradle
 
+import com.android.build.gradle.api.ApkVariantOutput
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import okio.buffer
 import okio.sink
 import okio.source
 import java.io.File
+import java.io.Serializable
 
 @JsonClass(generateAdapter = true)
 data class AndroidManifestInfo(
@@ -13,25 +15,49 @@ data class AndroidManifestInfo(
     val versionCode: String,
     val buildUUID: String,
     val versionName: String,
-    val applicationId: String
-) {
+    val applicationId: String,
+    val metaVersionCode: String? = null,
+    val metaVersionName: String? = null
+) : Serializable {
     internal fun write(file: File) {
         file.sink().buffer().use {
             ADAPTER.toJson(it, this)
         }
     }
 
+    internal fun forApkVariantOutput(variant: ApkVariantOutput): AndroidManifestInfo {
+        var variantVersionCode = metaVersionCode ?: versionCode
+        if (variant.versionCodeOverride.toString() != versionCode) {
+            require(metaVersionCode == null) {
+                "cannot use versionCodeOverride and com.bugsnag.android.VERSION_CODE meta-data in the same project"
+            }
+
+            variantVersionCode = variant.versionCodeOverride.toString()
+        }
+
+        var variantVersionName = metaVersionName ?: versionName
+        if (variant.versionNameOverride != null && variant.versionNameOverride != versionName) {
+            require(metaVersionName == null) {
+                "cannot use versionNameOverride and com.bugsnag.android.APP_VERSION meta-data in the same project"
+            }
+
+            variantVersionName = variant.versionNameOverride
+        }
+
+        return copy(
+            versionCode = variantVersionCode,
+            versionName = variantVersionName
+        )
+    }
+
     internal companion object {
+        private const val serialVersionUID = 1L
+
         private val ADAPTER = Moshi.Builder().build().adapter(AndroidManifestInfo::class.java)
 
-        fun read(file: File, versionCode: Int?): AndroidManifestInfo {
-            val info = file.source().buffer().use {
+        fun read(file: File): AndroidManifestInfo {
+            return file.source().buffer().use {
                 ADAPTER.fromJson(it) ?: error("Failed to parse manifest info.")
-            }
-            return if (versionCode == null) {
-                info
-            } else {
-                info.copy(versionCode = versionCode.toString())
             }
         }
     }

--- a/src/main/kotlin/com/bugsnag/android/gradle/AndroidManifestInfoReceiver.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/AndroidManifestInfoReceiver.kt
@@ -1,26 +1,9 @@
 package com.bugsnag.android.gradle
 
-import org.gradle.api.Task
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity.NONE
 
-interface AndroidManifestInfoReceiver : Task {
-    @get:PathSensitive(NONE)
-    @get:InputFile
-    val manifestInfoFile: RegularFileProperty
-
-    // versionCode needs to be read separately as the manifestInfoFile is not the final merged
-    // manifest, and does not contain the final versionCode on AGP 4.1+.
-    @get:Optional
+interface AndroidManifestInfoReceiver {
     @get:Input
-    val versionCode: Property<Int>
-}
-
-internal fun AndroidManifestInfoReceiver.parseManifestInfo(): AndroidManifestInfo {
-    return AndroidManifestInfo.read(manifestInfoFile.asFile.get(), versionCode.orNull)
+    val manifestInfo: Property<AndroidManifestInfo>
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/AndroidManifestParser.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/AndroidManifestParser.kt
@@ -40,12 +40,14 @@ internal class AndroidManifestParser {
         var buildUuid: String? = null
         var versionName: String? = null
         var applicationId: String? = null
+        var metaVersionCode: String? = null
+        var metaVersionName: String? = null
 
         openAndroidManifestXml(manifestPath) { doc ->
             apiKey = findBugsnagMetadataValue(doc, TAG_API_KEY)
             buildUuid = findBugsnagMetadataValue(doc, TAG_BUILD_UUID)
-            versionCode = findBugsnagMetadataValue(doc, TAG_VERSION_CODE)
-            versionName = findBugsnagMetadataValue(doc, TAG_APP_VERSION)
+            metaVersionCode = findBugsnagMetadataValue(doc, TAG_VERSION_CODE)
+            metaVersionName = findBugsnagMetadataValue(doc, TAG_APP_VERSION)
 
             val manifest = doc.getElementsByTagName(TAG_MANIFEST).item(0)
 
@@ -82,7 +84,9 @@ internal class AndroidManifestParser {
             requireNotNull(versionCode),
             requireNotNull(buildUuid),
             requireNotNull(versionName),
-            requireNotNull(applicationId)
+            requireNotNull(applicationId),
+            metaVersionCode,
+            metaVersionName
         )
     }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
@@ -10,18 +10,13 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity.NONE
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
@@ -39,13 +34,8 @@ open class BugsnagGenerateNdkSoMappingTask @Inject constructor(
         description = "Generates NDK mapping files for upload to Bugsnag"
     }
 
-    @get:PathSensitive(NONE)
-    @get:InputFile
-    override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
-
-    @get:Optional
     @get:Input
-    override val versionCode: Property<Int> = objects.property()
+    override val manifestInfo: Property<AndroidManifestInfo> = objects.property()
 
     @get:Internal
     internal lateinit var variantOutput: ApkVariantOutput

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateProguardTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateProguardTask.kt
@@ -10,12 +10,8 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity.NONE
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
@@ -33,16 +29,11 @@ open class BugsnagGenerateProguardTask @Inject constructor(
         description = "Generates a compressed JVM mapping file for upload to Bugsnag"
     }
 
+    @get:Input
+    override val manifestInfo: Property<AndroidManifestInfo> = objects.property()
+
     @get:InputFiles
     val mappingFileProperty: ConfigurableFileCollection = objects.fileCollection()
-
-    @get:PathSensitive(NONE)
-    @get:InputFile
-    override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
-
-    @get:Optional
-    @get:Input
-    override val versionCode: Property<Int> = objects.property()
 
     @get:OutputFile
     val archiveOutputFile: RegularFileProperty = objects.fileProperty()

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
@@ -13,17 +13,12 @@ import okio.source
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity.NONE
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
@@ -42,13 +37,8 @@ internal open class BugsnagGenerateUnitySoMappingTask @Inject constructor(
         description = "Generates Unity mapping files for upload to Bugsnag"
     }
 
-    @get:PathSensitive(NONE)
-    @get:InputFile
-    override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
-
-    @get:Optional
     @get:Input
-    override val versionCode: Property<Int> = objects.property()
+    override val manifestInfo: Property<AndroidManifestInfo> = objects.property()
 
     @get:Internal
     internal lateinit var variantOutput: ApkVariantOutput

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -17,6 +17,7 @@ import com.bugsnag.android.gradle.internal.TASK_JNI_LIBS
 import com.bugsnag.android.gradle.internal.UNITY_SO_COPY_DIR
 import com.bugsnag.android.gradle.internal.UNITY_SO_MAPPING_DIR
 import com.bugsnag.android.gradle.internal.UploadRequestClient
+import com.bugsnag.android.gradle.internal.dependsOn
 import com.bugsnag.android.gradle.internal.getDexguardAabTaskName
 import com.bugsnag.android.gradle.internal.hasDexguardPlugin
 import com.bugsnag.android.gradle.internal.intermediateForGenerateJvmMapping
@@ -210,23 +211,27 @@ class BugsnagPlugin : Plugin<Project> {
             val unityEnabled = isUnityLibraryUploadEnabled(bugsnag, android)
             val reactNativeEnabled = isReactNativeUploadEnabled(bugsnag)
 
+            // register bugsnag tasks
+            val mappingFilesProvider = createMappingFileProvider(project, variant, output)
+            val manifestTaskProvider = registerManifestUuidTask(project, variant)
+
+            val manifestInfoProvider = manifestTaskProvider
+                .flatMap { it.manifestInfoProvider }
+                .map { AndroidManifestInfo.read(it.asFile).forApkVariantOutput(output) }
+
             // skip tasks for variant if JVM/NDK/Unity minification not enabled
             if (!jvmMinificationEnabled && !ndkEnabled && !unityEnabled && !reactNativeEnabled) {
                 return@configureEach
             }
-
-            // register bugsnag tasks
-            val manifestInfoFileProvider = registerManifestUuidTask(project, variant)
-            val mappingFilesProvider = createMappingFileProvider(project, variant, output)
 
             val generateProguardTaskProvider = when {
                 jvmMinificationEnabled -> registerGenerateProguardTask(
                     project,
                     output,
                     bugsnag,
-                    manifestInfoFileProvider,
+                    manifestInfoProvider,
                     mappingFilesProvider
-                )
+                ).dependsOn(manifestTaskProvider)
                 else -> null
             }
 
@@ -236,10 +241,10 @@ class BugsnagPlugin : Plugin<Project> {
                     output,
                     bugsnag,
                     httpClientHelperProvider,
-                    manifestInfoFileProvider,
+                    manifestInfoProvider,
                     proguardUploadClientProvider,
                     generateProguardTaskProvider
-                )
+                ).dependsOn(manifestTaskProvider)
                 else -> null
             }
             val ndkSoMappingOutput = "$NDK_SO_MAPPING_DIR/${output.name}"
@@ -250,9 +255,9 @@ class BugsnagPlugin : Plugin<Project> {
                     output,
                     bugsnag,
                     android,
-                    manifestInfoFileProvider,
+                    manifestInfoProvider,
                     ndkSoMappingOutput
-                )
+                ).dependsOn(manifestTaskProvider)
                 else -> null
             }
             val uploadNdkMappingProvider = when {
@@ -262,11 +267,11 @@ class BugsnagPlugin : Plugin<Project> {
                         output,
                         bugsnag,
                         httpClientHelperProvider,
-                        manifestInfoFileProvider,
+                        manifestInfoProvider,
                         ndkUploadClientProvider,
                         generateNdkMappingProvider,
                         ndkSoMappingOutput
-                    )
+                    ).dependsOn(manifestTaskProvider)
                 }
                 else -> null
             }
@@ -277,10 +282,10 @@ class BugsnagPlugin : Plugin<Project> {
                     project,
                     output,
                     bugsnag,
-                    manifestInfoFileProvider,
+                    manifestInfoProvider,
                     unityMappingDir,
                     "$UNITY_SO_COPY_DIR/${output.name}"
-                )
+                ).dependsOn(manifestTaskProvider)
                 else -> null
             }
             val uploadUnityMappingProvider = when {
@@ -290,11 +295,11 @@ class BugsnagPlugin : Plugin<Project> {
                         output,
                         bugsnag,
                         httpClientHelperProvider,
-                        manifestInfoFileProvider,
+                        manifestInfoProvider,
                         unityUploadClientProvider,
                         generateUnityMappingProvider,
                         unityMappingDir
-                    )
+                    ).dependsOn(manifestTaskProvider)
                 }
                 else -> null
             }
@@ -305,8 +310,8 @@ class BugsnagPlugin : Plugin<Project> {
                     variant,
                     output,
                     bugsnag,
-                    manifestInfoFileProvider
-                )
+                    manifestInfoProvider
+                )?.dependsOn(manifestTaskProvider)
                 else -> null
             }
 
@@ -315,12 +320,12 @@ class BugsnagPlugin : Plugin<Project> {
                 variant,
                 output,
                 bugsnag,
-                manifestInfoFileProvider,
+                manifestInfoProvider,
                 releasesUploadClientProvider,
                 mappingFilesProvider,
-                generateNdkMappingProvider != null,
+                ndkEnabled,
                 httpClientHelperProvider
-            )
+            ).dependsOn(manifestTaskProvider)
 
             val releaseAutoUpload = bugsnag.reportBuilds.get()
             variant.register(project, releaseUploadTask, releaseAutoUpload)
@@ -413,13 +418,13 @@ class BugsnagPlugin : Plugin<Project> {
     private fun registerManifestUuidTask(
         project: Project,
         variant: BaseVariant
-    ): Provider<RegularFile> {
+    ): TaskProvider<BugsnagManifestUuidTaskV2> {
         val taskName = taskNameForManifestUuid(variant.name)
         // This task will have already been created!
         val manifestUpdater = project.tasks
             .withType(BugsnagManifestUuidTaskV2::class.java)
             .named(taskName)
-        return manifestUpdater.flatMap(BaseBugsnagManifestUuidTask::manifestInfoProvider)
+        return manifestUpdater
     }
 
     /**
@@ -430,17 +435,16 @@ class BugsnagPlugin : Plugin<Project> {
         project: Project,
         output: BaseVariantOutput,
         bugsnag: BugsnagPluginExtension,
-        manifestInfoFileProvider: Provider<RegularFile>,
+        manifestInfoProvider: Provider<AndroidManifestInfo>,
         mappingFilesProvider: Provider<FileCollection>
     ): TaskProvider<out BugsnagGenerateProguardTask> {
         val taskName = taskNameForGenerateJvmMapping(output)
         val gzipOutputProvider = intermediateForGenerateJvmMapping(project, output)
 
         return BugsnagGenerateProguardTask.register(project, taskName) {
-            manifestInfoFile.set(manifestInfoFileProvider)
+            manifestInfo.set(manifestInfoProvider)
             archiveOutputFile.set(gzipOutputProvider)
             failOnUploadError.set(bugsnag.failOnUploadError)
-            versionCode.set(output.findVersionCode())
 
             mappingFilesProvider.let {
                 mappingFileProperty.from(it)
@@ -457,7 +461,7 @@ class BugsnagPlugin : Plugin<Project> {
         output: BaseVariantOutput,
         bugsnag: BugsnagPluginExtension,
         httpClientHelperProvider: Provider<out BugsnagHttpClientHelper>,
-        manifestInfoFileProvider: Provider<RegularFile>,
+        manifestInfoProvider: Provider<AndroidManifestInfo>,
         proguardUploadClientProvider: Provider<out UploadRequestClient>,
         generateProguardTaskProvider: TaskProvider<out BugsnagGenerateProguardTask>?
     ): TaskProvider<out BugsnagUploadProguardTask> {
@@ -468,10 +472,9 @@ class BugsnagPlugin : Plugin<Project> {
         return BugsnagUploadProguardTask.register(project, taskName) {
             requestOutputFile.set(requestOutputFileProvider)
             httpClientHelper.set(httpClientHelperProvider)
-            manifestInfoFile.set(manifestInfoFileProvider)
+            manifestInfo.set(manifestInfoProvider)
             uploadRequestClient.set(proguardUploadClientProvider)
             mappingFileProperty.set(gzipOutputProvider)
-            versionCode.set(output.findVersionCode())
             configureWith(bugsnag)
 
             val task = generateProguardTaskProvider?.get()
@@ -488,7 +491,7 @@ class BugsnagPlugin : Plugin<Project> {
         variant: BaseVariant,
         output: BaseVariantOutput,
         bugsnag: BugsnagPluginExtension,
-        manifestInfoFileProvider: Provider<RegularFile>
+        manifestInfoProvider: Provider<AndroidManifestInfo>
     ): TaskProvider<out BugsnagUploadJsSourceMapTask>? {
         val taskName = taskNameForUploadSourcemaps(output)
         val path = intermediateForUploadSourcemaps(project, output)
@@ -509,14 +512,13 @@ class BugsnagPlugin : Plugin<Project> {
 
         return BugsnagUploadJsSourceMapTask.register(project, taskName) {
             requestOutputFile.set(path)
-            manifestInfoFile.set(manifestInfoFileProvider)
+            manifestInfo.set(manifestInfoProvider)
             bundleJsFileProvider.set(File(rnBundle))
             sourceMapFileProvider.set(File(rnSourceMap))
             overwrite.set(bugsnag.overwrite)
             endpoint.set(bugsnag.endpoint.get())
             devEnabled.set("true" == dev)
             failOnUploadError.set(bugsnag.failOnUploadError)
-            versionCode.set(output.findVersionCode())
 
             val jsProjectRoot = project.rootProject.rootDir.parentFile
             projectRootFileProvider.from(jsProjectRoot)
@@ -536,7 +538,7 @@ class BugsnagPlugin : Plugin<Project> {
         output: ApkVariantOutput,
         bugsnag: BugsnagPluginExtension,
         android: BaseExtension,
-        manifestInfoFileProvider: Provider<RegularFile>,
+        manifestInfoProvider: Provider<AndroidManifestInfo>,
         soMappingOutputPath: String
     ): TaskProvider<out BugsnagGenerateNdkSoMappingTask> {
         // Create a Bugsnag task to upload NDK mapping file(s)
@@ -544,8 +546,7 @@ class BugsnagPlugin : Plugin<Project> {
         return BugsnagGenerateNdkSoMappingTask.register(project, taskName) {
             variantOutput = output
             objDumpPaths.set(bugsnag.objdumpPaths)
-            manifestInfoFile.set(manifestInfoFileProvider)
-            versionCode.set(output.findVersionCode())
+            manifestInfo.set(manifestInfoProvider)
 
             val searchPaths = getSharedObjectSearchPaths(project, bugsnag, android)
             searchDirectories.from(searchPaths)
@@ -566,7 +567,7 @@ class BugsnagPlugin : Plugin<Project> {
         project: Project,
         output: ApkVariantOutput,
         bugsnag: BugsnagPluginExtension,
-        manifestInfoFileProvider: Provider<RegularFile>,
+        manifestInfoProvider: Provider<AndroidManifestInfo>,
         mappingFileOutputDir: String,
         copyOutputDir: String
     ): TaskProvider<out BugsnagGenerateUnitySoMappingTask> {
@@ -575,9 +576,8 @@ class BugsnagPlugin : Plugin<Project> {
         return BugsnagGenerateUnitySoMappingTask.register(project, taskName) {
             variantOutput = output
             objDumpPaths.set(bugsnag.objdumpPaths)
-            manifestInfoFile.set(manifestInfoFileProvider)
+            manifestInfo.set(manifestInfoProvider)
             rootProjectDir.set(project.rootProject.projectDir)
-            versionCode.set(output.findVersionCode())
             intermediateOutputDir.set(project.layout.buildDirectory.dir(mappingFileOutputDir))
             unitySharedObjectDir.set(project.layout.buildDirectory.dir(copyOutputDir))
         }
@@ -589,18 +589,17 @@ class BugsnagPlugin : Plugin<Project> {
         output: BaseVariantOutput,
         bugsnag: BugsnagPluginExtension,
         httpClientHelperProvider: Provider<out BugsnagHttpClientHelper>,
-        manifestInfoFileProvider: Provider<RegularFile>,
+        manifestInfoProvider: Provider<AndroidManifestInfo>,
         ndkUploadClientProvider: Provider<out UploadRequestClient>,
         generateTaskProvider: TaskProvider<out BugsnagGenerateNdkSoMappingTask>,
         soMappingOutputDir: String
     ): TaskProvider<out BugsnagUploadSharedObjectTask> {
         return registerSharedObjectUploadTask(
             project,
-            output,
             generateTaskProvider,
             bugsnag,
             httpClientHelperProvider,
-            manifestInfoFileProvider,
+            manifestInfoProvider,
             ndkUploadClientProvider,
             taskNameForUploadNdkMapping(output),
             intermediateForNdkSoRequest(project, output),
@@ -615,18 +614,17 @@ class BugsnagPlugin : Plugin<Project> {
         output: BaseVariantOutput,
         bugsnag: BugsnagPluginExtension,
         httpClientHelperProvider: Provider<out BugsnagHttpClientHelper>,
-        manifestInfoFileProvider: Provider<RegularFile>,
+        manifestInfoProvider: Provider<AndroidManifestInfo>,
         ndkUploadClientProvider: Provider<out UploadRequestClient>,
         generateTaskProvider: TaskProvider<out BugsnagGenerateUnitySoMappingTask>,
         mappingFileOutputDir: String
     ): TaskProvider<out BugsnagUploadSharedObjectTask> {
         return registerSharedObjectUploadTask(
             project,
-            output,
             generateTaskProvider,
             bugsnag,
             httpClientHelperProvider,
-            manifestInfoFileProvider,
+            manifestInfoProvider,
             ndkUploadClientProvider,
             taskNameForUploadUnityMapping(output),
             intermediateForUnitySoRequest(project, output),
@@ -638,11 +636,10 @@ class BugsnagPlugin : Plugin<Project> {
     @Suppress("LongParameterList")
     private fun registerSharedObjectUploadTask(
         project: Project,
-        output: BaseVariantOutput,
         generateTaskProvider: TaskProvider<out Task>,
         bugsnag: BugsnagPluginExtension,
         httpClientHelperProvider: Provider<out BugsnagHttpClientHelper>,
-        manifestInfoFileProvider: Provider<RegularFile>,
+        manifestInfoProvider: Provider<AndroidManifestInfo>,
         ndkUploadClientProvider: Provider<out UploadRequestClient>,
         taskName: String,
         requestOutputFile: Provider<RegularFile>,
@@ -657,10 +654,9 @@ class BugsnagPlugin : Plugin<Project> {
             this.uploadType.set(uploadType)
             projectRoot.set(bugsnag.projectRoot.getOrElse(project.projectDir.toString()))
             httpClientHelper.set(httpClientHelperProvider)
-            manifestInfoFile.set(manifestInfoFileProvider)
+            manifestInfo.set(manifestInfoProvider)
             uploadRequestClient.set(ndkUploadClientProvider)
             intermediateOutputDir.set(project.layout.buildDirectory.dir(intermediateOutputPath))
-            versionCode.set(output.findVersionCode())
             configureWith(bugsnag)
         }
     }
@@ -671,7 +667,7 @@ class BugsnagPlugin : Plugin<Project> {
         variant: BaseVariant,
         output: BaseVariantOutput,
         bugsnag: BugsnagPluginExtension,
-        manifestInfoFileProvider: Provider<RegularFile>,
+        manifestInfoProvider: Provider<AndroidManifestInfo>,
         releasesUploadClientProvider: Provider<out UploadRequestClient>,
         mappingFilesProvider: Provider<FileCollection>?,
         checkSearchDirectories: Boolean,
@@ -692,9 +688,8 @@ class BugsnagPlugin : Plugin<Project> {
             metadata.set(bugsnag.metadata)
             builderName.set(bugsnag.builderName)
             gradleVersion.set(project.gradle.gradleVersion)
-            manifestInfoFile.set(manifestInfoFileProvider)
+            manifestInfo.set(manifestInfoProvider)
             uploadRequestClient.set(releasesUploadClientProvider)
-            versionCode.set(output.findVersionCode())
 
             if (project.isJvmMinificationEnabled(variant)) {
                 mappingFilesProvider?.let {

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
@@ -19,13 +19,10 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity.NONE
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.process.ExecOperations
@@ -58,19 +55,14 @@ open class BugsnagReleasesTask @Inject constructor(
         description = "Assembles information about the build that will be sent to the releases API"
     }
 
+    @get:Input
+    override val manifestInfo: Property<AndroidManifestInfo> = objects.property()
+
     @get:Internal
     internal val uploadRequestClient: Property<UploadRequestClient> = objects.property()
 
     @get:Internal
     internal val httpClientHelper: Property<BugsnagHttpClientHelper> = objects.property()
-
-    @get:PathSensitive(NONE)
-    @get:InputFile
-    override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
-
-    @get:Optional
-    @get:Input
-    override val versionCode: Property<Int> = objects.property()
 
     @get:OutputFile
     val requestOutputFile: RegularFileProperty = objects.fileProperty()
@@ -149,7 +141,7 @@ open class BugsnagReleasesTask @Inject constructor(
 
     @TaskAction
     fun fetchReleaseInfo() {
-        val manifestInfo = parseManifestInfo()
+        val manifestInfo = manifestInfo.get()
         val payload = generateJsonPayload(manifestInfo)
 
         val response =

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
@@ -13,10 +13,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import javax.inject.Inject
@@ -30,13 +27,8 @@ open class BugsnagUploadJsSourceMapTask @Inject constructor(
         description = "Uploads JS source maps to Bugsnag"
     }
 
-    @get:PathSensitive(PathSensitivity.NONE)
-    @get:InputFile
-    override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
-
-    @get:Optional
     @get:Input
-    override val versionCode: Property<Int> = objects.property()
+    override val manifestInfo: Property<AndroidManifestInfo> = objects.property()
 
     @get:InputFile
     val bugsnagSourceMaps: RegularFileProperty = objects.fileProperty()
@@ -68,7 +60,7 @@ open class BugsnagUploadJsSourceMapTask @Inject constructor(
     @TaskAction
     fun uploadJsSourceMap() {
         // Construct a basic request
-        val manifestInfo = parseManifestInfo()
+        val manifestInfo = manifestInfo.get()
         val executable = bugsnagSourceMaps.get().asFile
         val builder = generateUploadCommand(executable.absolutePath, manifestInfo)
         project.logger.lifecycle("Bugsnag: uploading react native sourcemap: ${builder.command()}")

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadProguardTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadProguardTask.kt
@@ -12,13 +12,9 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity.NONE
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import javax.inject.Inject
@@ -45,6 +41,9 @@ open class BugsnagUploadProguardTask @Inject constructor(
         description = "Uploads the mapping file to Bugsnag"
     }
 
+    @get:Input
+    override val manifestInfo: Property<AndroidManifestInfo> = objects.property()
+
     @get:Internal
     internal val uploadRequestClient: Property<UploadRequestClient> = objects.property()
 
@@ -53,14 +52,6 @@ open class BugsnagUploadProguardTask @Inject constructor(
 
     @get:InputFiles
     val mappingFileProperty: RegularFileProperty = objects.fileProperty()
-
-    @get:PathSensitive(NONE)
-    @get:InputFile
-    override val manifestInfoFile: RegularFileProperty = objects.fileProperty()
-
-    @get:Optional
-    @get:Input
-    override val versionCode: Property<Int> = objects.property()
 
     @get:OutputFile
     val requestOutputFile: RegularFileProperty = objects.fileProperty()
@@ -87,7 +78,7 @@ open class BugsnagUploadProguardTask @Inject constructor(
         // Read the API key and Build ID etc..
 
         // Construct a basic request
-        val manifestInfo = parseManifestInfo()
+        val manifestInfo = manifestInfo.get()
 
         // Send the request
         val request = BugsnagMultiPartUploadRequest.from(this)

--- a/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestInfoTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestInfoTest.kt
@@ -1,9 +1,12 @@
 package com.bugsnag.android.gradle
 
+import com.android.build.gradle.api.ApkVariantOutput
 import groovy.util.GroovyTestCase.assertEquals
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
 import java.io.File
 
 class AndroidManifestInfoTest {
@@ -39,10 +42,19 @@ class AndroidManifestInfoTest {
             """.trimIndent()
         )
 
-        val copy = AndroidManifestInfo.read(jsonFile, null)
+        val copy = AndroidManifestInfo.read(jsonFile)
         assertEquals(info, copy)
+    }
 
-        val customCode = AndroidManifestInfo.read(jsonFile, 2)
-        assertEquals(info.copy(versionCode = "2"), customCode)
+    @Test
+    fun testManifestReadForApkVariant() {
+        val variantOutput = mock(ApkVariantOutput::class.java)
+        `when`(variantOutput.versionCodeOverride).thenReturn(21)
+        val variantManifestInfo = info.forApkVariantOutput(variantOutput)
+
+        assertEquals(
+            info.copy(versionCode = "21"),
+            variantManifestInfo
+        )
     }
 }

--- a/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestParseOverrideTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestParseOverrideTest.kt
@@ -15,10 +15,12 @@ class AndroidManifestParseOverrideTest {
 
     private val info = AndroidManifestInfo(
         "api-key",
-        "103",
+        "12",
         "build-uuid-123",
-        "57.2",
-        "com.example"
+        "5.2",
+        "com.example",
+        "103",
+        "57.2"
     )
 
     @Mock


### PR DESCRIPTION
## Goal
The Android Gradle Plugin allows each application variant to have it's own `versionCode` and `versionName`, while Bugsnag also allows `versionCode` overriding using an `AndroidManifest.xml` meta-data attribute (`com.bugsnag.android.VERSION_CODE`). Using these two attributes together causes unexpected behaviour, with the source-maps being uploaded with one version and reports generated with a different version.

When detecting both a `versionCodeOverride` and `com.bugsnag.android.VERSION_CODE` in the same project we will now emit an error explaining that they should not be used together.

## Design
The default `versionCode` / `versionName` attributes are tracked separately to those provided in `meta-data` attributes, and the final version details for a variant output are determined by a new `AndroidManifestInfo.forApkVariantOutput` function. This logic has been lifted into the `BugsnagPlugin` and the tasks requiring the version details receive their final `AndroidManifestInfo` by way of a mapped `Provider`.

## Testing
New unit tests and end-to-end tests.