### PR TITLE
Upload .so files produced using objcopy

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -9,12 +9,11 @@
     <ID>MagicNumber:BugsnagReleasesTask.kt$BugsnagReleasesTask$200</ID>
     <ID>MagicNumber:MappingFileProvider.kt$9</ID>
     <ID>MaxLineLength:NdkToolchain.kt$NdkToolchain.Companion$/* * SdkComponents.ndkDirectory * https://developer.android.com/reference/tools/gradle-api/7.2/com/android/build/api/dsl/SdkComponents#ndkDirectory() * sometimes fails to resolve when ndkPath is not defined (Cannot query the value of this property because it has * no value available.). This means that even `map` and `isPresent` will break. * * So we also fall back use the old BaseExtension if it appears broken */</ID>
-    <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ @Suppress("SENSELESS_COMPARISON") internal fun isUnityLibraryUploadEnabled( bugsnag: BugsnagPluginExtension, android: BaseExtension ): Boolean</ID>
+    <ID>ReturnCount:BugsnagGenerateUnitySoMappingTask.kt$BugsnagGenerateUnitySoMappingTask.Companion$ @Suppress("SENSELESS_COMPARISON") internal fun isUnityLibraryUploadEnabled( bugsnag: BugsnagPluginExtension, android: BaseExtension ): Boolean</ID>
     <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ private fun registerUploadSourceMapTask( project: Project, variant: BaseVariant, output: BaseVariantOutput, bugsnag: BugsnagPluginExtension, manifestInfoProvider: Provider&lt;RegularFile> ): TaskProvider&lt;out BugsnagUploadJsSourceMapTask>?</ID>
     <ID>ReturnCount:ManifestUuidTaskV2Compat.kt$internal fun createManifestUpdateTask( bugsnag: BugsnagPluginExtension, project: Project, variantName: String, variantOutput: VariantOutput ): TaskProvider&lt;BugsnagManifestUuidTask>?</ID>
-    <ID>ReturnCount:NdkToolchain.kt$NdkToolchain.Companion$private fun getBugsnagAndroidNDKVersion(variant: ApkVariant): VersionNumber?</ID>
     <ID>SpreadOperator:DexguardCompat.kt$(buildDir, *path, variant.dirName, outputDir, "mapping.txt")</ID>
-    <ID>SwallowedException:NdkToolchain.kt$NdkToolchain.Companion$catch (e: Exception) { return null }</ID>
+    <ID>SwallowedException:NdkToolchain.kt$NdkToolchain.Companion$catch (e: Exception) { null }</ID>
     <ID>SwallowedException:NdkToolchain.kt$NdkToolchain.Companion$catch (e: Exception) { return@provider extensions.getByType(BaseExtension::class.java).ndkDirectory.absoluteFile }</ID>
     <ID>TooGenericExceptionCaught:AbstractSoMappingTask.kt$AbstractSoMappingTask$e: Exception</ID>
     <ID>TooGenericExceptionCaught:BugsnagHttpClientHelper.kt$exc: Throwable</ID>

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -8,14 +8,13 @@
     <ID>MagicNumber:BugsnagPluginExtension.kt$BugsnagPluginExtension$60000</ID>
     <ID>MagicNumber:BugsnagReleasesTask.kt$BugsnagReleasesTask$200</ID>
     <ID>MagicNumber:MappingFileProvider.kt$9</ID>
-    <ID>MagicNumber:NdkToolchain.kt$NdkToolchain$23</ID>
-    <ID>MagicNumber:NdkToolchain.kt$NdkToolchain.Companion$26</ID>
-    <ID>MagicNumber:NdkToolchain.kt$NdkToolchain.Companion$5</ID>
     <ID>MaxLineLength:NdkToolchain.kt$NdkToolchain.Companion$/* * SdkComponents.ndkDirectory * https://developer.android.com/reference/tools/gradle-api/7.2/com/android/build/api/dsl/SdkComponents#ndkDirectory() * sometimes fails to resolve when ndkPath is not defined (Cannot query the value of this property because it has * no value available.). This means that even `map` and `isPresent` will break. * * So we also fall back use the old BaseExtension if it appears broken */</ID>
     <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ @Suppress("SENSELESS_COMPARISON") internal fun isUnityLibraryUploadEnabled( bugsnag: BugsnagPluginExtension, android: BaseExtension ): Boolean</ID>
     <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ private fun registerUploadSourceMapTask( project: Project, variant: BaseVariant, output: BaseVariantOutput, bugsnag: BugsnagPluginExtension, manifestInfoProvider: Provider&lt;RegularFile> ): TaskProvider&lt;out BugsnagUploadJsSourceMapTask>?</ID>
     <ID>ReturnCount:ManifestUuidTaskV2Compat.kt$internal fun createManifestUpdateTask( bugsnag: BugsnagPluginExtension, project: Project, variantName: String, variantOutput: VariantOutput ): TaskProvider&lt;BugsnagManifestUuidTask>?</ID>
+    <ID>ReturnCount:NdkToolchain.kt$NdkToolchain.Companion$private fun getBugsnagAndroidNDKVersion(variant: ApkVariant): VersionNumber?</ID>
     <ID>SpreadOperator:DexguardCompat.kt$(buildDir, *path, variant.dirName, outputDir, "mapping.txt")</ID>
