### PR TITLE
Fix search path for ndkBuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+* Fixed a bug where using ndkBuild generated empty some mapping files which could not be uploaded
+  [#478](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/478)
+
 ## 7.3.0 (2022-07-27)
 
 * Emit an error if the ReactNative bundle task cannot be found instead of silently failing

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.bugsnag.android.gradle'
 
-ext.abiCodes = ['arm64-v8a':2, 'armeabi-v7a':3, 'x86':4, 'x86_64':5]
+ext.abiCodes = ['arm64-v8a': 2, 'armeabi-v7a': 3, 'x86': 4, 'x86_64': 5]
 
 android {
     compileSdkVersion 29
@@ -29,8 +29,14 @@ android {
         }
     }
     externalNativeBuild {
-        cmake {
-            path "CMakeLists.txt"
+        if (System.getenv("USE_NDK_BUILD") == "true") {
+            ndkBuild {
+                path "src/main/cpp/Android.mk"
+            }
+        } else {
+            cmake {
+                path "CMakeLists.txt"
+            }
         }
     }
     lintOptions {
@@ -78,7 +84,7 @@ bugsnag {
 
     if (objdumpLocation != null) {
         objdumpPaths = [
-            "x86": objdumpLocation,
+            "x86"      : objdumpLocation,
             "arm64-v8a": objdumpLocation
         ]
     }

--- a/features/fixtures/ndkapp/app/src/main/cpp/Android.mk
+++ b/features/fixtures/ndkapp/app/src/main/cpp/Android.mk
@@ -1,0 +1,17 @@
+LOCAL_PATH   := $(call my-dir)
+BUGSNAG_LIBS := $(LOCAL_PATH)/../../../build/intermediates/bugsnag-libs
+
+include $(CLEAR_VARS)
+LOCAL_MODULE            := bugsnag-ndk
+LOCAL_SRC_FILES         := $(BUGSNAG_LIBS)/jni/$(TARGET_ARCH_ABI)/libbugsnag-ndk.so
+LOCAL_EXPORT_C_INCLUDES := $(BUGSNAG_LIBS)/assets/include
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE     := native-lib
+LOCAL_SRC_FILES  := native-lib.cpp
+
+LOCAL_LDLIBS           := -llog -landroid
+LOCAL_SHARED_LIBRARIES := bugsnag-ndk
+
+include $(BUILD_SHARED_LIBRARY)

--- a/features/fixtures/ndkapp/app/src/main/cpp/Application.mk
+++ b/features/fixtures/ndkapp/app/src/main/cpp/Application.mk
@@ -1,0 +1,3 @@
+APP_PLATFORM := android-14
+APP_ABI      := arm64-v8a armeabi-v7a x86 x86_64
+APP_STL      := stlport_static

--- a/features/ndk_app.feature
+++ b/features/ndk_app.feature
@@ -23,6 +23,31 @@ Scenario: NDK apps send requests
       | jvmSymbols |
       | com.bugsnag.android.ndkapp.MainActivity |
 
+Scenario: ndkBuild apps send requests
+    Given I set environment variable "USE_NDK_BUILD" to "true"
+    When I build the NDK app
+    And I wait to receive 6 builds
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 4 requests are valid for the android NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | arm64-v8a   | /\S+/       | libnative-lib.so |
+        | armeabi-v7a | /\S+/       | libnative-lib.so |
+        | x86         | /\S+/       | libnative-lib.so |
+        | x86_64      | /\S+/       | libnative-lib.so |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | appId                      |
+        | com.bugsnag.android.ndkapp |
+
+    And 1 requests have an R8 mapping file with the following symbols:
+        | jvmSymbols |
+        | com.bugsnag.android.ndkapp.MainActivity |
+
+
 Scenario: Custom projectRoot is added to payload
     When I set environment variable "PROJECT_ROOT" to "/repos/custom/my-app"
     And I build the NDK app

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/ExternalNativeBuildTaskUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/ExternalNativeBuildTaskUtil.kt
@@ -19,7 +19,9 @@ class ExternalNativeBuildTaskUtil(private val providerFactory: ProviderFactory) 
         }
 
     private fun fixNativeOutputPath(taskFolder: File): File {
-        return taskFolder.parentFile.parentFile.takeIf { it.parentFile.name == "cxx" } ?: taskFolder
+        return taskFolder.parentFile.parentFile.takeIf { it.parentFile.name == "cxx" }
+            ?: taskFolder.parentFile.parentFile.parentFile.takeIf { it.parentFile.name == "cxx" }
+            ?: taskFolder
     }
 
     fun findSearchPaths(buildTask: Provider<ExternalNativeBuildTask>) = arrayOf(


### PR DESCRIPTION
## Goal
Avoid generating empty mapping files (or no mapping file) when `ndkBuild` is used.

## Changelog
`ndkBuild` generates an additional directory level (typically named `local`) between the expected `obj` directory and the architecture directory. This change looks for the `cxx` directory two or three levels above the directory reported from `ExternalNativeBuildTask`.

## Testing
Added support for `ndkBuild` to the existing `ndk` test fixture, and a test scenario to go with it.