### PR TITLE
Don't fail Expo / EAS builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Emit an error if the ReactNative bundle task cannot be found instead of silently failing
   [#470](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/470)
+* Do not fail builds for Expo apps, which do not depend on `@bugsnag/react-native`
+  [#471](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/471)
 
 ## 7.2.1 (2022-05-24)
 


### PR DESCRIPTION
## Goal
Don't fail builds for Expo applications, which are ReactNative applications but don't depend on `@bugsnag/react-native`.

## Testing
Tested manually with Expo project, new end-to-end tests will be added once our Expo integration uses the `bugsnag-android-gradle-plugin`.