### PR TITLE
Add a test pipeline for AGP 7.4.1 / Gradle 7.5.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,6 +68,18 @@ steps:
                   - RN_FIXTURE_DIR=features/fixtures/rn065/android
               command: ['bundle', 'exec', 'maze-runner', '-c', '--verbose', '--fail-fast']
 
+  - label: ':android: AGP 7.4.1 E2E tests'
+    depends_on: 'agp-ci'
+    timeout_in_minutes: 60
+    plugins:
+        - docker-compose#v3.7.0:
+              run: android-gradle-plugin-ci
+              env:
+                  - AGP_VERSION=7.4.1
+                  - GRADLE_WRAPPER_VERSION=7.5.1
+                  - RN_FIXTURE_DIR=features/fixtures/rn065/android
+              command: ['bundle', 'exec', 'maze-runner', '-c', '--verbose', '--fail-fast']
+
   - label: ':android: AGP 7.2.1 R/N 0.70 E2E tests'
     depends_on: 'agp-ci'
     timeout_in_minutes: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -77,7 +77,7 @@ steps:
               env:
                   - AGP_VERSION=7.4.1
                   - GRADLE_WRAPPER_VERSION=7.5.1
-                  - RN_FIXTURE_DIR=features/fixtures/rn065/android
+                  - RN_FIXTURE_DIR=features/fixtures/rn70/android
               command: ['bundle', 'exec', 'maze-runner', '-c', '--verbose', '--fail-fast']
 
   - label: ':android: AGP 7.2.1 R/N 0.70 E2E tests'

--- a/features/fixtures/config/ndk/objcopy.gradle
+++ b/features/fixtures/config/ndk/objcopy.gradle
@@ -2,5 +2,5 @@ dependencies {
     implementation 'com.bugsnag:bugsnag-android:5.26.0'
 }
 
-android.ndkVersion = "23.0.7599858"
+android.ndkVersion = "24.0.8215888"
 bugsnag.useLegacyNdkSymbolUpload = false


### PR DESCRIPTION
## Goal
Add CI pipelines to test AGP 7.4.1 and Gradle 7.5.1

## Testing
Relied on existing tests and the new pipeline