### PR TITLE
Emit an error if the `bundle*JsAndAssets` task cant be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Emit an error if the ReactNative bundle task cannot be found instead of silently failing
+  [#470](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/470)
+
 ## 7.2.1 (2022-05-24)
 
 * Support for AGP 7.2

--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,12 @@ detekt {
     }
 }
 
+ktlint {
+    filter {
+        exclude { element -> element.file.path.contains("/generated/") }
+    }
+}
+
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 // see https://github.com/asciidoctor/asciidoctorj/pull/862

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -502,7 +502,12 @@ class BugsnagPlugin : Plugin<Project> {
         // lookup the react-native task by its name
         // https://github.com/facebook/react-native/blob/master/react.gradle#L132
         val rnTaskName = "bundle${variant.name.capitalize()}JsAndAssets"
-        val rnTask: Task = project.tasks.findByName(rnTaskName) ?: return null
+        val rnTask: Task? = project.tasks.findByName(rnTaskName)
+        if (rnTask == null) {
+            project.logger.error("Bugsnag: unable to find ReactNative bundle task '$rnTaskName'")
+            return null
+        }
+
         val rnSourceMap = findReactNativeSourcemapFile(project, variant)
         val rnBundle =
             BugsnagUploadJsSourceMapTask.findReactNativeTaskArg(rnTask, "--bundle-output")


### PR DESCRIPTION
## Goal
Emit an error if the ReactNative "bundle" task cannot be found instead of failing silently, as this implies a misconfigured ReactNative project and the result would be that the build passes with no sourcemap being uploaded.

## Testing
Manually tested and relied on existing tests