### PR TITLE
Move task registration from Plugin to Task

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -4,7 +4,6 @@
   <CurrentIssues>
     <ID>ComplexCondition:AndroidManifestParser.kt$AndroidManifestParser$apiKey == null || "" == apiKey || versionCode == null || buildUuid == null || versionName == null || applicationId == null</ID>
     <ID>ComplexCondition:BugsnagPlugin.kt$BugsnagPlugin$!jvmMinificationEnabled &amp;&amp; !ndkEnabled &amp;&amp; !unityEnabled &amp;&amp; !reactNativeEnabled</ID>
-    <ID>LargeClass:BugsnagPlugin.kt$BugsnagPlugin : Plugin</ID>
     <ID>MagicNumber:BugsnagPluginExtension.kt$BugsnagPluginExtension$60000</ID>
     <ID>MagicNumber:BugsnagReleasesTask.kt$BugsnagReleasesTask$200</ID>
     <ID>MagicNumber:MappingFileProvider.kt$9</ID>

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -4,6 +4,7 @@
   <CurrentIssues>
     <ID>ComplexCondition:AndroidManifestParser.kt$AndroidManifestParser$apiKey == null || "" == apiKey || versionCode == null || buildUuid == null || versionName == null || applicationId == null</ID>
     <ID>ComplexCondition:BugsnagPlugin.kt$BugsnagPlugin$!jvmMinificationEnabled &amp;&amp; !ndkEnabled &amp;&amp; !unityEnabled &amp;&amp; !reactNativeEnabled</ID>
+    <ID>LongParameterList:BugsnagGenerateNdkSoMappingTask.kt$BugsnagGenerateNdkSoMappingTask.Companion$( project: Project, variant: BaseVariant, output: ApkVariantOutput, objdumpPaths: Provider&lt;Map&lt;String, String>>, searchPaths: List&lt;File>, soMappingOutputPath: String )</ID>
     <ID>MagicNumber:BugsnagPluginExtension.kt$BugsnagPluginExtension$60000</ID>
     <ID>MagicNumber:BugsnagReleasesTask.kt$BugsnagReleasesTask$200</ID>
     <ID>MagicNumber:MappingFileProvider.kt$9</ID>

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
@@ -3,8 +3,8 @@ package com.bugsnag.android.gradle
 import com.android.build.VariantOutput
 import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.api.BaseVariant
-import com.bugsnag.android.gradle.internal.BugsnagTaskCompanion
 import com.bugsnag.android.gradle.internal.ExternalNativeBuildTaskUtil
+import com.bugsnag.android.gradle.internal.VariantTaskCompanion
 import com.bugsnag.android.gradle.internal.clearDir
 import com.bugsnag.android.gradle.internal.dependsOn
 import com.bugsnag.android.gradle.internal.forBuildOutput
@@ -114,7 +114,7 @@ open class BugsnagGenerateNdkSoMappingTask @Inject constructor(
         }
     }
 
