### PR TITLE
Fix FileAlreadyExistsException when using ReactNative & Hermes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+# Bug Fixes
+
+* Fix FileAlreadyExistsException errors when building ReactNative projects with Hermes
+  [#451](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/451)
+
 ## 5.8.1 (2021-09-23)
 
 * Prevent exception when old Moshi version on buildScript classpath

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
@@ -203,7 +203,7 @@ sealed class BugsnagUploadJsSourceMapTask @Inject constructor(
                 actions.add(
                     indexToInsert,
                     Action<Task> {
-                        rnSourceBundle.copyTo(rnRescuedSourceBundle)
+                        rnSourceBundle.copyTo(rnRescuedSourceBundle, overwrite = true)
                     }
                 )
 


### PR DESCRIPTION
## Goal
Fix [#1550](https://github.com/bugsnag/bugsnag-js/issues/1550) by ensuring that existing source-maps are overwritten instead of causing build failures.

## Testing
Tested manually by reproducing the error as described, and then testing that the fix no-longer causes the same issue. Instead the source maps are now overwritten and the new source maps are uploaded.