+    <ID>SwallowedException:NdkToolchain.kt$NdkToolchain.Companion$catch (e: Exception) { return null }</ID>
     <ID>SwallowedException:NdkToolchain.kt$NdkToolchain.Companion$catch (e: Exception) { return@provider extensions.getByType(BaseExtension::class.java).ndkDirectory.absoluteFile }</ID>
     <ID>TooGenericExceptionCaught:AbstractSoMappingTask.kt$AbstractSoMappingTask$e: Exception</ID>
     <ID>TooGenericExceptionCaught:BugsnagHttpClientHelper.kt$exc: Throwable</ID>

--- a/features/fixtures/config/ndk/objcopy.gradle
+++ b/features/fixtures/config/ndk/objcopy.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    implementation 'com.bugsnag:bugsnag-android:5.26.0'
+}
+
+android.ndkVersion = "23.0.7599858"
+bugsnag.useLegacyNdkSymbolUpload = false

--- a/features/fixtures/config/ndk/old_sdk_upload_failure.gradle
+++ b/features/fixtures/config/ndk/old_sdk_upload_failure.gradle
@@ -2,4 +2,5 @@ dependencies {
     implementation 'com.bugsnag:bugsnag-android:5.9.4'
 }
 
+android.ndkVersion = "23.0.7599858"
 bugsnag.useLegacyNdkSymbolUpload = true

--- a/features/ndk_app.feature
+++ b/features/ndk_app.feature
@@ -90,3 +90,22 @@ Scenario: Mapping fails when using obcopy and an incompatible SDK
     When I build the NDK app using the "old_sdk_upload_failure" config
     And I wait for 3 seconds
     Then I should receive no requests
