### PR TITLE
Update Travis to use Xenial image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: android
-dist: trusty
+dist: xenial
 sudo: false
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.8.0 (2021-09-15)
+## 5.8.0 (2021-09-16)
 
 * Address task dependency warning when using APK splits
   [#408](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/408)


### PR DESCRIPTION
## Goal

Updates Travis CI to use Xenial rather than Trusty, which is EOL. The Trusty image seems to have changed recently which is failing a scenario on AGP 4.2 with a classloader error, as seen here: https://app.travis-ci.com/github/bugsnag/bugsnag-android-gradle-plugin/jobs/537352065