### PR TITLE
Prevent exception when old Moshi version on buildScript classpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Prevent exception when old Moshi version on buildScript classpath
+  [#439](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/439)
+
 ## 5.8.0 (2021-09-20)
 
 * Address task dependency warning when using APK splits

--- a/src/main/kotlin/com/bugsnag/android/gradle/AndroidManifestInfo.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/AndroidManifestInfo.kt
@@ -16,8 +16,8 @@ data class AndroidManifestInfo(
     val buildUUID: String,
     val versionName: String,
     val applicationId: String,
-    val metaVersionCode: String? = null,
-    val metaVersionName: String? = null
+    val metaVersionCode: String?,
+    val metaVersionName: String?
 ) : Serializable {
     internal fun write(file: File) {
         file.sink().buffer().use {

--- a/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestInfoTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestInfoTest.kt
@@ -16,7 +16,9 @@ class AndroidManifestInfoTest {
         "12",
         "build-123",
         "5.2",
-        "com.example"
+        "com.example",
+        null,
+        null
     )
 
     private lateinit var jsonFile: File

--- a/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestParseUuidTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/AndroidManifestParseUuidTest.kt
@@ -18,7 +18,9 @@ class AndroidManifestParseUuidTest {
         "12",
         "build-uuid-123",
         "5.2",
-        "com.example"
+        "com.example",
+        null,
+        null
     )
 
     @Mock

--- a/src/test/kotlin/com/bugsnag/android/gradle/UploadRequestClientTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/UploadRequestClientTest.kt
@@ -11,7 +11,9 @@ class UploadRequestClientTest {
         "5",
         "build-uuid-123",
         "1.0",
-        "com.example"
+        "com.example",
+        null,
+        null
     )
 
     @Test


### PR DESCRIPTION
## Goal

v5.8.0 added default values in [these constructor parameters](https://github.com/bugsnag/bugsnag-android-gradle-plugin/compare/v5.7.8...v5.8.0#diff-a4be372f96043e6c0392999924c83bb6d09fc0eca56b59d9463d422e05c3e8f2R19), which compiled to bytecode results in two constructors. This results in Moshi generating a slightly different JsonAdapter class, which needs to use the `DEFAULT_CONSTRUCTOR_MARKER` field to try and find the correct ctor.

If a user has a plugin in the buildscript classpath which has a dependency on an old version of Moshi (<1.9.1) then the `DEFAULT_CONSTRUCTOR_MARKER` is not present, resulting in a `NoSuchFieldError` being thrown.

This fixes the issue by avoiding the use of default parameters. The end-user should also update any plugins using an old version of Moshi.

## Testing

Manually verified in an example app.