-    companion object : BugsnagTaskCompanion<BugsnagGenerateNdkSoMappingTask> {
+    companion object : VariantTaskCompanion<BugsnagGenerateNdkSoMappingTask> {
 
         /**
          * SO files which should be ignored by the NDK upload task. These are Unity

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateProguardTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateProguardTask.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.BaseVariantOutput
-import com.bugsnag.android.gradle.internal.BugsnagTaskCompanion
+import com.bugsnag.android.gradle.internal.VariantTaskCompanion
 import com.bugsnag.android.gradle.internal.dependsOn
 import com.bugsnag.android.gradle.internal.forBuildOutput
 import com.bugsnag.android.gradle.internal.intermediateForGenerateJvmMapping
@@ -73,7 +73,7 @@ open class BugsnagGenerateProguardTask @Inject constructor(
         return mappingFile
     }
 
-    companion object : BugsnagTaskCompanion<BugsnagGenerateProguardTask> {
+    companion object : VariantTaskCompanion<BugsnagGenerateProguardTask> {
         override fun taskNameFor(variantOutputName: String) = "generateBugsnag${variantOutputName.capitalize()}Mapping"
 
         fun archiveOutputFile(project: Project, output: BaseVariantOutput): Provider<RegularFile> =

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.ApkVariantOutput
-import com.bugsnag.android.gradle.internal.BugsnagTaskCompanion
+import com.bugsnag.android.gradle.internal.VariantTaskCompanion
 import com.bugsnag.android.gradle.internal.clearDir
 import com.bugsnag.android.gradle.internal.dependsOn
 import com.bugsnag.android.gradle.internal.forBuildOutput
@@ -197,7 +197,7 @@ internal open class BugsnagGenerateUnitySoMappingTask @Inject constructor(
         } ?: emptyList()
     }
 
-    companion object : BugsnagTaskCompanion<BugsnagGenerateUnitySoMappingTask> {
+    companion object : VariantTaskCompanion<BugsnagGenerateUnitySoMappingTask> {
 
         fun register(
             project: Project,

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagManifestUuidTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagManifestUuidTask.kt
@@ -1,10 +1,16 @@
 package com.bugsnag.android.gradle
 
+import com.android.build.gradle.api.BaseVariantOutput
+import com.bugsnag.android.gradle.internal.BugsnagTaskCompanion
+import com.bugsnag.android.gradle.internal.forBuildOutput
 import com.bugsnag.android.gradle.internal.property
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
@@ -61,5 +67,13 @@ abstract class BugsnagManifestUuidTask @Inject constructor(
 
     fun writeManifestInfo(info: AndroidManifestInfo) {
         info.write(manifestInfoProvider.get().asFile)
+    }
+
+    companion object : BugsnagTaskCompanion<BugsnagManifestUuidTask> {
+        fun manifestInfoForOutput(project: Project, output: BaseVariantOutput): Provider<RegularFile> =
+            forBuildOutput(project, output).flatMap { it.manifestInfoProvider }
+
+        override fun taskNameFor(variantOutputName: String): String =
+            "processBugsnag${variantOutputName.capitalize()}Manifest"
     }
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagManifestUuidTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagManifestUuidTask.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android.gradle
 
 import com.android.build.gradle.api.BaseVariantOutput
-import com.bugsnag.android.gradle.internal.BugsnagTaskCompanion
+import com.bugsnag.android.gradle.internal.VariantTaskCompanion
 import com.bugsnag.android.gradle.internal.forBuildOutput
 import com.bugsnag.android.gradle.internal.property
 import org.gradle.api.DefaultTask
@@ -69,7 +69,7 @@ abstract class BugsnagManifestUuidTask @Inject constructor(
         info.write(manifestInfoProvider.get().asFile)
     }
 
-    companion object : BugsnagTaskCompanion<BugsnagManifestUuidTask> {
+    companion object : VariantTaskCompanion<BugsnagManifestUuidTask> {
         fun manifestInfoForOutput(project: Project, output: BaseVariantOutput): Provider<RegularFile> =
             forBuildOutput(project, output).flatMap { it.manifestInfoProvider }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -586,6 +586,9 @@ class BugsnagPlugin : Plugin<Project> {
         return BugsnagUploadSharedObjectTask.register(project, taskName) {
             // upload task requires SO mapping generation to occur first
             this.dependsOn(generateTaskProvider)
+            this.usesService(httpClientHelperProvider)
+            this.usesService(ndkUploadClientProvider)
+
             this.requestOutputFile.set(requestOutputFile)
             this.uploadType.set(uploadType)
             projectRoot.set(bugsnag.projectRoot.getOrElse(project.projectDir.toString()))
@@ -612,6 +615,9 @@ class BugsnagPlugin : Plugin<Project> {
         val taskName = taskNameForUploadRelease(output)
         val requestOutputFile = intermediateForReleaseRequest(project, output)
         return BugsnagReleasesTask.register(project, taskName) {
+            usesService(httpClientHelperProvider)
+            usesService(releasesUploadClientProvider)
+
             this.requestOutputFile.set(requestOutputFile)
             httpClientHelper.set(httpClientHelperProvider)
             retryCount.set(bugsnag.retryCount)

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -7,7 +7,6 @@ import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
-import com.android.build.gradle.api.LibraryVariantOutput
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.bugsnag.android.gradle.BugsnagInstallJniLibsTask.Companion.resolveBugsnagArtifacts
 import com.bugsnag.android.gradle.internal.AgpVersions
@@ -23,9 +22,7 @@ import com.bugsnag.android.gradle.internal.getDexguardAabTaskName
 import com.bugsnag.android.gradle.internal.hasDexguardPlugin
 import com.bugsnag.android.gradle.internal.intermediateForGenerateJvmMapping
 import com.bugsnag.android.gradle.internal.intermediateForMappingFileRequest
-import com.bugsnag.android.gradle.internal.intermediateForNdkSoRequest
 import com.bugsnag.android.gradle.internal.intermediateForReleaseRequest
-import com.bugsnag.android.gradle.internal.intermediateForUnitySoRequest
 import com.bugsnag.android.gradle.internal.intermediateForUploadSourcemaps
 import com.bugsnag.android.gradle.internal.isDexguardEnabledForVariant
 import com.bugsnag.android.gradle.internal.isVariantEnabled
@@ -34,10 +31,8 @@ import com.bugsnag.android.gradle.internal.register
 import com.bugsnag.android.gradle.internal.registerV2ManifestUuidTask
 import com.bugsnag.android.gradle.internal.taskNameForManifestUuid
 import com.bugsnag.android.gradle.internal.taskNameForUploadJvmMapping
-import com.bugsnag.android.gradle.internal.taskNameForUploadNdkMapping
 import com.bugsnag.android.gradle.internal.taskNameForUploadRelease
 import com.bugsnag.android.gradle.internal.taskNameForUploadSourcemaps
-import com.bugsnag.android.gradle.internal.taskNameForUploadUnityMapping
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -89,16 +84,12 @@ class BugsnagPlugin : Plugin<Project> {
             )
         }
 
-        // After Gradle 5.2, this can use service injection for injecting ObjectFactory
-        val bugsnag = project.extensions.create(
-            "bugsnag",
-            BugsnagPluginExtension::class.java,
-            project.objects
-        )
+        val bugsnag = project.extensions.create("bugsnag", BugsnagPluginExtension::class.java)
 
         if (!bugsnag.enabled.get()) {
             return
         }
+
         runCatching {
             val android = project.extensions.getByType(BaseExtension::class.java)
 
@@ -259,16 +250,14 @@ class BugsnagPlugin : Plugin<Project> {
             }
             val uploadNdkMappingProvider = when {
                 ndkEnabled && generateNdkMappingProvider != null -> {
-                    registerUploadNdkTask(
+                    BugsnagUploadSharedObjectTask.registerUploadNdkTask(
                         project,
                         output,
-                        bugsnag,
                         httpClientHelperProvider,
-                        manifestInfoProvider,
                         ndkUploadClientProvider,
                         generateNdkMappingProvider,
                         ndkSoMappingOutput
-                    ).dependsOn(manifestTaskProvider)
+                    )
                 }
                 else -> null
             }
@@ -288,16 +277,14 @@ class BugsnagPlugin : Plugin<Project> {
             }
             val uploadUnityMappingProvider = when {
                 unityEnabled && generateUnityMappingProvider != null -> {
-                    registerUploadUnityTask(
+                    BugsnagUploadSharedObjectTask.registerUploadUnityTask(
                         project,
                         output,
-                        bugsnag,
                         httpClientHelperProvider,
-                        manifestInfoProvider,
                         unityUploadClientProvider,
                         generateUnityMappingProvider,
                         unityMappingDir
-                    ).dependsOn(manifestTaskProvider)
+                    )
                 }
                 else -> null
             }
@@ -520,87 +507,6 @@ class BugsnagPlugin : Plugin<Project> {
     }
 
     @Suppress("LongParameterList")
-    private fun registerUploadNdkTask(
-        project: Project,
-        output: BaseVariantOutput,
-        bugsnag: BugsnagPluginExtension,
-        httpClientHelperProvider: Provider<out BugsnagHttpClientHelper>,
-        manifestInfoProvider: Provider<RegularFile>,
-        ndkUploadClientProvider: Provider<out UploadRequestClient>,
-        generateTaskProvider: TaskProvider<out BugsnagGenerateNdkSoMappingTask>,
-        soMappingOutputDir: String
-    ): TaskProvider<out BugsnagUploadSharedObjectTask> {
-        return registerSharedObjectUploadTask(
-            project,
-            generateTaskProvider,
-            bugsnag,
-            httpClientHelperProvider,
-            manifestInfoProvider,
-            ndkUploadClientProvider,
-            taskNameForUploadNdkMapping(output),
-            intermediateForNdkSoRequest(project, output),
-            BugsnagUploadSharedObjectTask.UploadType.NDK,
-            soMappingOutputDir
-        )
-    }
-
-    @Suppress("LongParameterList")
-    private fun registerUploadUnityTask(
-        project: Project,
-        output: BaseVariantOutput,
-        bugsnag: BugsnagPluginExtension,
-        httpClientHelperProvider: Provider<out BugsnagHttpClientHelper>,
-        manifestInfoProvider: Provider<RegularFile>,
-        ndkUploadClientProvider: Provider<out UploadRequestClient>,
-        generateTaskProvider: TaskProvider<out BugsnagGenerateUnitySoMappingTask>,
-        mappingFileOutputDir: String
-    ): TaskProvider<out BugsnagUploadSharedObjectTask> {
-        return registerSharedObjectUploadTask(
-            project,
-            generateTaskProvider,
-            bugsnag,
-            httpClientHelperProvider,
-            manifestInfoProvider,
-            ndkUploadClientProvider,
-            taskNameForUploadUnityMapping(output),
-            intermediateForUnitySoRequest(project, output),
-            BugsnagUploadSharedObjectTask.UploadType.UNITY,
-            mappingFileOutputDir
-        )
-    }
-
-    @Suppress("LongParameterList")
-    private fun registerSharedObjectUploadTask(
-        project: Project,
-        generateTaskProvider: TaskProvider<out Task>,
-        bugsnag: BugsnagPluginExtension,
-        httpClientHelperProvider: Provider<out BugsnagHttpClientHelper>,
-        manifestInfoProvider: Provider<RegularFile>,
-        ndkUploadClientProvider: Provider<out UploadRequestClient>,
-        taskName: String,
-        requestOutputFile: Provider<RegularFile>,
-        uploadType: BugsnagUploadSharedObjectTask.UploadType,
-        intermediateOutputPath: String
-    ): TaskProvider<BugsnagUploadSharedObjectTask> {
-        // Create a Bugsnag task to upload NDK mapping file(s)
-        return BugsnagUploadSharedObjectTask.register(project, taskName) {
-            // upload task requires SO mapping generation to occur first
-            this.dependsOn(generateTaskProvider)
-            this.usesService(httpClientHelperProvider)
-            this.usesService(ndkUploadClientProvider)
-
-            this.requestOutputFile.set(requestOutputFile)
-            this.uploadType.set(uploadType)
-            projectRoot.set(bugsnag.projectRoot.getOrElse(project.projectDir.toString()))
-            httpClientHelper.set(httpClientHelperProvider)
-            manifestInfo.set(manifestInfoProvider)
-            uploadRequestClient.set(ndkUploadClientProvider)
-            intermediateOutputDir.set(project.layout.buildDirectory.dir(intermediateOutputPath))
-            configureWith(bugsnag)
-        }
-    }
-
-    @Suppress("LongParameterList")
     private fun registerReleasesUploadTask(
         project: Project,
         variant: BaseVariant,
@@ -646,14 +552,6 @@ class BugsnagPlugin : Plugin<Project> {
                 }
             }
             configureMetadata()
-        }
-    }
-
-    private fun BaseVariantOutput.findVersionCode(): Int {
-        return when (this) {
-            is LibraryVariantOutput
-            -> throw IllegalStateException("Library modules not currently supported as they have no versionCode")
-            else -> versionCode
         }
     }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
@@ -12,6 +12,7 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.util.ConfigureUtil
 import java.io.File
+import java.util.Locale
 
 // To make kotlin happy with gradle's nullability
 private val NULL_STRING: String? = null
@@ -96,7 +97,7 @@ open class BugsnagPluginExtension(objects: ObjectFactory) {
     }
 
     internal var filter: Action<VariantFilter> = Action {
-        if (it.name.toLowerCase().contains("debug")) {
+        if (it.name.toLowerCase(Locale.ENGLISH).contains("debug")) {
             it.setEnabled(false)
         }
     }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
@@ -13,6 +13,7 @@ import org.gradle.api.provider.Property
 import org.gradle.util.ConfigureUtil
 import java.io.File
 import java.util.Locale
+import javax.inject.Inject
 
 // To make kotlin happy with gradle's nullability
 private val NULL_STRING: String? = null
@@ -24,8 +25,7 @@ internal const val UPLOAD_ENDPOINT_DEFAULT: String = "https://upload.bugsnag.com
 /**
  * Defines configuration options (Gradle plugin extensions) for the BugsnagPlugin
  */
-// After Gradle 5.2, this can use service injection for injecting ObjectFactory
-open class BugsnagPluginExtension(objects: ObjectFactory) {
+open class BugsnagPluginExtension @Inject constructor(objects: ObjectFactory) {
 
     val sourceControl: SourceControl = objects.newInstance()
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadSharedObjectTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadSharedObjectTask.kt
@@ -26,7 +26,7 @@ import javax.inject.Inject
  * Task that uploads shared object mapping files to Bugsnag.
  */
 internal open class BugsnagUploadSharedObjectTask @Inject constructor(
-    objects: ObjectFactory
+    objects: ObjectFactory,
 ) : DefaultTask(), AndroidManifestInfoReceiver, BugsnagFileUploadTask {
 
     enum class UploadType(private val path: String, val uploadKey: String) {

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagTaskCompanion.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagTaskCompanion.kt
@@ -1,0 +1,36 @@
+package com.bugsnag.android.gradle.internal
+
+import com.android.build.api.variant.VariantOutput
+import com.android.build.api.variant.impl.VariantOutputImpl
+import com.android.build.gradle.api.BaseVariantOutput
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.TaskProvider
+
+internal interface BugsnagTaskCompanion<T : Task> {
+    fun taskNameFor(variantOutputName: String): String
+    fun taskNameFor(output: BaseVariantOutput): String = taskNameFor(output.name)
+    fun taskNameFor(output: VariantOutput): String =
+        taskNameFor((output as VariantOutputImpl).baseName)
+}
+
+internal inline fun <reified T : Task> BugsnagTaskCompanion<T>.register(
+    project: Project,
+    output: BaseVariantOutput,
+    noinline configure: T.() -> Unit
+) = project.tasks.register(taskNameFor(output), configure)
+
+internal inline fun <reified T : Task> BugsnagTaskCompanion<T>.register(
+    project: Project,
+    output: VariantOutput,
+    noinline configure: T.() -> Unit
+) = project.tasks.register(taskNameFor(output), configure)
+
+internal inline fun <reified T : Task> BugsnagTaskCompanion<T>.forBuildOutput(
+    project: Project,
+    output: BaseVariantOutput
+): TaskProvider<T> {
+    return project.tasks
+        .withType(T::class.java)
+        .named(taskNameFor(output))
+}

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagTasks.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagTasks.kt
@@ -9,9 +9,6 @@ internal const val TASK_JNI_LIBS = "bugsnagInstallJniLibsTask"
 internal fun taskNameForUploadJvmMapping(output: BaseVariantOutput) =
     "uploadBugsnag${output.taskNameSuffix()}Mapping"
 
-internal fun taskNameForGenerateNdkMapping(output: BaseVariantOutput) =
-    "generateBugsnagNdk${output.taskNameSuffix()}Mapping"
-
 internal fun taskNameForGenerateUnityMapping(output: BaseVariantOutput) =
     "generateBugsnagUnity${output.taskNameSuffix()}Mapping"
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagTasks.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagTasks.kt
@@ -9,9 +9,6 @@ internal const val TASK_JNI_LIBS = "bugsnagInstallJniLibsTask"
 internal fun taskNameForUploadJvmMapping(output: BaseVariantOutput) =
     "uploadBugsnag${output.taskNameSuffix()}Mapping"
 
-internal fun taskNameForGenerateUnityMapping(output: BaseVariantOutput) =
-    "generateBugsnagUnity${output.taskNameSuffix()}Mapping"
-
 internal fun taskNameForUploadNdkMapping(output: BaseVariantOutput) =
     "uploadBugsnagNdk${output.taskNameSuffix()}Mapping"
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagTasks.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagTasks.kt
@@ -6,9 +6,6 @@ import com.android.build.gradle.api.BaseVariantOutput
 
 internal const val TASK_JNI_LIBS = "bugsnagInstallJniLibsTask"
 
-internal fun taskNameForGenerateJvmMapping(output: BaseVariantOutput) =
-    "generateBugsnag${output.taskNameSuffix()}Mapping"
-
 internal fun taskNameForUploadJvmMapping(output: BaseVariantOutput) =
     "uploadBugsnag${output.taskNameSuffix()}Mapping"
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/ManifestUuidTaskV2Compat.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/ManifestUuidTaskV2Compat.kt
@@ -48,17 +48,13 @@ internal fun createManifestUpdateTask(
     }
 
     check(variantOutput is VariantOutputImpl)
-    val taskName = taskNameForManifestUuid(variantOutput.baseName)
     val manifestInfoOutputFile = project.computeManifestInfoOutputV2(variantOutput.baseName)
     val buildUuidProvider = project.newUuidProvider()
-    return project.tasks.register(
-        taskName,
-        BugsnagManifestUuidTask::class.java
-    ) {
-        it.versionCode.set(variantOutput.versionCode)
-        it.versionName.set(variantOutput.versionName)
-        it.buildUuid.set(buildUuidProvider)
-        it.manifestInfoProvider.set(manifestInfoOutputFile)
+    return BugsnagManifestUuidTask.register(project, variantOutput) {
+        versionCode.set(variantOutput.versionCode)
+        versionName.set(variantOutput.versionName)
+        buildUuid.set(buildUuidProvider)
+        manifestInfoProvider.set(manifestInfoOutputFile)
     }
 }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/VariantTaskCompanion.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/VariantTaskCompanion.kt
@@ -7,26 +7,26 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
 
-internal interface BugsnagTaskCompanion<T : Task> {
+internal interface VariantTaskCompanion<T : Task> {
     fun taskNameFor(variantOutputName: String): String
     fun taskNameFor(output: BaseVariantOutput): String = taskNameFor(output.name)
     fun taskNameFor(output: VariantOutput): String =
         taskNameFor((output as VariantOutputImpl).baseName)
 }
 
-internal inline fun <reified T : Task> BugsnagTaskCompanion<T>.register(
+internal inline fun <reified T : Task> VariantTaskCompanion<T>.register(
     project: Project,
     output: BaseVariantOutput,
     noinline configure: T.() -> Unit
 ) = project.tasks.register(taskNameFor(output), configure)
 
-internal inline fun <reified T : Task> BugsnagTaskCompanion<T>.register(
+internal inline fun <reified T : Task> VariantTaskCompanion<T>.register(
     project: Project,
     output: VariantOutput,
     noinline configure: T.() -> Unit
 ) = project.tasks.register(taskNameFor(output), configure)
 
-internal inline fun <reified T : Task> BugsnagTaskCompanion<T>.forBuildOutput(
+internal inline fun <reified T : Task> VariantTaskCompanion<T>.forBuildOutput(
     project: Project,
     output: BaseVariantOutput
 ): TaskProvider<T> {

--- a/src/test/kotlin/com/bugsnag/android/gradle/UploadRequestClientTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/UploadRequestClientTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.gradle
 
-import com.bugsnag.android.gradle.internal.LegacyUploadRequestClient
+import com.bugsnag.android.gradle.internal.UploadRequestClient
+import org.gradle.api.services.BuildServiceParameters
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -18,7 +19,8 @@ class UploadRequestClientTest {
 
     @Test
     fun testRequestDiffVersionInfo() {
-        val client = LegacyUploadRequestClient()
+        val client = createTestRequestClient()
+
         var requestCount = 0
         val request = {
             requestCount += 1
@@ -31,7 +33,8 @@ class UploadRequestClientTest {
 
     @Test
     fun testRequestDiffPayload() {
-        val client = LegacyUploadRequestClient()
+        val client = createTestRequestClient()
+
         var requestCount = 0
         val request = {
             requestCount += 1
@@ -44,7 +47,8 @@ class UploadRequestClientTest {
 
     @Test
     fun testRequestSameInfo() {
-        val client = LegacyUploadRequestClient()
+        val client = createTestRequestClient()
+
         var requestCount = 0
         val request = {
             requestCount += 1
@@ -53,5 +57,9 @@ class UploadRequestClientTest {
         client.makeRequestIfNeeded(info, "{}".hashCode(), request)
         client.makeRequestIfNeeded(info, "{}".hashCode(), request)
         assertEquals(1, requestCount)
+    }
+
+    private fun createTestRequestClient() = object : UploadRequestClient() {
+        override fun getParameters(): BuildServiceParameters.None = null!!
     }
 }


### PR DESCRIPTION
## Goal
Simplify the responsibility of the `BugsnagPlugin` by moving most of the task registration logic into the task companion objects.

## Changeset

* Tasks that deal with single variant-outputs have their registration and naming abstracted by `VariantTaskCompanion`
* The `BugsnagUploadSharedObjectTask` registration was also moved into its companion object
* Removed several legacy paths dealing with Gradle < 7

## Testing
Relied on existing tests