+
+Scenario: objcopy is used to produce symbols when configured
+    When I build the NDK app using the "objcopy" config
+    And I wait to receive 6 builds
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 4 requests are valid for the android so symbol mapping API and match the following:
+        | projectRoot | sharedObjectName |
+        | /\S+/       | libnative-lib.so |
+        | /\S+/       | libnative-lib.so |
+        | /\S+/       | libnative-lib.so |
+        | /\S+/       | libnative-lib.so |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | appId                      |
+        | com.bugsnag.android.ndkapp |

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -66,7 +66,7 @@ def setup_and_run_script(module_config, bugsnag_config, script_path, variant = n
 end
 
 When("I build the failing {string} on AGP {string} using the {string} bugsnag config") do |module_config, agp_version, bugsnag_config|
-steps %Q{
+  steps %Q{
     When I set environment variable "AGP_VERSION" to "#{agp_version}"
     And I build the failing "#{module_config}" using the "#{bugsnag_config}" bugsnag config
 }
@@ -197,6 +197,14 @@ end
 def valid_android_so_symbol_mapping_api?(request_body)
   valid_mapping_api?(request_body)
   assert_not_nil(request_body['soFile'])
+
+  gzipped_part = request_body['soFile']
+  archive = Zlib::GzipReader.new(StringIO.new(gzipped_part))
+
+  # check that decompressed this is a valid ELF file:
+  # https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
+  header = archive.read(4)
+  assert_equal("\x7f\x45\x4c\x46", header, 'not a valid ELF file')
 end
 
 def valid_android_unity_ndk_mapping_api?(request_body)

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -112,6 +112,16 @@ Then('{int} requests are valid for the android unity NDK mapping API and match t
   end
 end
 
+Then('{int} requests are valid for the android so symbol mapping API and match the following:') do |request_count, data_table|
+  requests = get_requests_with_field('build', 'soFile')
+  assert_equal(request_count, requests.length, 'Wrong number of android .so symbol mapping API requests')
+  Maze::Assertions::RequestSetAssertions.assert_requests_match requests, data_table
+
+  requests.each do |request|
+    valid_android_so_symbol_mapping_api?(request[:body])
+  end
+end
+
 Then('{int} requests are valid for the JS source map API and match the following:') do |request_count, data_table|
   requests = get_requests_with_field('build', 'sourceMap')
   assert_equal(request_count, requests.length, 'Wrong number of JS source map API requests')
@@ -174,16 +184,24 @@ end
 
 def valid_android_mapping_api?(request_body)
   valid_mapping_api?(request_body)
+  assert_not_nil(request_body['buildUUID'])
   assert_not_nil(request_body['proguard'])
 end
 
 def valid_android_ndk_mapping_api?(request_body)
   valid_mapping_api?(request_body)
+  assert_not_nil(request_body['buildUUID'])
   assert_not_nil(request_body['soSymbolFile'])
+end
+
+def valid_android_so_symbol_mapping_api?(request_body)
+  valid_mapping_api?(request_body)
+  assert_not_nil(request_body['soFile'])
 end
 
 def valid_android_unity_ndk_mapping_api?(request_body)
   valid_mapping_api?(request_body)
+  assert_not_nil(request_body['buildUUID'])
   assert_not_nil(request_body['soSymbolTableFile'])
 end
 
@@ -191,7 +209,6 @@ def valid_mapping_api?(request_body)
   assert_equal($api_key, request_body['apiKey'])
   assert_not_nil(request_body['appId'])
   assert_not_nil(request_body['versionCode'])
-  assert_not_nil(request_body['buildUUID'])
   assert_not_nil(request_body['versionName'])
 end
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/AndroidManifestInfoReceiver.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/AndroidManifestInfoReceiver.kt
@@ -1,10 +1,10 @@
 package com.bugsnag.android.gradle
 
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 
 interface AndroidManifestInfoReceiver {
-    @get:Input
+    @get:InputFile
     val manifestInfo: RegularFileProperty
 }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagFileUploadTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagFileUploadTask.kt
@@ -2,13 +2,26 @@ package com.bugsnag.android.gradle
 
 import com.bugsnag.android.gradle.internal.BugsnagHttpClientHelper
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 
 interface BugsnagFileUploadTask {
+    @get:Input
     val failOnUploadError: Property<Boolean>
+
+    @get:Input
     val overwrite: Property<Boolean>
+
+    @get:Input
     val endpoint: Property<String>
+
+    @get:Input
     val retryCount: Property<Int>
+
+    @get:Input
     val timeoutMillis: Property<Long>
+
+    @get:Internal
     val httpClientHelper: Property<BugsnagHttpClientHelper>
 
     fun configureWith(bugsnag: BugsnagPluginExtension) {

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -257,7 +257,8 @@ class BugsnagPlugin : Plugin<Project> {
                 else -> null
             }
             val uploadNdkMappingProvider = when {
-                ndkEnabled && generateNdkMappingProvider != null -> {
+                ndkEnabled && generateNdkMappingProvider != null
+                    && ndkToolchain.preferredMappingTool() == NdkToolchain.MappingTool.OBJDUMP -> {
                     BugsnagUploadSharedObjectTask.registerUploadNdkTask(
                         project,
                         output,
@@ -267,6 +268,14 @@ class BugsnagPlugin : Plugin<Project> {
                         ndkSoMappingOutput
                     )
                 }
+
+                ndkEnabled && generateNdkMappingProvider != null -> BugsnagUploadSoSymTask.register(
+                    project,
+                    output,
+                    generateNdkMappingProvider,
+                    httpClientHelperProvider,
+                    ndkUploadClientProvider
+                )
 
                 else -> null
             }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -203,7 +203,7 @@ class BugsnagPlugin : Plugin<Project> {
             }
             val jvmMinificationEnabled = project.isJvmMinificationEnabled(variant)
             val ndkEnabled = isNdkUploadEnabled(bugsnag, android)
-            val unityEnabled = isUnityLibraryUploadEnabled(bugsnag, android)
+            val unityEnabled = BugsnagGenerateUnitySoMappingTask.isUnityLibraryUploadEnabled(bugsnag, android)
             val reactNativeEnabled = isReactNativeUploadEnabled(bugsnag)
 
             // register bugsnag tasks
@@ -576,40 +576,13 @@ class BugsnagPlugin : Plugin<Project> {
         }
     }
 
-    /**
-     * Determines whether SO mapping files should be generated for the
-     * libunity.so file in Unity projects.
-     */
-    @Suppress("SENSELESS_COMPARISON")
-    internal fun isUnityLibraryUploadEnabled(
-        bugsnag: BugsnagPluginExtension,
-        android: BaseExtension
-    ): Boolean {
-        val enabled = bugsnag.uploadNdkUnityLibraryMappings.orNull
-        return when {
-            enabled != null -> enabled
-            else -> {
-                // workaround to avoid exception as noCompress was null until AGP 4.1
-                runCatching {
-                    val clz = android.aaptOptions.javaClass
-                    val method = clz.getMethod("getNoCompress")
-                    val noCompress = method.invoke(android.aaptOptions)
-                    if (noCompress is Collection<*>) {
-                        return noCompress.contains(".unity3d")
-                    }
-                }
-                return false
-            }
-        }
-    }
-
     internal fun isNdkUploadEnabled(
         bugsnag: BugsnagPluginExtension,
         android: BaseExtension
     ): Boolean {
         val usesCmake = android.externalNativeBuild.cmake.path != null
         val usesNdkBuild = android.externalNativeBuild.ndkBuild.path != null
-        val unityEnabled = isUnityLibraryUploadEnabled(bugsnag, android)
+        val unityEnabled = BugsnagGenerateUnitySoMappingTask.isUnityLibraryUploadEnabled(bugsnag, android)
         val default = usesCmake || usesNdkBuild || unityEnabled
         return bugsnag.uploadNdkMappings.getOrElse(default)
     }
@@ -634,7 +607,7 @@ class BugsnagPlugin : Plugin<Project> {
         android: BaseExtension
     ): List<File> {
         val searchPaths = bugsnag.sharedObjectPaths.get().toMutableList()
-        val unityEnabled = isUnityLibraryUploadEnabled(bugsnag, android)
+        val unityEnabled = BugsnagGenerateUnitySoMappingTask.isUnityLibraryUploadEnabled(bugsnag, android)
         val ndkEnabled = isNdkUploadEnabled(bugsnag, android)
 
         if (unityEnabled && ndkEnabled) {

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadProguardTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadProguardTask.kt
@@ -85,8 +85,9 @@ open class BugsnagUploadProguardTask @Inject constructor(
         val request = BugsnagMultiPartUploadRequest.from(this)
         val mappingFileHash = mappingFile.md5HashCode()
         val response = uploadRequestClient.get().makeRequestIfNeeded(manifestInfo, mappingFileHash) {
-            request.uploadMultipartEntity(manifestInfo, retryCount.get()) { builder ->
+            request.uploadMultipartEntity(retryCount.get()) { builder ->
                 logger.lifecycle("Bugsnag: Uploading JVM mapping file from: $mappingFile")
+                builder.addAndroidManifestInfo(manifestInfo)
                 builder.addFormDataPart("proguard", mappingFile.name, mappingFile.asRequestBody())
             }
         }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadSharedObjectTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadSharedObjectTask.kt
@@ -125,10 +125,10 @@ internal open class BugsnagUploadSharedObjectTask @Inject constructor(
         val mappingFileHash = mappingFile.md5HashCode()
         val response = uploadRequestClient.get().makeRequestIfNeeded(manifestInfo, mappingFileHash) {
             logger.lifecycle(
-                "Bugsnag: Uploading SO mapping file for " +
-                    "$sharedObjectName ($arch) from $mappingFile"
+                "Bugsnag: Uploading SO mapping file for $sharedObjectName ($arch) from $mappingFile"
             )
-            request.uploadMultipartEntity(manifestInfo, retryCount.get()) { builder ->
+            request.uploadMultipartEntity(retryCount.get()) { builder ->
+                builder.addAndroidManifestInfo(manifestInfo)
                 builder.addFormDataPart(soUploadKey, mappingFile.name, mappingFile.asRequestBody())
                 builder.addFormDataPart("arch", arch)
                 builder.addFormDataPart("sharedObjectName", sharedObjectName)

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadSoSymTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadSoSymTask.kt
@@ -1,0 +1,139 @@
+package com.bugsnag.android.gradle
+
+import com.android.build.gradle.api.BaseVariantOutput
+import com.bugsnag.android.gradle.internal.AbstractSoMappingTask
+import com.bugsnag.android.gradle.internal.BugsnagHttpClientHelper
+import com.bugsnag.android.gradle.internal.UploadRequestClient
+import com.bugsnag.android.gradle.internal.md5HashCode
+import com.bugsnag.android.gradle.internal.taskNameSuffix
+import okhttp3.RequestBody.Companion.asRequestBody
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.StopExecutionException
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+import java.io.File
+import java.net.HttpURLConnection.HTTP_NOT_FOUND
+
+abstract class BugsnagUploadSoSymTask : DefaultTask(), AndroidManifestInfoReceiver, BugsnagFileUploadTask {
+
+    @get:InputDirectory
+    abstract val symbolFilesDir: DirectoryProperty
+
+    @get:OutputFile
+    abstract val requestOutputFile: RegularFileProperty
+
+    @get:Input
+    abstract val projectRoot: Property<String>
+
+    @get:Internal
+    internal abstract val uploadRequestClient: Property<UploadRequestClient>
+
+    init {
+        group = BugsnagPlugin.GROUP_NAME
+        description = "Uploads SO Symbol files to Bugsnag"
+    }
+
+    @TaskAction
+    fun upload() {
+        val rootDir = symbolFilesDir.asFile.get()
+        logger.info("Bugsnag: Found shared object files for upload: $rootDir")
+        rootDir.walkTopDown()
+            .filter { it.isFile && it.extension == "gz" && it.length() >= VALID_SO_FILE_THRESHOLD }
+            .forEach { uploadSymbols(it) }
+    }
+
+    /**
+     * Uploads the given shared object mapping information
+     * @param mappingFile the file to upload
+     */
+    private fun uploadSymbols(mappingFile: File) {
+        val sharedObjectName = mappingFile.nameWithoutExtension
+        val requestEndpoint = endpoint.get() + ENDPOINT_SUFFIX
+
+        val request = BugsnagMultiPartUploadRequest.from(this, requestEndpoint)
+        val manifestInfo = parseManifestInfo()
+        val mappingFileHash = mappingFile.md5HashCode()
+
+        val response = uploadRequestClient.get().makeRequestIfNeeded(manifestInfo, mappingFileHash) {
+            logger.lifecycle("Bugsnag: Uploading SO mapping file from $mappingFile")
+            val body = request.createMultipartBody { builder ->
+                builder
+                    .addFormDataPart("apiKey", manifestInfo.apiKey)
+                    .addFormDataPart("appId", manifestInfo.applicationId)
+                    .addFormDataPart("versionCode", manifestInfo.versionCode)
+                    .addFormDataPart("versionName", manifestInfo.versionName)
+                    .addFormDataPart("soFile", mappingFile.name, mappingFile.asRequestBody())
+                    .addFormDataPart("sharedObjectName", sharedObjectName)
+                    .addFormDataPart("projectRoot", projectRoot.get())
+            }
+
+            request.uploadRequest(body) { response ->
+                if (response.code == HTTP_NOT_FOUND && endpoint.get() != UPLOAD_ENDPOINT_DEFAULT) {
+                    throw StopExecutionException(
+                        "Bugsnag instance does not support the new NDK symbols upload mechanism. " +
+                            "Please set legacyNDKSymbolsUpload or upgrade your Bugsnag instance. " +
+                            "See https://docs.bugsnag.com/api/ndk-symbol-mapping-upload/ for details."
+                    )
+                }
+
+                if (!response.isSuccessful) {
+                    "Failure"
+                } else {
+                    response.body!!.string()
+                }
+            }
+        }
+        requestOutputFile.asFile.get().writeText(response)
+    }
+
+    companion object {
+        private const val ENDPOINT_SUFFIX = "/ndk-symbol"
+
+        private const val VALID_SO_FILE_THRESHOLD = 1024
+
+        fun taskNameFor(variant: BaseVariantOutput) =
+            "uploadBugsnag${variant.baseName.capitalize()}Symbols"
+
+        internal fun requestOutputFileFor(project: Project, output: BaseVariantOutput): Provider<RegularFile> {
+            val path = "intermediates/bugsnag/requests/symFor${output.taskNameSuffix()}.json"
+            return project.layout.buildDirectory.file(path)
+        }
+
+        fun register(
+            project: Project,
+            variant: BaseVariantOutput,
+            generateTaskProvider: TaskProvider<out AbstractSoMappingTask>,
+            httpClientHelperProvider: Provider<out BugsnagHttpClientHelper>,
+            ndkUploadClientProvider: Provider<out UploadRequestClient>,
+        ): TaskProvider<BugsnagUploadSoSymTask> {
+            val bugsnag = project.extensions.getByType(BugsnagPluginExtension::class.java)
+            return project.tasks.register(taskNameFor(variant), BugsnagUploadSoSymTask::class.java) { task ->
+                task.dependsOn(generateTaskProvider)
+                task.usesService(httpClientHelperProvider)
+                task.usesService(ndkUploadClientProvider)
+
+                task.endpoint.set(bugsnag.endpoint)
+
+                task.manifestInfo.set(BugsnagManifestUuidTask.manifestInfoForOutput(project, variant))
+                task.symbolFilesDir.set(generateTaskProvider.flatMap { it.outputDirectory })
+                task.requestOutputFile.set(requestOutputFileFor(project, variant))
+                task.projectRoot.set(bugsnag.projectRoot.getOrElse(project.projectDir.toString()))
+
+                task.httpClientHelper.set(httpClientHelperProvider)
+                task.uploadRequestClient.set(ndkUploadClientProvider)
+
+                task.configureWith(bugsnag)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/NdkToolchain.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/NdkToolchain.kt
@@ -11,22 +11,10 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.util.VersionNumber
 import java.io.File
-
-private val osName = when {
-    Os.isFamily(Os.FAMILY_MAC) -> "darwin-x86_64"
-    Os.isFamily(Os.FAMILY_UNIX) -> "linux-x86_64"
-    Os.isFamily(Os.FAMILY_WINDOWS) -> {
-        when {
-            "x86" == System.getProperty("os.arch") -> "windows"
-            else -> "windows-x86_64"
-        }
-    }
-
-    else -> null
-}
 
 abstract class NdkToolchain {
     @get:Input
@@ -38,7 +26,38 @@ abstract class NdkToolchain {
     @get:Input
     abstract val overrides: MapProperty<Abi, String>
 
+    @get:Input
+    @get:Optional
+    abstract val bugsnagNdkVersion: Property<String>
+
     fun preferredMappingTool(): MappingTool {
+        var legacyUploadRequired = bugsnagNdkVersion.orNull
+            ?.let { VersionNumber.parse(it) }
+            ?.let { it < MIN_BUGSNAG_ANDROID_VERSION }
+        if (legacyUploadRequired == null) {
+//            logger.warn(
+//                "Cannot detect Bugsnag SDK version for variant ${variant.name}, assuming a modern version is " +
+//                    "being used. This can cause problems with NDK symbols if older versions are being used. " +
+//                    "Please either specify the Bugsnag SDK version for ${variant.name} directly." +
+//                    "See https://docs.bugsnag.com/api/ndk-symbol-mapping-upload/ for details."
+//            )
+
+            legacyUploadRequired = false
+        }
+
+        if (!useLegacyNdkSymbolUpload.get() && legacyUploadRequired) {
+            throw StopExecutionException(
+                "Your Bugsnag SDK configured for variant does not support the new NDK " +
+                    "symbols upload mechanism. Please set legacyNDKSymbolsUpload or upgrade your " +
+                    "Bugsnag SDK. See https://docs.bugsnag.com/api/ndk-symbol-mapping-upload/ for details."
+            )
+//            throw StopExecutionException(
+//                "Your Bugsnag SDK configured for variant ${variant.name} does not support the new NDK " +
+//                    "symbols upload mechanism. Please set legacyNDKSymbolsUpload or upgrade your " +
+//                    "Bugsnag SDK. See https://docs.bugsnag.com/api/ndk-symbol-mapping-upload/ for details."
+//            )
+        }
+
         // useLegacyNdkSymbolUpload force overrides any defaults or options
         if (useLegacyNdkSymbolUpload.get()) {
             return MappingTool.OBJDUMP
@@ -46,7 +65,7 @@ abstract class NdkToolchain {
 
         val ndkVersion = version.get()
         return when {
-            ndkVersion >= VersionNumber.version(23, 0) -> MappingTool.OBJCOPY
+            ndkVersion >= MIN_NDK_OBJCOPY_VERSION -> MappingTool.OBJCOPY
             else -> MappingTool.OBJDUMP
         }
     }
@@ -58,6 +77,7 @@ abstract class NdkToolchain {
         baseDir.set(other.baseDir)
         overrides.set(other.overrides)
         useLegacyNdkSymbolUpload.set(other.useLegacyNdkSymbolUpload)
+        bugsnagNdkVersion.set(other.bugsnagNdkVersion)
     }
 
     private fun executableName(cmdName: String): String {
@@ -75,12 +95,21 @@ abstract class NdkToolchain {
     }
 
     fun objcopyForAbi(abi: Abi): File {
-        val objdumpOverrides = overrides.get()
+        val objcopyOverrides = overrides.get()
 
-        return objdumpOverrides[abi]?.let { File(it) } ?: File(
-            baseDir.get(),
-            "toolchains/llvm/prebuilt/$osName/bin/${executableName("llvm-objcopy")}"
-        )
+        return objcopyOverrides[abi]?.let { File(it) }
+            ?: locateObjcopy(abi)
+    }
+
+    private fun locateObjcopy(abi: Abi): File {
+        val relativeExecutablePath = when {
+            isLLVMPreferred.get() -> "toolchains/llvm/prebuilt/$osName/bin/${executableName("llvm-objcopy")}"
+            else ->
+                "toolchains/${abi.toolchainPrefix}-4.9/prebuilt/" +
+                    "$osName/bin/${abi.objdumpPrefix}-${executableName("objcopy")}"
+        }
+
+        return File(baseDir.get(), relativeExecutablePath)
     }
 
     enum class MappingTool {
@@ -89,6 +118,35 @@ abstract class NdkToolchain {
     }
 
     companion object {
+        /**
+         * Minimum `bugsnag-android` version where the new symbol uploading is available, using `objcopy` to produce
+         * the symbol files instead of `objdump`
+         */
+        internal val MIN_BUGSNAG_ANDROID_VERSION = VersionNumber.version(5, 26)
+
+        /**
+         * The minimum NDK version where we will use `objcopy` instead of `objdump` to produce the symbol files
+         */
+        internal val MIN_NDK_OBJCOPY_VERSION = VersionNumber.version(21)
+
+        /**
+         * The minimum NDK version where we will use the LLVM toolchain instead of the GNU toolchain
+         */
+        internal val MIN_NDK_LLVM_VERSION = VersionNumber.version(23)
+
+        private val osName = when {
+            Os.isFamily(Os.FAMILY_MAC) -> "darwin-x86_64"
+            Os.isFamily(Os.FAMILY_UNIX) -> "linux-x86_64"
+            Os.isFamily(Os.FAMILY_WINDOWS) -> {
+                when {
+                    "x86" == System.getProperty("os.arch") -> "windows"
+                    else -> "windows-x86_64"
+                }
+            }
+
+            else -> null
+        }
+
         /*
          * SdkComponents.ndkDirectory
          * https://developer.android.com/reference/tools/gradle-api/7.2/com/android/build/api/dsl/SdkComponents#ndkDirectory()
@@ -110,13 +168,20 @@ abstract class NdkToolchain {
             }
         }
 
-        private fun isLegacyMappingRequired(variant: ApkVariant): Boolean? {
-            val bugsnagAndroidCoreVersion = variant.compileConfiguration.allDependencyConstraints
-                .find { it.group == "com.bugsnag" && it.name == "bugsnag-plugin-android-ndk" }
-                ?.version
-                ?: return null
+        private fun getBugsnagAndroidNDKVersion(variant: ApkVariant): String? {
+            try {
+                val bugsnagAndroidCoreVersion = variant.compileConfiguration.resolvedConfiguration.resolvedArtifacts
+                    .find {
+                        it.moduleVersion.id.group == "com.bugsnag" &&
+                            it.moduleVersion.id.name == "bugsnag-plugin-android-ndk"
+                    }
+                    ?.moduleVersion?.id?.version
+                    ?: return null
 
-            return VersionNumber.parse(bugsnagAndroidCoreVersion) < VersionNumber.version(5, 26)
+                return bugsnagAndroidCoreVersion
+            } catch (e: Exception) {
+                return null
+            }
         }
 
         fun configureNdkToolkit(
@@ -125,36 +190,18 @@ abstract class NdkToolchain {
             variant: ApkVariant
         ): NdkToolchain {
             val useLegacyNdkSymbolUpload = bugsnag.useLegacyNdkSymbolUpload.get()
-            var legacyUploadRequired = isLegacyMappingRequired(variant)
-
-            if (legacyUploadRequired == null) {
-                project.logger.warn(
-                    "Cannot detect Bugsnag SDK version for variant ${variant.name}, assuming a modern version is " +
-                        "being used. This can cause problems with NDK symbols if older versions are being used. " +
-                        "Please either specify the Bugsnag SDK version for ${variant.name} directly." +
-                        "See https://docs.bugsnag.com/api/ndk-symbol-mapping-upload/ for details."
-                )
-
-                legacyUploadRequired = false
-            }
-
-            if (!useLegacyNdkSymbolUpload && legacyUploadRequired) {
-                throw StopExecutionException(
-                    "Your Bugsnag SDK configured for variant ${variant.name} does not support the new NDK " +
-                        "symbols upload mechanism. Please set legacyNDKSymbolsUpload or upgrade your " +
-                        "Bugsnag SDK. See https://docs.bugsnag.com/api/ndk-symbol-mapping-upload/ for details."
-                )
-            }
-
             val overrides = bugsnag.objdumpPaths.map { it.mapKeys { (abi, _) -> Abi.findByName(abi)!! } }
+
             val ndkToolchain = project.objects.newInstance<NdkToolchain>()
             ndkToolchain.baseDir.set(ndkToolchainDirectoryFor(project))
             ndkToolchain.useLegacyNdkSymbolUpload.set(useLegacyNdkSymbolUpload)
             ndkToolchain.overrides.set(overrides)
+            ndkToolchain.bugsnagNdkVersion.set(project.provider { getBugsnagAndroidNDKVersion(variant) })
 
             return ndkToolchain
         }
     }
 }
 
-val NdkToolchain.version get() = baseDir.map { VersionNumber.parse(it.name) }
+private val NdkToolchain.version get() = baseDir.map { VersionNumber.parse(it.name) }
+private val NdkToolchain.isLLVMPreferred get() = version.map { it >= NdkToolchain.MIN_NDK_LLVM_VERSION }

--- a/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
@@ -79,7 +79,7 @@ class PluginExtensionTest {
 
         // ndk/unity upload defaults to false
         val plugin = proj.plugins.findPlugin(BugsnagPlugin::class.java)!!
-        assertFalse(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
+        assertFalse(BugsnagGenerateUnitySoMappingTask.isUnityLibraryUploadEnabled(bugsnag, android))
         assertFalse(plugin.isNdkUploadEnabled(bugsnag, android))
         assertFalse(plugin.isReactNativeUploadEnabled(bugsnag))
         assertEquals(emptyList<File>(), plugin.getSharedObjectSearchPaths(proj, bugsnag, android))
@@ -143,7 +143,7 @@ class PluginExtensionTest {
 
         // ndk/unity upload overridden to true
         val plugin = proj.plugins.findPlugin(BugsnagPlugin::class.java)!!
-        assertTrue(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
+        assertTrue(BugsnagGenerateUnitySoMappingTask.isUnityLibraryUploadEnabled(bugsnag, android))
         assertTrue(plugin.isNdkUploadEnabled(bugsnag, android))
         assertTrue(plugin.isReactNativeUploadEnabled(bugsnag))
         assertEquals("http://localhost:1234", bugsnag.endpoint.get())
@@ -168,7 +168,7 @@ class PluginExtensionTest {
         `when`(cmake.path).thenReturn(File("/users/sdk/cmake"))
 
         // ndk/unity upload overridden to true
-        assertTrue(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
+        assertTrue(BugsnagGenerateUnitySoMappingTask.isUnityLibraryUploadEnabled(bugsnag, android))
         assertTrue(plugin.isNdkUploadEnabled(bugsnag, android))
         val expected = listOf(
             File(proj.projectDir, "src/main/jniLibs"),
@@ -198,7 +198,7 @@ class PluginExtensionTest {
         `when`(aaptOptions.noCompress).thenReturn(mutableListOf(".unity3d"))
 
         // ndk/unity uploads overridden to true
-        assertTrue(plugin.isUnityLibraryUploadEnabled(bugsnag, android))
+        assertTrue(BugsnagGenerateUnitySoMappingTask.isUnityLibraryUploadEnabled(bugsnag, android))
         assertTrue(plugin.isNdkUploadEnabled(bugsnag, android))
         val expected = listOf(
             File(proj.projectDir, "src/main/jniLibs"),

--- a/src/test/kotlin/com/bugsnag/android/gradle/internal/NdkToolchainTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/internal/NdkToolchainTest.kt
@@ -1,0 +1,104 @@
+package com.bugsnag.android.gradle.internal
+
+import com.bugsnag.android.gradle.Abi
+import org.gradle.api.Transformer
+import org.gradle.api.internal.provider.DefaultProvider
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import java.io.File
+import org.mockito.Mockito.`when` as whenMock
+
+class NdkToolchainTest {
+    @Test
+    fun ndk19() {
+        val toolchain = TestNdkToolchainImpl(File("/19.2.5345600/"), true)
+        assertEquals(NdkToolchain.MappingTool.OBJDUMP, toolchain.preferredMappingTool())
+    }
+
+    @Test
+    fun ndk21Legacy() {
+        val toolchain = TestNdkToolchainImpl(File("/21.1.6352462/"), true)
+        assertEquals(NdkToolchain.MappingTool.OBJDUMP, toolchain.preferredMappingTool())
+    }
+
+    @Test
+    fun ndk21() {
+        val toolchain = TestNdkToolchainImpl(File("/21.1.6352462/"), false)
+        assertEquals(NdkToolchain.MappingTool.OBJCOPY, toolchain.preferredMappingTool())
+
+        val objcopyPath = toolchain.objcopyForAbi(Abi.ARM64_V8A).toString()
+        assertTrue(
+            "expected GNU objcopy path, but got: $objcopyPath",
+            objcopyPath.contains("/aarch64-linux-android-objcopy")
+        )
+    }
+
+    @Test
+    fun ndk23() {
+        val toolchain = TestNdkToolchainImpl(File("/23.0.7599858/"), false)
+        assertEquals(NdkToolchain.MappingTool.OBJCOPY, toolchain.preferredMappingTool())
+
+        val objcopyPath = toolchain.objcopyForAbi(Abi.ARM64_V8A).toString()
+        assertTrue(
+            "expected LLVM objcopy, but got: $objcopyPath",
+            objcopyPath.contains("/llvm-objcopy")
+        )
+    }
+
+    @Test
+    fun objcopyOverrides() {
+        val toolchain = TestNdkToolchainImpl(
+            File("/23.0.7599858/"), false, mapOf(Abi.ARM64_V8A to "arm64-objcopy")
+        )
+
+        assertEquals(NdkToolchain.MappingTool.OBJCOPY, toolchain.preferredMappingTool())
+
+        assertEquals("arm64-objcopy", toolchain.objcopyForAbi(Abi.ARM64_V8A).toString())
+        assertNotEquals("arm64-objcopy", toolchain.objcopyForAbi(Abi.X86).toString())
+        assertNotEquals("arm64-objcopy", toolchain.objcopyForAbi(Abi.X86_64).toString())
+        assertNotEquals("arm64-objcopy", toolchain.objcopyForAbi(Abi.ARMEABI).toString())
+    }
+
+    @Test
+    fun objdumpOverrides() {
+        val toolchain = TestNdkToolchainImpl(
+            File("/19.2.5345600/"), true, mapOf(Abi.ARM64_V8A to "arm64-objcopy")
+        )
+
+        assertEquals(NdkToolchain.MappingTool.OBJDUMP, toolchain.preferredMappingTool())
+
+        assertEquals("arm64-objcopy", toolchain.objdumpForAbi(Abi.ARM64_V8A).toString())
+        assertNotEquals("arm64-objcopy", toolchain.objdumpForAbi(Abi.X86).toString())
+        assertNotEquals("arm64-objcopy", toolchain.objdumpForAbi(Abi.X86_64).toString())
+        assertNotEquals("arm64-objcopy", toolchain.objdumpForAbi(Abi.ARMEABI).toString())
+    }
+}
+
+private class TestNdkToolchainImpl(
+    baseDir: File,
+    useLegacyNdkSymbolUpload: Boolean,
+    overrides: Map<Abi, String> = emptyMap()
+) : NdkToolchain() {
+    override val baseDir: Property<File> = Mockito.mock(Property::class.java) as Property<File>
+    override val useLegacyNdkSymbolUpload: Property<Boolean> = Mockito.mock(Property::class.java) as Property<Boolean>
+    override val overrides: MapProperty<Abi, String> = Mockito.mock(MapProperty::class.java) as MapProperty<Abi, String>
+    override val bugsnagNdkVersion: Property<String> = Mockito.mock(Property::class.java) as Property<String>
+
+    init {
+        whenMock(this.baseDir.get()).thenReturn(baseDir)
+        whenMock(this.baseDir.map(any<Transformer<out Any, in File>>()))
+            .thenAnswer {
+                DefaultProvider {
+                    (it.arguments.first() as Transformer<out Any, in File>).transform(baseDir)
+                }
+            }
+        whenMock(this.useLegacyNdkSymbolUpload.get()).thenReturn(useLegacyNdkSymbolUpload)
+        whenMock(this.overrides.get()).thenReturn(overrides)
+    }
+}

--- a/src/test/kotlin/com/bugsnag/android/gradle/internal/NdkToolchainTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/internal/NdkToolchainTest.kt
@@ -89,6 +89,7 @@ private class TestNdkToolchainImpl(
     override val useLegacyNdkSymbolUpload: Property<Boolean> = Mockito.mock(Property::class.java) as Property<Boolean>
     override val overrides: MapProperty<Abi, String> = Mockito.mock(MapProperty::class.java) as MapProperty<Abi, String>
     override val bugsnagNdkVersion: Property<String> = Mockito.mock(Property::class.java) as Property<String>
+    override val variantName: Property<String> = Mockito.mock(Property::class.java) as Property<String>
 
     init {
         whenMock(this.baseDir.get()).thenReturn(baseDir)


### PR DESCRIPTION
## Goal
Upload the symbol / debug-info files generated using `objcopy` to the new endpoint.

## Testing
New end-to-end tests which include a check to ensure the target files appear to be valid ELF files.