### PR TITLE
Add a couple of missing usesService() calls

### DIFF
--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagFileUploadTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagFileUploadTask.kt
@@ -1,11 +1,13 @@
 package com.bugsnag.android.gradle
 
 import com.bugsnag.android.gradle.internal.BugsnagHttpClientHelper
+import org.gradle.api.Task
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 
-interface BugsnagFileUploadTask {
+interface BugsnagFileUploadTask : Task {
     @get:Input
     val failOnUploadError: Property<Boolean>
 
@@ -24,11 +26,13 @@ interface BugsnagFileUploadTask {
     @get:Internal
     val httpClientHelper: Property<BugsnagHttpClientHelper>
 
-    fun configureWith(bugsnag: BugsnagPluginExtension) {
+    fun configureWith(bugsnag: BugsnagPluginExtension, httpClientHelperProvider: Provider<out BugsnagHttpClientHelper>) {
         failOnUploadError.set(bugsnag.failOnUploadError)
         overwrite.set(bugsnag.overwrite)
         endpoint.set(bugsnag.endpoint)
         retryCount.set(bugsnag.retryCount)
         timeoutMillis.set(bugsnag.requestTimeoutMs)
+        httpClientHelper.set(httpClientHelperProvider)
+        usesService(httpClientHelperProvider)
     }
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -453,11 +453,13 @@ class BugsnagPlugin : Plugin<Project> {
 
         return BugsnagUploadProguardTask.register(project, taskName) {
             requestOutputFile.set(requestOutputFileProvider)
-            httpClientHelper.set(httpClientHelperProvider)
             manifestInfo.set(manifestInfoProvider)
-            uploadRequestClient.set(proguardUploadClientProvider)
             mappingFileProperty.set(gzipOutputProvider)
-            configureWith(bugsnag)
+
+            uploadRequestClient.set(proguardUploadClientProvider)
+            usesService(proguardUploadClientProvider)
+
+            configureWith(bugsnag, httpClientHelperProvider)
 
             val task = generateProguardTaskProvider?.get()
             mustRunAfter(task)

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadSoSymTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadSoSymTask.kt
@@ -178,7 +178,6 @@ internal abstract class BugsnagUploadSoSymTask : DefaultTask(), AndroidManifestI
                 BugsnagUploadSoSymTask::class.java
             ) { task ->
                 task.dependsOn(generateTaskProvider)
-                task.usesService(httpClientHelperProvider)
                 task.usesService(ndkUploadClientProvider)
 
                 task.endpoint.set(bugsnag.endpoint)
@@ -191,10 +190,9 @@ internal abstract class BugsnagUploadSoSymTask : DefaultTask(), AndroidManifestI
                 task.requestOutputFile.set(requestOutputFileFor(project, variant))
                 task.projectRoot.set(bugsnag.projectRoot.getOrElse(project.projectDir.toString()))
 
-                task.httpClientHelper.set(httpClientHelperProvider)
                 task.uploadRequestClient.set(ndkUploadClientProvider)
 
-                task.configureWith(bugsnag)
+                task.configureWith(bugsnag, httpClientHelperProvider)
             }
         }
     }


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
Noticed these while auditing plugins for the upcoming [`STABLE_CONFIGURATION_CACHE` flag](https://github.com/gradle/gradle/blob/9a08b2368ca049a33783781c7810a7d2f4aaeab2/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc#stable-configuration-cache) in Gradle. Consolidated logic in BugsnagFileUploadTask but let me know if you're rather keep that interface task-agnostic. Figured it was fair game since it used task annotations on its properties now

## Design

<!-- Why was this approach used? -->
Just matching the existing structure + consolidating some shared logic.

## Changeset

<!-- What changed? -->
Add missing `usesService()` calls to remaining tasks that use internal build services.

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->

Existing tests