### PR TITLE
Fix FileAlreadyExistsException in v7 when using ReactNative & Hermes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+# Bug Fixes
+
+* Fix FileAlreadyExistsException errors when building ReactNative projects with Hermes
+  [#482](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/482)
+
 ## 7.3.1 (2022-10-05)
 
 * Fixed a bug where using ndkBuild generated empty some mapping files which could not be uploaded

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadJsSourceMapTask.kt
@@ -196,7 +196,7 @@ open class BugsnagUploadJsSourceMapTask @Inject constructor(
                 actions.add(
                     indexToInsert,
                     Action<Task> {
-                        rnSourceBundle.copyTo(rnRescuedSourceBundle)
+                        rnSourceBundle.copyTo(rnRescuedSourceBundle, overwrite = true)
                     }
                 )
 


### PR DESCRIPTION
Goal
Fix `FileAlreadyExistsException` during ReactNative builds using Hermes by ensuring that existing source-maps are overwritten instead of causing build failures.

Testing
Tested manually by reproducing the error as described, and then testing that the fix no-longer causes the same issue. Instead the source maps are now overwritten and the new source maps are uploaded.