### PR TITLE
fix: alter task dependencies to avoid unnecessary APK generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Prevent exception when old Moshi version on buildScript classpath
   [#439](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/439)
 
+* Address task dependency warning when using APK splits
+  [#412](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/412)
+
 ## 7.1.0 (2021-09-20)
 
 * Custom Dexguard paths are resolved correctly (relative to the project)

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -525,7 +525,7 @@ class BugsnagPlugin : Plugin<Project> {
             val nodeModulesDir = bugsnag.nodeModulesDir.getOrElse(defaultLocation)
             val cliPath = File(nodeModulesDir, "@bugsnag/source-maps/bin/cli")
             bugsnagSourceMaps.set(cliPath)
-            mustRunAfter(rnTask)
+            dependsOn(rnTask)
         }
     }
 


### PR DESCRIPTION
## Goal

v7 PR for https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/412.

Alters task registration to avoid unnecessary creation of APKs and tasks.

## Changeset

The root cause of unnecessary APK generation is that BAGP registered tasks by adding task dependencies on `packageApplicationProvider` with `dependsOn()`, which eagerly configures the `PackageAndroidArtifact` task. Pre-AGP 4.1 this was harmless, but from AGP 4.1 onwards `PackageAndroidArtifact` includes an APK in its task outputs. This lead to unnecessary generation of an APK when customer apps ran `./gradlew bundleRelease`.

This changeset alters the task registration process so that only `mustRunAfter` is used, which avoids eager configuration of the `PackageAndroidArtifact` task. The React Native upload task also needed altering to have a `dependsOn` relationship with the `bundleJsAssets` task as a consequence of this change.

The `dependsOn` for the assemble/bundle task providers has also been altered to extract some code to a function, and to use a `configure` block to avoid eager configuration.

## Testing

Relied on existing E2E test coverage. Manually verified in an example app with AGP 4.2 that only a bundle is generated now when running `./gradlew bundleRelease`.