### PR TITLE
Ensure Bugsnag mapping tasks run after Dexguard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug Fixes
+
+* Fix task ordering when using DexGuard and a `bundle***` task
+  [496](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/496)
+
 ## 7.4.0 (2022-11-10)
 
 ### Enhancements

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
@@ -70,7 +70,7 @@ internal fun Project.hasDexguardPlugin(): Boolean {
  */
 internal fun Project.isDexguardEnabledForVariant(variant: BaseVariant): Boolean {
     val flavor = variant.flavorName
-    val buildType = variant.buildType.name.capitalize()
+    val buildType = if (flavor.isEmpty()) variant.buildType.name else variant.buildType.name.capitalize()
     return GroovyCompat.isDexguardEnabledForVariant(project, "$flavor$buildType")
 }
 


### PR DESCRIPTION
## Goal
Ensure Bugsnag mapping tasks run after Dexguard so that the correct mapping files can be found and uploaded.

## Changelog
Corrected the task lookup to match the capitalisation used by Dexguard when no build flavour is being used.

## Testing
Tested locally