### PR TITLE
Fix NdkToolchain.baseDir configuration cache

### DIFF
--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/NdkToolchain.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/NdkToolchain.kt
@@ -8,20 +8,23 @@ import com.bugsnag.android.gradle.BugsnagGenerateUnitySoMappingTask
 import com.bugsnag.android.gradle.BugsnagPluginExtension
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.util.VersionNumber
 import java.io.File
 
 abstract class NdkToolchain {
-    @get:Input
-    abstract val baseDir: Property<File>
+    // Internal rather than InputDirectory because this is an
+    // absolute path otherwise and would break build caching.
+    @get:Internal
+    abstract val baseDir: DirectoryProperty
 
     @get:Input
     abstract val useLegacyNdkSymbolUpload: Property<Boolean>
@@ -92,7 +95,7 @@ abstract class NdkToolchain {
         val objdumpOverrides = overrides.get()
 
         return objdumpOverrides[abi]?.let { File(it) } ?: File(
-            baseDir.get(),
+            baseDir.asFile.get(),
             "toolchains/${abi.toolchainPrefix}-4.9/prebuilt/" +
                 "$osName/bin/${abi.objdumpPrefix}-${executableName("objdump")}"
         )
@@ -113,7 +116,7 @@ abstract class NdkToolchain {
                     "$osName/bin/${abi.objdumpPrefix}-${executableName("objcopy")}"
         }
 
-        return File(baseDir.get(), relativeExecutablePath)
+        return File(baseDir.asFile.get(), relativeExecutablePath)
     }
 
     enum class MappingTool {
@@ -159,16 +162,17 @@ abstract class NdkToolchain {
          *
          * So we also fall back use the old BaseExtension if it appears broken
          */
-        private fun ndkToolchainDirectoryFor(project: Project): Provider<File> {
+        private fun setNdkToolchainDirectory(
+            ndkToolchain: NdkToolchain,
+            project: Project,
+        ) {
             val extensions = project.extensions
             val sdkComponents = extensions.getByType(AndroidComponentsExtension::class.java)?.sdkComponents
 
-            return project.provider {
-                try {
-                    return@provider sdkComponents!!.ndkDirectory.get().asFile
-                } catch (e: Exception) {
-                    return@provider extensions.getByType(BaseExtension::class.java).ndkDirectory.absoluteFile
-                }
+            if (sdkComponents != null) {
+                ndkToolchain.baseDir.set(sdkComponents!!.ndkDirectory)
+            } else {
+                ndkToolchain.baseDir.set(extensions.getByType(BaseExtension::class.java).ndkDirectory)
             }
         }
 
@@ -196,7 +200,7 @@ abstract class NdkToolchain {
             val overrides = bugsnag.objdumpPaths.map { it.mapKeys { (abi, _) -> Abi.findByName(abi)!! } }
 
             val ndkToolchain = project.objects.newInstance<NdkToolchain>()
-            ndkToolchain.baseDir.set(ndkToolchainDirectoryFor(project))
+            setNdkToolchainDirectory(ndkToolchain, project)
             ndkToolchain.useLegacyNdkSymbolUpload.set(useLegacyNdkSymbolUpload)
             ndkToolchain.overrides.set(overrides)
 
@@ -213,5 +217,5 @@ abstract class NdkToolchain {
     }
 }
 
-private val NdkToolchain.version get() = baseDir.map { VersionNumber.parse(it.name) }
+private val NdkToolchain.version get() = baseDir.map { VersionNumber.parse(it.asFile.name) }
 private val NdkToolchain.isLLVMPreferred get() = version.map { it >= NdkToolchain.MIN_NDK_LLVM_VERSION }


### PR DESCRIPTION
This property should be a `DirectoryProperty` rather than `Property<File>` in order to be compatible with configuration cache. This also allows for it to be more chainable with providers of this from android components.

## Goal

See above

## Design

See above

## Changeset

See above

## Testing

Manually tested in our project via maven local.