### PR TITLE
Fix "Task not found" failures when using DexGuard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Address task dependency warning when using APK splits
   [#412](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/412)
 
+* Fix "Task with name *** not found" errors when using custom build variants and DexGuard
+  [#452](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/452)
+
 ## 7.1.0 (2021-09-20)
 
 * Custom Dexguard paths are resolved correctly (relative to the project)

--- a/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
@@ -61,4 +61,24 @@ class GroovyCompat {
             return null
         }
     }
+
+    static boolean isDexguardEnabledForVariant(Project project, String variantName) {
+        def dexguard = project.extensions.findByName("dexguard")
+
+        try {
+            if (dexguard == null) {
+                return null
+            }
+
+            if (dexguard.configurations != null) {
+                return dexguard.configurations.findByName(variantName) != null
+            } else {
+                // no configurations = assume all variants configured
+                return true
+            }
+        } catch (MissingPropertyException ignored) {
+            // running earlier version of DexGuard, ignore missing property
+            return false
+        }
+    }
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -26,6 +26,7 @@ import com.bugsnag.android.gradle.internal.intermediateForNdkSoRequest
 import com.bugsnag.android.gradle.internal.intermediateForReleaseRequest
 import com.bugsnag.android.gradle.internal.intermediateForUnitySoRequest
 import com.bugsnag.android.gradle.internal.intermediateForUploadSourcemaps
+import com.bugsnag.android.gradle.internal.isDexguardEnabledForVariant
 import com.bugsnag.android.gradle.internal.isVariantEnabled
 import com.bugsnag.android.gradle.internal.newUploadRequestClientProvider
 import com.bugsnag.android.gradle.internal.register
@@ -346,10 +347,14 @@ class BugsnagPlugin : Plugin<Project> {
                 // DexGuard 9 runs as part of the bundle task supplied by AGP,
                 // so need to alter task dependency so that BAGP always runs
                 // after DexGuard
-                if (project.hasDexguardPlugin()) {
+                if (project.hasDexguardPlugin() && project.isDexguardEnabledForVariant(variant)) {
                     val taskName = getDexguardAabTaskName(variant)
-                    project.tasks.named(taskName).configure { dexguardTask ->
-                        generateProguardTaskProvider.get().mustRunAfter(dexguardTask)
+                    releaseUploadTask.configure {
+                        it.dependsOn(generateProguardTaskProvider)
+                    }
+
+                    generateProguardTaskProvider.configure {
+                        it.dependsOn(project.tasks.named(taskName))
                     }
                 }
             }

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
@@ -66,6 +66,15 @@ internal fun Project.hasDexguardPlugin(): Boolean {
 }
 
 /**
+ * Determine whether a specific variant is configured for DexGuard.
+ */
+internal fun Project.isDexguardEnabledForVariant(variant: BaseVariant): Boolean {
+    val flavor = variant.flavorName
+    val buildType = variant.buildType.name.capitalize()
+    return GroovyCompat.isDexguardEnabledForVariant(project, "$flavor$buildType")
+}
+
+/**
  * Retrieves the major version of DexGuard in use in the project
  */
 internal fun getDexguardMajorVersionInt(project: Project): Int {


### PR DESCRIPTION
## Goal
Fix [#444](https://github.com/bugsnag/bugsnag-android-gradle-plugin/issues/444) where builds with custom variants and DexGuard could fail with a "Task not found" error where limited build flavours where configured for DexGuard.

## Design
Check for variant level DexGuard configurations and if they exist: check each variant is configured in DexGuard before attempting to create an upload task for that variant.

## Testing
Manually tested with a known failing project.