### PR TITLE
Reinstate React Native E2E tests for AGP 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
       # AGP 4.2.0 E2E tests
     - name: AGP 4.2.0 E2E tests
       env:
-        - AGP_VERSION=4.2.0-beta03
-        - GRADLE_WRAPPER_VERSION=7.0-rc-1
+        - AGP_VERSION=4.2.0
+        - GRADLE_WRAPPER_VERSION=6.8.3
         - RN_FIXTURE_DIR=features/fixtures/rn063/android
       script: bundle exec maze-runner -c --verbose --fail-fast

--- a/features/react_native.feature
+++ b/features/react_native.feature
@@ -1,7 +1,5 @@
 Feature: Plugin integrated in React Native app
 
-# blocked by PLAT-6305
-@skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when assembling an app with the default project structure
     When I build the React Native app
     And I wait to receive a build
@@ -19,8 +17,6 @@ Scenario: Source maps are uploaded when assembling an app with the default proje
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
 
-# blocked by PLAT-6305
-@skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when bundling an app with the default project structure
     And I run the script "features/scripts/bundle_react_native_app.sh" synchronously
     And I wait to receive a build
@@ -38,8 +34,6 @@ Scenario: Source maps are uploaded when bundling an app with the default project
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
 
-# blocked by PLAT-6305
-@skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when assembling an app which uses productFlavors
     When I set environment variable "USE_RN_FLAVORS" to "true"
     When I build the React Native app
@@ -61,8 +55,6 @@ Scenario: Source maps are uploaded when assembling an app which uses productFlav
         | 5              | 2.45.beta  | false     | false |
         | 5              | 2.45.beta  | false     | false |
 
-# blocked by PLAT-6305
-@skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when assembling an app within a monorepo
     When I run the script "features/scripts/build_react_native_monorepo_app.sh" synchronously
     And I wait to receive a build
@@ -80,8 +72,6 @@ Scenario: Source maps are uploaded when assembling an app within a monorepo
       | appVersionCode | appVersion | overwrite | dev   |
       | 5              | 2.45.beta  | true      | false |
 
-# blocked by PLAT-6305
-@skip_gradle_7_or_higher
 Scenario: Setting uploadReactNativeMappings to false will prevent any source map upload
     When I set environment variable "UPLOAD_RN_MAPPINGS" to "false"
     When I build the React Native app
@@ -96,8 +86,6 @@ Scenario: Setting uploadReactNativeMappings to false will prevent any source map
         | versionCode | versionName | appId                     |
         | 5           | 2.45.beta  | com.bugsnag.android.rnapp |
 
-# blocked by PLAT-6305
-@skip_gradle_7_or_higher
 Scenario: Manually invoking source map upload task
     And I run the script "features/scripts/manual_upload_react_native.sh" synchronously
     And I wait to receive an upload
@@ -105,8 +93,6 @@ Scenario: Manually invoking source map upload task
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
 
-# blocked by PLAT-6305
-@skip_gradle_7_or_higher
 # Hermes driver cannot build rn_60 fixture
 @skip_rn60_fixture
 Scenario: Source maps are uploaded in an app using Hermes
@@ -127,8 +113,6 @@ Scenario: Source maps are uploaded in an app using Hermes
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | false     | false |
 
-# blocked by PLAT-6305
-@skip_gradle_7_or_higher
 Scenario: Plugin handles server failure gracefully
     When I set the HTTP status code to 500
     And I run the script "features/scripts/manual_upload_react_native.sh" synchronously
@@ -142,8 +126,6 @@ Scenario: Plugin handles server failure gracefully
         | 5              | 2.45.beta  | false     | false |
         | 5              | 2.45.beta  | false     | false |
 
-# blocked by PLAT-6305
-@skip_gradle_7_or_higher
 Scenario: Source maps are uploaded when assembling an app with a custom nodeModulesDir
     When I set environment variable "CUSTOM_NODE_MODULES_DIR" to "true"
     When I build the React Native app


### PR DESCRIPTION
## Goal

Enables the React Native E2E tests for AGP 4.2 by using Gradle 6.8. This circumvents a bug in the RN CLI that prevents use of older RN versions with Gradle 7.

The fixture in v7 will be updated to use Gradle 7 + RN 0.65.