### PR TITLE
Fix task ordering for AGP 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Avoid registering the release task if minification is disabled, restoring the behaviour of v5.7.8
   [#443](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/443)
 
+* Fix task ordering for projects using AGP 3.*
+  [#441](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/441)
+
 ## 5.8.0 (2021-09-20)
 
 * Address task dependency warning when using APK splits


### PR DESCRIPTION
## Goal
Fix projects using Android Gradle Plugin 3.5 with Proguard by ensuring that our generation and upload tasks run after the main build process has been completed.

## Design
Due to how the Proguard `mapping.txt` is handled in AGP < 4 we need to manually enforce a task ordering to ensure that our Proguard generation and upload tasks run after the `mapping.txt` is actually generated.

## Testing
ReactNative Monorepo fixture configured for `enableProguardInReleaseBuilds`. Manual testing with various versions of AGP and ReactNative projects.