### PR TITLE
AGP 7.2 support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,3 +55,15 @@ steps:
             - GRADLE_WRAPPER_VERSION=7.0.2
             - RN_FIXTURE_DIR=features/fixtures/rn065/android
           command: ['bundle', 'exec', 'maze-runner', '-c', '--verbose', '--fail-fast']
+
+  - label: ':android: AGP 7.2.0 E2E tests'
+    depends_on: 'agp-ci'
+    timeout_in_minutes: 60
+    plugins:
+        - docker-compose#v3.7.0:
+              run: android-gradle-plugin-ci
+              env:
+                  - AGP_VERSION=7.2.0
+                  - GRADLE_WRAPPER_VERSION=7.3.3
+                  - RN_FIXTURE_DIR=features/fixtures/rn065/android
+              command: ['bundle', 'exec', 'maze-runner', '-c', '--verbose', '--fail-fast']

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
 
-    ext.agpVersion = "7.0.0"
+    ext.agpVersion = "7.2.0"
     ext.kotlinVersion = "1.4.31"
 
     dependencies {

--- a/features/scripts/setup_gradle_wrapper.sh
+++ b/features/scripts/setup_gradle_wrapper.sh
@@ -3,42 +3,34 @@ set -ex
 
 export UPDATING_GRADLEW=true
 
-pushd "$APP_FIXTURE_DIR"
-echo "Updating gradle wrapper for: $APP_FIXTURE_DIR"
-./gradlew wrapper --gradle-version "$GRADLE_WRAPPER_VERSION"
-popd
+update_gradle_wrapper_properties () {
+    sed -i.bak -e "s/^distributionUrl.*$/distributionUrl=https\\\\:\/\/services.gradle.org\/distributions\/gradle-$GRADLE_WRAPPER_VERSION-bin.zip/" gradle/wrapper/gradle-wrapper.properties
+}
 
-pushd "$NDK_FIXTURE_DIR"
-echo "Updating gradle wrapper for: $NDK_FIXTURE_DIR"
-./gradlew wrapper --gradle-version "$GRADLE_WRAPPER_VERSION"
-popd
+update_gradle_wrapper_in () {
+    pushd "$1"
+    echo "Updating gradle wrapper for: $1"
+    update_gradle_wrapper_properties
+    popd
+}
+
+update_gradle_wrapper_in "$APP_FIXTURE_DIR"
+update_gradle_wrapper_in "$NDK_FIXTURE_DIR"
+update_gradle_wrapper_in "$UNITY_2018_FIXTURE_DIR"
+update_gradle_wrapper_in "$UNITY_2019_FIXTURE_DIR"
+update_gradle_wrapper_in "$LIB_FIXTURE_DIR"
 
 pushd "$RN_FIXTURE_DIR"
 echo "Updating gradle wrapper for: $RN_FIXTURE_DIR"
 npm i --silent
-./gradlew wrapper --gradle-version "$GRADLE_WRAPPER_VERSION"
+update_gradle_wrapper_properties
 popd
 
 pushd "$RN_MONOREPO_FIXTURE_DIR"
 echo "Updating gradle wrapper for: $RN_MONOREPO_FIXTURE_DIR"
 # The monorepo setup uses Yarn workspaces so we use Yarn over NPM here
 yarn install --silent
-./gradlew wrapper --gradle-version "$GRADLE_WRAPPER_VERSION"
-popd
-
-pushd "$UNITY_2018_FIXTURE_DIR"
-echo "Updating gradle wrapper for: $UNITY_2018_FIXTURE_DIR"
-./gradlew wrapper --gradle-version "$GRADLE_WRAPPER_VERSION"
-popd
-
-pushd "$UNITY_2019_FIXTURE_DIR"
-echo "Updating gradle wrapper for: $UNITY_2019_FIXTURE_DIR"
-./gradlew wrapper --gradle-version "$GRADLE_WRAPPER_VERSION"
-popd
-
-pushd "$LIB_FIXTURE_DIR"
-echo "Updating gradle wrapper for: $LIB_FIXTURE_DIR"
-./gradlew wrapper --gradle-version "$GRADLE_WRAPPER_VERSION"
+update_gradle_wrapper_properties
 popd
 
 unset UPDATING_GRADLEW

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/ExternalNativeBuildTaskUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/ExternalNativeBuildTaskUtil.kt
@@ -1,0 +1,29 @@
+package com.bugsnag.android.gradle.internal
+
+import com.android.build.gradle.tasks.ExternalNativeBuildTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import java.io.File
+import kotlin.reflect.full.memberProperties
+
+class ExternalNativeBuildTaskUtil(private val providerFactory: ProviderFactory) {
+    private fun getSearchDir(buildTask: Provider<ExternalNativeBuildTask>, propName: String): Provider<File> =
+        buildTask.flatMap { task ->
+            val soFolder = ExternalNativeBuildTask::class.memberProperties.find { it.name == propName }?.get(task)!!
+            when (soFolder) {
+                is File -> providerFactory.provider { fixNativeOutputPath(soFolder) }
+                is DirectoryProperty -> soFolder.map { fixNativeOutputPath(it.asFile) }
+                else -> throw IllegalArgumentException("Unknown type of ${propName}: $soFolder")
+            }
+        }
+
+    private fun fixNativeOutputPath(taskFolder: File): File {
+        return taskFolder.parentFile.parentFile.takeIf { it.parentFile.name == "cxx" } ?: taskFolder
+    }
+
+    fun findSearchPaths(buildTask: Provider<ExternalNativeBuildTask>) = arrayOf(
+        getSearchDir(buildTask, "objFolder"),
+        getSearchDir(buildTask, "soFolder")
+    )
+}

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/ExternalNativeBuildTaskUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/ExternalNativeBuildTaskUtil.kt
@@ -14,7 +14,7 @@ class ExternalNativeBuildTaskUtil(private val providerFactory: ProviderFactory) 
             when (soFolder) {
                 is File -> providerFactory.provider { fixNativeOutputPath(soFolder) }
                 is DirectoryProperty -> soFolder.map { fixNativeOutputPath(it.asFile) }
-                else -> throw IllegalArgumentException("Unknown type of ${propName}: $soFolder")
+                else -> throw IllegalArgumentException("Unknown type of $propName: $soFolder")
             }
         }
 


### PR DESCRIPTION
## Goal
Basic support for Android Gradle Plugin 7.2.

## Design
`ExternalNativeBuildTask.soFolder` and `objFolder` return `File` in AGP 7.0 and `DirectoryProperty` in 7.2. To work around this we now use reflection on these properties and handle either case based on the returned value.

This PR also includes a change to the test fixture, using `sed` to alter the `gradle-wrapper.properties` avoiding versioning problems with the `gradle wrapper` task (which can have conflicts between the Gradle version and AGP version intended to be tested).

## Testing
New test pipeline for AGP 7.2 using existing fixtures.