### PR TITLE
AGP-8 Compatibility

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,9 @@
 steps:
-  - label: 'Audit current licenses'
-    timeout_in_minutes: 30
-    plugins:
-      - docker-compose#v3.7.0:
-          run: license-audit
+#  - label: 'Audit current licenses'
+#    timeout_in_minutes: 30
+#    plugins:
+#      - docker-compose#v3.7.0:
+#          run: license-audit
 
   - label: ':docker: Build Android gradle plugin CI image'
     key: 'agp-ci'
@@ -11,21 +11,21 @@ steps:
     plugins:
       - docker-compose#v3.7.0:
           build:
-            - android-gradle-plugin-ci
+            - android-gradle-plugin-ci-v8
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
           cache-from:
             - android-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:latest
-            - android-gradle-plugin-ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-gradle-plugin-ci-v7
+            - android-gradle-plugin-ci-v8:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-gradle-plugin-ci-v8
       - docker-compose#v3.7.0:
           push:
-            - android-gradle-plugin-ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-gradle-plugin-ci-v7
+            - android-gradle-plugin-ci-v8:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-gradle-plugin-ci-v8
 
   - label: ':android: Detekt'
     depends_on: 'agp-ci'
     timeout_in_minutes: 30
     plugins:
       - docker-compose#v3.7.0:
-          run: android-gradle-plugin-ci
+          run: android-gradle-plugin-ci-v8
           command: ['./gradlew', 'detekt']
 
   - label: ':android: Ktlint'
@@ -33,7 +33,7 @@ steps:
     timeout_in_minutes: 30
     plugins:
       - docker-compose#v3.7.0:
-          run: android-gradle-plugin-ci
+          run: android-gradle-plugin-ci-v8
           command: ['./gradlew', 'ktlintCheck']
 
   - label: ':android: Unit tests'
@@ -41,53 +41,17 @@ steps:
     timeout_in_minutes: 30
     plugins:
       - docker-compose#v3.7.0:
-          run: android-gradle-plugin-ci
+          run: android-gradle-plugin-ci-v8
           command: ['./gradlew', 'test']
 
-  - label: ':android: AGP 7.0.0 E2E tests'
+  - label: ':android: AGP 8.0.0 E2E tests'
     depends_on: 'agp-ci'
     timeout_in_minutes: 60
     plugins:
       - docker-compose#v3.7.0:
-          run: android-gradle-plugin-ci
+          run: android-gradle-plugin-ci-v8
           env:
-            - AGP_VERSION=7.0.0
-            - GRADLE_WRAPPER_VERSION=7.0.2
-            - RN_FIXTURE_DIR=features/fixtures/rn065/android
+            - AGP_VERSION=8.0.0-beta02
+            - GRADLE_WRAPPER_VERSION=8.0
+            - RN_FIXTURE_DIR=features/fixtures/rn070/android
           command: ['bundle', 'exec', 'maze-runner', '-c', '--verbose', '--fail-fast']
-
-  - label: ':android: AGP 7.2.0 E2E tests'
-    depends_on: 'agp-ci'
-    timeout_in_minutes: 60
-    plugins:
-        - docker-compose#v3.7.0:
-              run: android-gradle-plugin-ci
-              env:
-                  - AGP_VERSION=7.2.0
-                  - GRADLE_WRAPPER_VERSION=7.3.3
-                  - RN_FIXTURE_DIR=features/fixtures/rn065/android
-              command: ['bundle', 'exec', 'maze-runner', '-c', '--verbose', '--fail-fast']
-
-  - label: ':android: AGP 7.4.1 E2E tests'
-    depends_on: 'agp-ci'
-    timeout_in_minutes: 60
-    plugins:
-        - docker-compose#v3.7.0:
-              run: android-gradle-plugin-ci
-              env:
-                  - AGP_VERSION=7.4.1
-                  - GRADLE_WRAPPER_VERSION=7.5.1
-                  - RN_FIXTURE_DIR=features/fixtures/rn70/android
-              command: ['bundle', 'exec', 'maze-runner', '-c', '--verbose', '--fail-fast']
-
-  - label: ':android: AGP 7.2.1 R/N 0.70 E2E tests'
-    depends_on: 'agp-ci'
-    timeout_in_minutes: 60
-    plugins:
-        - docker-compose#v3.7.0:
-              run: android-gradle-plugin-ci
-              env:
-                  - AGP_VERSION=7.2.1
-                  - GRADLE_WRAPPER_VERSION=7.3.3
-                  - RN_FIXTURE_DIR=features/fixtures/rn70/android
-              command: ['bundle', 'exec', 'maze-runner', '-c', '--verbose', '--fail-fast']

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
     plugins:
       - docker-compose#v3.7.0:
           build:
-            - android-gradle-plugin-ci
+            - android-gradle-plugin-ci-v8
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
           cache-from:
             - android-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:latest

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
     plugins:
       - docker-compose#v3.7.0:
           build:
-            - android-gradle-plugin-ci-v8
+            - android-gradle-plugin-ci
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
           cache-from:
             - android-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:latest

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,10 +15,10 @@ steps:
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
           cache-from:
             - android-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:latest
-            - android-gradle-plugin-ci-v8:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-gradle-plugin-ci-v7
+            - android-gradle-plugin-ci-v8:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-gradle-plugin-${BRANCH_NAME}-ci-v8
       - docker-compose#v3.7.0:
           push:
-            - android-gradle-plugin-ci-v8:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-gradle-plugin-ci-v8
+            - android-gradle-plugin-ci-v8:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-gradle-plugin-${BRANCH_NAME}-ci-v8
 
   - label: ':android: Detekt'
     depends_on: 'agp-ci'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,5 +53,5 @@ steps:
           env:
             - AGP_VERSION=8.0.0-beta02
             - GRADLE_WRAPPER_VERSION=8.0
-            - RN_FIXTURE_DIR=features/fixtures/rn070/android
+            - RN_FIXTURE_DIR=features/fixtures/rn70/android
           command: ['bundle', 'exec', 'maze-runner', '-c', '--verbose', '--fail-fast']

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
           cache-from:
             - android-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:latest
-            - android-gradle-plugin-ci-v8:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-gradle-plugin-ci-v8
+            - android-gradle-plugin-ci-v8:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-gradle-plugin-ci-v7
       - docker-compose#v3.7.0:
           push:
             - android-gradle-plugin-ci-v8:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-gradle-plugin-ci-v8

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,5 +53,5 @@ steps:
           env:
             - AGP_VERSION=8.0.0-beta02
             - GRADLE_WRAPPER_VERSION=8.0
-            - RN_FIXTURE_DIR=features/fixtures/rn70/android
+            - RN_FIXTURE_DIR=features/fixtures/rn065/android
           command: ['bundle', 'exec', 'maze-runner', '-c', '--verbose', '--fail-fast']

--- a/build.gradle
+++ b/build.gradle
@@ -1,41 +1,21 @@
-buildscript {
-    repositories {
-        maven { url "https://plugins.gradle.org/m2/" }
-        mavenCentral()
-        google()
-    }
-
-    ext.agpVersion = "7.2.0"
-    ext.kotlinVersion = "1.4.31"
-
-    dependencies {
-        classpath "com.android.tools.build:gradle:$agpVersion"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.17.1"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.1.0"
-    }
-}
-// Gradle plugins
 plugins {
-    id "java-gradle-plugin"
-    id "groovy"
-    id 'maven-publish'
-    id "com.gradle.plugin-publish" version "0.15.0"
-    id "com.vanniktech.maven.publish" version "0.15.1"
-    id "com.github.hierynomus.license" version "0.16.1"
+    id("java-gradle-plugin")
+    id("groovy")
+    id("maven-publish")
+
+    id("org.jetbrains.kotlin.kapt") version "1.7.10"
+    id("org.jetbrains.kotlin.jvm") version "1.7.10"
+
+    id("org.jlleitschuh.gradle.ktlint") version "10.1.0"
+    id("io.gitlab.arturbosch.detekt") version "1.21.0"
+    id("com.github.hierynomus.license") version "0.16.1"
+
+    id("org.jetbrains.dokka") version "1.7.20"
+    id("com.gradle.plugin-publish") version "1.1.0"
 }
 
-apply plugin: "org.jetbrains.kotlin.jvm"
-apply plugin: "org.jetbrains.kotlin.kapt"
-apply plugin: "io.gitlab.arturbosch.detekt"
-apply plugin: "org.jlleitschuh.gradle.ktlint"
-
-allprojects {
-    repositories {
-        mavenCentral()
-        google()
-    }
-}
+def agpVersion = "8.1.0-alpha01"
+def kotlinVersion = "1.7.10"
 
 sourceSets {
     main {
@@ -45,15 +25,9 @@ sourceSets {
     }
 }
 
-// Repositories for dependencies
-repositories {
-    mavenCentral()
-    google()
-}
-
 compileGroovy {
-    sourceCompatibility = "1.8"
-    targetCompatibility = "1.8"
+    sourceCompatibility = "11"
+    targetCompatibility = "11"
 }
 
 // compile groovy first, see
@@ -68,7 +42,7 @@ tasks.named("compileKotlin") {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 }
 
@@ -76,23 +50,25 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 // as otherwise the downloadLicenses task misses these deps
 // Build dependencies
 dependencies {
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.9.3"
-    compileOnly "com.android.tools.build:gradle:$agpVersion"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    kapt("com.squareup.moshi:moshi-kotlin-codegen:1.14.0")
+
+    api("com.android.tools.build:gradle:$agpVersion")
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
 
     // For uploading proguard/ndk files
-    compile "com.squareup.okhttp3:okhttp:4.8.0"
-    compile "com.squareup.retrofit2:retrofit:2.9.0"
-    compile "com.squareup.retrofit2:converter-moshi:2.9.0"
-    compile "com.squareup.retrofit2:converter-scalars:2.9.0"
+    implementation "com.squareup.okhttp3:okhttp:4.8.0"
+    implementation "com.squareup.retrofit2:retrofit:2.9.0"
+    implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
+    implementation "com.squareup.retrofit2:converter-scalars:2.9.0"
 
     // For serialization of shared data
-    compile "com.squareup.moshi:moshi:1.9.3"
+    implementation "com.squareup.moshi:moshi:1.9.3"
 
     // For multiple I/O use cases
-    compile "com.squareup.okio:okio:2.7.0"
+    implementation "com.squareup.okio:okio:2.7.0"
 
-    testImplementation "com.android.tools.build:gradle:$agpVersion"
+    testImplementation "com.android.tools.build:gradle-api:$agpVersion"
     testImplementation "junit:junit:4.12"
     testImplementation "org.mockito:mockito-core:2.28.2"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.8.0"
@@ -100,43 +76,43 @@ dependencies {
     testImplementation "com.google.truth:truth:1.0.1"
 }
 
-// Gradle plugin publishing settings (plugins.gradle.com)
-pluginBundle {
-    website = POM_URL
-    vcsUrl = POM_SCM_URL
-
-    plugins {
-        androidGradlePlugin {
-            id = "com.bugsnag.android.gradle"
-            displayName = POM_NAME
-            description = POM_DESCRIPTION
-            tags = ["bugsnag", "proguard", "android", "upload"]
-        }
-    }
-
-    mavenCoordinates {
-        groupId = GROUP
-        artifactId = POM_ARTIFACT_ID
-    }
-}
-
-publishing {
-    repositories {
-        maven {
-            name = "Sonatype"
-            if (VERSION_NAME.contains("SNAPSHOT")) {
-                url = "https://oss.sonatype.org/content/repositories/snapshots/"
-            } else {
-                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-            }
-
-            credentials {
-                username = project.hasProperty("NEXUS_USERNAME") ? "$NEXUS_USERNAME" : System.getenv("NEXUS_USERNAME")
-                password = project.hasProperty("NEXUS_PASSWORD") ? "$NEXUS_PASSWORD" : System.getenv("NEXUS_PASSWORD")
-            }
-        }
-    }
-}
+//// Gradle plugin publishing settings (plugins.gradle.com)
+//pluginBundle {
+//    website = POM_URL
+//    vcsUrl = POM_SCM_URL
+//
+//    plugins {
+//        androidGradlePlugin {
+//            id = "com.bugsnag.android.gradle"
+//            displayName = POM_NAME
+//            description = POM_DESCRIPTION
+//            tags = ["bugsnag", "proguard", "android", "upload"]
+//        }
+//    }
+//
+//    mavenCoordinates {
+//        groupId = GROUP
+//        artifactId = POM_ARTIFACT_ID
+//    }
+//}
+//
+//publishing {
+//    repositories {
+//        maven {
+//            name = "Sonatype"
+//            if (VERSION_NAME.contains("SNAPSHOT")) {
+//                url = "https://oss.sonatype.org/content/repositories/snapshots/"
+//            } else {
+//                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+//            }
+//
+//            credentials {
+//                username = project.hasProperty("NEXUS_USERNAME") ? "$NEXUS_USERNAME" : System.getenv("NEXUS_USERNAME")
+//                password = project.hasProperty("NEXUS_PASSWORD") ? "$NEXUS_PASSWORD" : System.getenv("NEXUS_PASSWORD")
+//            }
+//        }
+//    }
+//}
 
 // license checking
 license {
@@ -168,7 +144,7 @@ ktlint {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_11
 
 // see https://github.com/asciidoctor/asciidoctorj/pull/862
 Signature.metaClass.getToSignArtifact = { ->

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
     // For multiple I/O use cases
     implementation "com.squareup.okio:okio:2.7.0"
 
+    // For version checking
+    implementation "org.semver:api:0.9.33"
+
     testImplementation "com.android.tools.build:gradle:$agpVersion"
     testImplementation 'junit:junit:4.13.1'
     testImplementation "org.mockito:mockito-core:2.28.2"

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     // For multiple I/O use cases
     implementation "com.squareup.okio:okio:2.7.0"
 
-    testImplementation "com.android.tools.build:gradle-api:$agpVersion"
+    testImplementation "com.android.tools.build:gradle:$agpVersion"
     testImplementation 'junit:junit:4.13.1'
     testImplementation "org.mockito:mockito-core:2.28.2"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.8.0"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,5 @@
 plugins {
-    id("java-gradle-plugin")
     id("groovy")
-    id("maven-publish")
 
     id("org.jetbrains.kotlin.kapt") version "1.7.10"
     id("org.jetbrains.kotlin.jvm") version "1.7.10"
@@ -14,7 +12,7 @@ plugins {
     id("com.gradle.plugin-publish") version "1.1.0"
 }
 
-def agpVersion = "8.1.0-alpha01"
+def agpVersion = "8.0.0-beta02"
 def kotlinVersion = "1.7.10"
 
 sourceSets {
@@ -77,42 +75,46 @@ dependencies {
 }
 
 //// Gradle plugin publishing settings (plugins.gradle.com)
-//pluginBundle {
-//    website = POM_URL
-//    vcsUrl = POM_SCM_URL
-//
-//    plugins {
-//        androidGradlePlugin {
-//            id = "com.bugsnag.android.gradle"
-//            displayName = POM_NAME
-//            description = POM_DESCRIPTION
-//            tags = ["bugsnag", "proguard", "android", "upload"]
-//        }
-//    }
-//
-//    mavenCoordinates {
-//        groupId = GROUP
-//        artifactId = POM_ARTIFACT_ID
-//    }
-//}
-//
-//publishing {
-//    repositories {
-//        maven {
-//            name = "Sonatype"
-//            if (VERSION_NAME.contains("SNAPSHOT")) {
-//                url = "https://oss.sonatype.org/content/repositories/snapshots/"
-//            } else {
-//                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-//            }
-//
-//            credentials {
-//                username = project.hasProperty("NEXUS_USERNAME") ? "$NEXUS_USERNAME" : System.getenv("NEXUS_USERNAME")
-//                password = project.hasProperty("NEXUS_PASSWORD") ? "$NEXUS_PASSWORD" : System.getenv("NEXUS_PASSWORD")
-//            }
-//        }
-//    }
-//}
+gradlePlugin {
+    website = POM_URL
+    vcsUrl = POM_SCM_URL
+
+    plugins {
+        androidGradlePlugin {
+            id = "com.bugsnag.android.gradle"
+            implementationClass = "com.bugsnag.android.gradle.BugsnagPlugin"
+            displayName = POM_NAME
+            description = POM_DESCRIPTION
+            tags.set(["bugsnag", "proguard", "android", "upload"])
+        }
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "Sonatype"
+            if (VERSION_NAME.contains("SNAPSHOT")) {
+                url = "https://oss.sonatype.org/content/repositories/snapshots/"
+            } else {
+                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            }
+
+            credentials {
+                username = project.hasProperty("NEXUS_USERNAME") ? "$NEXUS_USERNAME" : System.getenv("NEXUS_USERNAME")
+                password = project.hasProperty("NEXUS_PASSWORD") ? "$NEXUS_PASSWORD" : System.getenv("NEXUS_PASSWORD")
+            }
+        }
+    }
+
+    publications {
+        pluginMaven(MavenPublication) {
+            groupId = GROUP
+            artifactId = POM_ARTIFACT_ID
+            version = VERSION_NAME
+        }
+    }
+}
 
 // license checking
 license {

--- a/build.gradle
+++ b/build.gradle
@@ -44,13 +44,10 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     }
 }
 
-// Several of these need to be kept as 'compile' for license checking to work
-// as otherwise the downloadLicenses task misses these deps
-// Build dependencies
 dependencies {
     kapt("com.squareup.moshi:moshi-kotlin-codegen:1.14.0")
 
-    api("com.android.tools.build:gradle:$agpVersion")
+    compileOnly("com.android.tools.build:gradle:$agpVersion")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
 
@@ -67,11 +64,11 @@ dependencies {
     implementation "com.squareup.okio:okio:2.7.0"
 
     testImplementation "com.android.tools.build:gradle-api:$agpVersion"
-    testImplementation "junit:junit:4.12"
+    testImplementation 'junit:junit:4.13.1'
     testImplementation "org.mockito:mockito-core:2.28.2"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.8.0"
     testImplementation "com.squareup.okhttp3:logging-interceptor:4.8.0"
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:1.1.3"
 }
 
 //// Gradle plugin publishing settings (plugins.gradle.com)

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -10,12 +10,10 @@
     <ID>MagicNumber:BugsnagReleasesTask.kt$BugsnagReleasesTask$200</ID>
     <ID>MagicNumber:MappingFileProvider.kt$9</ID>
     <ID>MaxLineLength:NdkToolchain.kt$NdkToolchain.Companion$/* * SdkComponents.ndkDirectory * https://developer.android.com/reference/tools/gradle-api/7.2/com/android/build/api/dsl/SdkComponents#ndkDirectory() * sometimes fails to resolve when ndkPath is not defined (Cannot query the value of this property because it has * no value available.). This means that even `map` and `isPresent` will break. * * So we also fall back use the old BaseExtension if it appears broken */</ID>
-    <ID>ReturnCount:BugsnagGenerateUnitySoMappingTask.kt$BugsnagGenerateUnitySoMappingTask.Companion$ @Suppress("SENSELESS_COMPARISON") internal fun isUnityLibraryUploadEnabled( bugsnag: BugsnagPluginExtension, android: BaseExtension ): Boolean</ID>
-    <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ private fun registerUploadSourceMapTask( project: Project, variant: BaseVariant, output: BaseVariantOutput, bugsnag: BugsnagPluginExtension, manifestInfoProvider: Provider&lt;RegularFile> ): TaskProvider&lt;out BugsnagUploadJsSourceMapTask>?</ID>
+    <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$private fun registerUploadSourceMapTask( project: Project, variant: BaseVariant, output: BaseVariantOutput, bugsnag: BugsnagPluginExtension, manifestInfoProvider: Provider&lt;RegularFile> ): TaskProvider&lt;out BugsnagUploadJsSourceMapTask>?</ID>
     <ID>ReturnCount:ManifestUuidTaskV2Compat.kt$internal fun createManifestUpdateTask( bugsnag: BugsnagPluginExtension, project: Project, variantName: String, variantOutput: VariantOutput ): TaskProvider&lt;BugsnagManifestUuidTask>?</ID>
     <ID>SpreadOperator:DexguardCompat.kt$(buildDir, *path, variant.dirName, outputDir, "mapping.txt")</ID>
-    <ID>SwallowedException:NdkToolchain.kt$NdkToolchain.Companion$catch (e: Exception) { null }</ID>
-    <ID>SwallowedException:NdkToolchain.kt$NdkToolchain.Companion$catch (e: Exception) { return@provider extensions.getByType(BaseExtension::class.java).ndkDirectory.absoluteFile }</ID>
+    <ID>SwallowedException:NdkToolchain.kt$NdkToolchain.Companion$e: Exception</ID>
     <ID>TooGenericExceptionCaught:AbstractSoMappingTask.kt$AbstractSoMappingTask$e: Exception</ID>
     <ID>TooGenericExceptionCaught:BugsnagHttpClientHelper.kt$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:BugsnagMultiPartUploadRequest.kt$BugsnagMultiPartUploadRequest$exc: Throwable</ID>
@@ -23,5 +21,7 @@
     <ID>TooGenericExceptionCaught:MappingFileProvider.kt$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:NdkToolchain.kt$NdkToolchain.Companion$e: Exception</ID>
     <ID>TooManyFunctions:BugsnagPlugin.kt$BugsnagPlugin : Plugin</ID>
+    <ID>UseCheckOrError:BugsnagPlugin.kt$BugsnagPlugin$throw IllegalStateException("Unexpected variant type: $android")</ID>
+    <ID>UseCheckOrError:BugsnagReleasesTask.kt$BugsnagReleasesTask$throw IllegalStateException("Request to Bugsnag Releases API failed, aborting build.")</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.license-audit
 
-  android-gradle-plugin-ci:
+  android-gradle-plugin-ci-v8:
     build:
       context: .
       dockerfile: dockerfiles/Dockerfile.android-ci

--- a/dockerfiles/Dockerfile.android-ci
+++ b/dockerfiles/Dockerfile.android-ci
@@ -72,7 +72,7 @@ WORKDIR /app
 COPY gradlew gradle.properties /app/
 COPY gradle/ /app/gradle/
 ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
-COPY settings.gradle /app/
+COPY settings.gradle.kts /app/
 RUN ./gradlew
 
 # Copy remaining Gradle files

--- a/dockerfiles/Dockerfile.android-ci
+++ b/dockerfiles/Dockerfile.android-ci
@@ -40,7 +40,7 @@ RUN mv bundletool-all-1.4.0.jar bundletool.jar
 
 # Install AGP specific system and Android requirements
 RUN apt-get update > /dev/null
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git ruby-full make libcurl4-openssl-dev gcc g++ openjdk-11-jdk
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git ruby-full make libcurl4-openssl-dev gcc g++ openjdk-17-jdk
 RUN apt-get clean > /dev/null
 
 RUN yes | sdkmanager 'ndk;16.1.4479499' >/dev/null

--- a/features/agp_compatibility_check.feature
+++ b/features/agp_compatibility_check.feature
@@ -1,6 +1,6 @@
 Feature: AGP7 Emits Compatibility Error
 
-Scenario: Compatibility Error Emitted when AGP 4.2.0 is used
-    When I build the failing "default_app" on AGP "4.2.0" using the "standard" bugsnag config
+Scenario: Compatibility Error Emitted when AGP 7.4.1 is used
+    When I build the failing "default_app" on AGP "7.4.1" using the "standard" bugsnag config
     And I wait for 3 seconds
     Then I should receive no requests

--- a/features/agp_compatibility_check.feature
+++ b/features/agp_compatibility_check.feature
@@ -1,30 +1,5 @@
 Feature: AGP7 Emits Compatibility Error
 
-Scenario: Compatibility Error Emitted when AGP 3.4.0 is used
-    When I build the failing "default_app" on AGP "3.4.0" using the "standard" bugsnag config
-    And I wait for 3 seconds
-    Then I should receive no requests
-
-Scenario: Compatibility Error Emitted when AGP 3.5.0 is used
-    When I build the failing "default_app" on AGP "3.5.0" using the "standard" bugsnag config
-    And I wait for 3 seconds
-    Then I should receive no requests
-
-Scenario: Compatibility Error Emitted when AGP 3.6.0 is used
-    When I build the failing "default_app" on AGP "3.6.0" using the "standard" bugsnag config
-    And I wait for 3 seconds
-    Then I should receive no requests
-
-Scenario: Compatibility Error Emitted when AGP 4.0.0 is used
-    When I build the failing "default_app" on AGP "4.0.0" using the "standard" bugsnag config
-    And I wait for 3 seconds
-    Then I should receive no requests
-
-Scenario: Compatibility Error Emitted when AGP 4.1.0 is used
-    When I build the failing "default_app" on AGP "4.1.0" using the "standard" bugsnag config
-    And I wait for 3 seconds
-    Then I should receive no requests
-
 Scenario: Compatibility Error Emitted when AGP 4.2.0 is used
     When I build the failing "default_app" on AGP "4.2.0" using the "standard" bugsnag config
     And I wait for 3 seconds

--- a/features/fixtures/app/build.gradle
+++ b/features/fixtures/app/build.gradle
@@ -1,20 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-
     repositories {
         mavenLocal()
         google()
         mavenCentral()
     }
+
     dependencies {
-        def agpVersion = System.env.AGP_VERSION ?: "7.0.0"
+        def agpVersion = System.env.AGP_VERSION ?: "8.0.0-beta02"
         classpath "com.android.tools.build:gradle:${agpVersion}"
 
         if (!System.env.UPDATING_GRADLEW) {
-            dependencies {
-                classpath "com.bugsnag:bugsnag-android-gradle-plugin:9000.0.0-test"
-            }
+            classpath "com.bugsnag:bugsnag-android-gradle-plugin:9000.0.0-test"
         }
     }
 }

--- a/features/fixtures/app/module/src/main/AndroidManifest.xml
+++ b/features/fixtures/app/module/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.bugsnag.libvanilla" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <application android:name="com.example.android.gradle.plugin.FooApp">
-
     <meta-data
       android:name="com.bugsnag.android.API_KEY"
       android:value="${BUGSNAG_API_KEY}" />

--- a/features/fixtures/app/module/src/main/AndroidManifestBuildUuid.xml
+++ b/features/fixtures/app/module/src/main/AndroidManifestBuildUuid.xml
@@ -1,7 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.bugsnag.libvanilla" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <application android:name="com.example.android.gradle.plugin.FooApp">
-
     <meta-data
       android:name="com.bugsnag.android.API_KEY"
       android:value="${BUGSNAG_API_KEY}" />

--- a/features/fixtures/app/module/src/main/AndroidManifestVersionCode.xml
+++ b/features/fixtures/app/module/src/main/AndroidManifestVersionCode.xml
@@ -1,17 +1,15 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.bugsnag.libvanilla" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <application android:name="com.example.android.gradle.plugin.FooApp">
-
     <meta-data
       android:name="com.bugsnag.android.API_KEY"
-      android:value="${BUGSNAG_API_KEY}" />
+      android:value="${BUGSNAG_API_KEY}"/>
 
     <meta-data
       android:name="com.bugsnag.android.VERSION_CODE"
-      android:value="101" />
+      android:value="101"/>
 
     <meta-data
       android:name="com.bugsnag.android.APP_VERSION"
-      android:value="3.5" />
+      android:value="3.5"/>
   </application>
 </manifest>

--- a/features/fixtures/config/android/common.gradle
+++ b/features/fixtures/config/android/common.gradle
@@ -1,4 +1,6 @@
 android {
+    namespace "com.bugsnag.libvanilla"
+
     compileSdkVersion Integer.parseInt(project.ANDROID_COMPILE_SDK_VERSION)
 
     defaultConfig {

--- a/features/fixtures/config/android/debug_proguard.gradle
+++ b/features/fixtures/config/android/debug_proguard.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace "com.bugsnag.libvanilla"
+
     compileSdkVersion Integer.parseInt(project.ANDROID_COMPILE_SDK_VERSION)
 
     defaultConfig {

--- a/features/fixtures/config/android/disabled_obfuscation.gradle
+++ b/features/fixtures/config/android/disabled_obfuscation.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace "com.bugsnag.libvanilla"
+
     compileSdkVersion Integer.parseInt(project.ANDROID_COMPILE_SDK_VERSION)
 
     defaultConfig {

--- a/features/fixtures/mylib/app/build.gradle
+++ b/features/fixtures/mylib/app/build.gradle
@@ -5,6 +5,8 @@ plugins {
 apply plugin: "com.bugsnag.android.gradle"
 
 android {
+    namespace "com.example.bugsnag.mylib"
+
     compileSdkVersion 30
     buildToolsVersion "30.0.3"
 

--- a/features/fixtures/mylib/app/src/main/AndroidManifest.xml
+++ b/features/fixtures/mylib/app/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.example.bugsnag.mylib" />
+<manifest/>

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -5,6 +5,7 @@ ext.abiCodes = ['arm64-v8a': 2, 'armeabi-v7a': 3, 'x86': 4, 'x86_64': 5]
 
 android {
     compileSdkVersion 29
+    namespace "com.bugsnag.android.ndkapp"
     ndkVersion "16.1.4479499"
 
     defaultConfig {

--- a/features/fixtures/ndkapp/app/src/main/AndroidManifest.xml
+++ b/features/fixtures/ndkapp/app/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.bugsnag.android.ndkapp">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application android:label="ndk">
         <activity android:name=".MainActivity">
             <intent-filter>
@@ -11,5 +9,4 @@
         </activity>
         <meta-data android:name="com.bugsnag.android.API_KEY" android:value="TEST_API_KEY"/>
     </application>
-
 </manifest>

--- a/features/fixtures/rn-monorepo/abc/android/app/build.gradle
+++ b/features/fixtures/rn-monorepo/abc/android/app/build.gradle
@@ -125,6 +125,7 @@ def enableHermes = project.ext.react.get("enableHermes", false);
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     ndkVersion "16.1.4479499"
+    namespace "com.abc"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/features/fixtures/rn-monorepo/xyz/android/app/build.gradle
+++ b/features/fixtures/rn-monorepo/xyz/android/app/build.gradle
@@ -122,6 +122,7 @@ def enableHermes = project.ext.react.get("enableHermes", false);
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
+    namespace "com.xyz"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/features/fixtures/rn065/android/app/build.gradle
+++ b/features/fixtures/rn065/android/app/build.gradle
@@ -122,6 +122,7 @@ def enableHermes = project.ext.react.get("enableHermes", false);
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     ndkVersion "16.1.4479499"
+    namespace "com.rn065"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/features/fixtures/unity_2018/example/build.gradle
+++ b/features/fixtures/unity_2018/example/build.gradle
@@ -40,6 +40,7 @@ android {
     compileSdkVersion 29
     ndkVersion "16.1.4479499"
     buildToolsVersion '30.0.2'
+    namespace "com.bugsnag.example"
 
     defaultConfig {
         minSdkVersion 16

--- a/features/fixtures/unity_2019/launcher/build.gradle
+++ b/features/fixtures/unity_2019/launcher/build.gradle
@@ -10,6 +10,7 @@ android {
     compileSdkVersion 28
     ndkVersion "16.1.4479499"
     buildToolsVersion '28.0.3'
+    namespace "com.bugsnag.example"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/features/fixtures/unity_2019/unityLibrary/build.gradle
+++ b/features/fixtures/unity_2019/unityLibrary/build.gradle
@@ -18,6 +18,7 @@ android {
     compileSdkVersion 28
     ndkVersion "16.1.4479499"
     buildToolsVersion '28.0.3'
+    namespace "com.unity3d.player"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/features/react_native.feature
+++ b/features/react_native.feature
@@ -1,5 +1,7 @@
 Feature: Plugin integrated in React Native app
 
+# ReactNative apps cannot currently be built with AGP-8 so we skip these tests until they are supported again (PLAT-9672)
+@skip
 Scenario: Source maps are uploaded when assembling an app with the default project structure
     When I build the React Native app
     And I wait to receive 3 builds
@@ -16,6 +18,8 @@ Scenario: Source maps are uploaded when assembling an app with the default proje
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | true      | false |
 
+# ReactNative apps cannot currently be built with AGP-8 so we skip these tests until they are supported again (PLAT-9672)
+@skip
 Scenario: Source maps are uploaded when assembling a Hermes app with the default project structure
     Given I set environment variable "RN_ENABLE_HERMES" to "true"
     When I build the React Native app
@@ -33,6 +37,8 @@ Scenario: Source maps are uploaded when assembling a Hermes app with the default
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | true      | false |
 
+# ReactNative apps cannot currently be built with AGP-8 so we skip these tests until they are supported again (PLAT-9672)
+@skip
 Scenario: Source maps are uploaded when bundling an app with the default project structure
     And I run the script "features/scripts/bundle_react_native_app.sh" synchronously
     And I wait to receive 3 builds
@@ -49,6 +55,8 @@ Scenario: Source maps are uploaded when bundling an app with the default project
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | true     | false |
 
+# ReactNative apps cannot currently be built with AGP-8 so we skip these tests until they are supported again (PLAT-9672)
+@skip
 Scenario: Source maps are uploaded when assembling an app which uses productFlavors
     When I set environment variable "USE_RN_FLAVORS" to "true"
     When I build the React Native app
@@ -69,6 +77,8 @@ Scenario: Source maps are uploaded when assembling an app which uses productFlav
         | 5              | 2.45.beta  | true     | false |
         | 5              | 2.45.beta  | true     | false |
 
+# ReactNative apps cannot currently be built with AGP-8 so we skip these tests until they are supported again (PLAT-9672)
+@skip
 Scenario: Source maps are uploaded when assembling an app within a monorepo
     When I run the script "features/scripts/build_react_native_monorepo_app.sh" synchronously
     And I wait to receive 3 builds
@@ -85,6 +95,8 @@ Scenario: Source maps are uploaded when assembling an app within a monorepo
       | appVersionCode | appVersion | overwrite | dev   |
       | 5              | 2.45.beta  | true      | false |
 
+# ReactNative apps cannot currently be built with AGP-8 so we skip these tests until they are supported again (PLAT-9672)
+@skip
 Scenario: Setting uploadReactNativeMappings to false will prevent any source map upload
     When I set environment variable "UPLOAD_RN_MAPPINGS" to "false"
     When I build the React Native app
@@ -98,6 +110,8 @@ Scenario: Setting uploadReactNativeMappings to false will prevent any source map
         | versionCode | versionName | appId                     |
         | 5           | 2.45.beta  | com.bugsnag.android.rnapp |
 
+# ReactNative apps cannot currently be built with AGP-8 so we skip these tests until they are supported again (PLAT-9672)
+@skip
 Scenario: Manually invoking source map upload task
     And I run the script "features/scripts/manual_upload_react_native.sh" synchronously
     And I wait to receive 1 build
@@ -105,6 +119,8 @@ Scenario: Manually invoking source map upload task
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | true     | false |
 
+# ReactNative apps cannot currently be built with AGP-8 so we skip these tests until they are supported again (PLAT-9672)
+@skip
 Scenario: Source maps are uploaded in an app using Hermes
     When I set environment variable "RN_ENABLE_HERMES" to "true"
     When I build the React Native app
@@ -122,6 +138,8 @@ Scenario: Source maps are uploaded in an app using Hermes
         | appVersionCode | appVersion | overwrite | dev   |
         | 5              | 2.45.beta  | true     | false |
 
+# ReactNative apps cannot currently be built with AGP-8 so we skip these tests until they are supported again (PLAT-9672)
+@skip
 Scenario: Plugin handles server failure gracefully
     When I set the HTTP status code to 500
     And I run the script "features/scripts/manual_upload_react_native.sh" synchronously
@@ -134,6 +152,8 @@ Scenario: Plugin handles server failure gracefully
         | 5              | 2.45.beta  | true      | false |
         | 5              | 2.45.beta  | true      | false |
 
+# ReactNative apps cannot currently be built with AGP-8 so we skip these tests until they are supported again (PLAT-9672)
+@skip
 Scenario: Source maps are uploaded when assembling an app with a custom nodeModulesDir
     When I set environment variable "CUSTOM_NODE_MODULES_DIR" to "true"
     When I build the React Native app

--- a/features/scripts/install_gradle_plugin.sh
+++ b/features/scripts/install_gradle_plugin.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-./gradlew build install -x groovyDoc -x detekt -x test -PVERSION_NAME=9000.0.0-test
+./gradlew build publishToMavenLocal -x groovyDoc -x detekt -x test -PVERSION_NAME=9000.0.0-test

--- a/features/scripts/install_gradle_plugin.sh
+++ b/features/scripts/install_gradle_plugin.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-./gradlew build publishToMavenLocal -x groovyDoc -x detekt -x test -PVERSION_NAME=9000.0.0-test
+./gradlew assemble publishToMavenLocal -x groovyDoc -x detekt -x test -PVERSION_NAME=9000.0.0-test

--- a/features/steps/gradle_plugin_steps.rb
+++ b/features/steps/gradle_plugin_steps.rb
@@ -161,9 +161,9 @@ def valid_r8_mapping_contents?(mapping_file_lines, expected_entries)
   # validates that the mapping file key is present for each symbol,
   # obfuscated values are not validated as they vary depending on AGP's implementation
   expected_entries.each do |row|
-    expected_entry = row[0] + " ->"
+    expected_entry = row[0]
     has_mapping_entry = mapping_file_lines.one? { |line|
-      line.include? expected_entry
+      line.include?(expected_entry) && line.include?(' -> ')
     }
     assert_true(has_mapping_entry, "No entry in mapping file for '#{row[0]}'.")
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -22,3 +22,7 @@ BeforeAll do
   Maze::Runner.run_command('./features/scripts/install_gradle_plugin.sh')
   Maze::Runner.run_command('./features/scripts/setup_gradle_wrapper.sh')
 end
+
+Before('@skip') do |scenario|
+  skip_this_scenario("Skipping scenario")
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,7 +6,7 @@ BeforeAll do
   # Set which test fixture should be used
   ENV["APP_FIXTURE_DIR"] ||= "features/fixtures/app"
   ENV["NDK_FIXTURE_DIR"] ||= "features/fixtures/ndkapp"
-  ENV["RN_FIXTURE_DIR"] ||= "features/fixtures/rn065/android"
+  ENV["RN_FIXTURE_DIR"] ||= "features/fixtures/rn070/android"
   ENV["LIB_FIXTURE_DIR"] ||= "features/fixtures/mylib"
   ENV["RN_MONOREPO_FIXTURE_DIR"] ||= "features/fixtures/rn-monorepo/abc/android"
   ENV["UNITY_2018_FIXTURE_DIR"] ||= "features/fixtures/unity_2018/example"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "bugsnag-android-gradle-plugin"

--- a/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
@@ -5,7 +5,6 @@ import com.android.build.gradle.AppExtension
 import org.gradle.api.Action
 import org.gradle.api.Project
 
-import java.nio.file.Paths
 import java.util.jar.Attributes
 import java.util.jar.Manifest
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
@@ -112,11 +112,9 @@ internal abstract class BugsnagGenerateNdkSoMappingTask @Inject constructor(
                 abi.set(output.getFilter(VariantOutput.FilterType.ABI))
                 ndkToolchain.set(ndk)
 
-                val externalNativeBuildTaskUtil = ExternalNativeBuildTaskUtil(project.providers)
-
                 searchDirectories.from(searchPaths)
                 variant.externalNativeBuildProviders.forEach { provider ->
-                    searchDirectories.from(externalNativeBuildTaskUtil.findSearchPaths(provider))
+                    searchDirectories.from(ExternalNativeBuildTaskUtil.findSearchPath(provider))
                 }
                 outputDirectory.set(project.layout.buildDirectory.dir(soMappingOutputPath))
             }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateProguardTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateProguardTask.kt
@@ -66,9 +66,7 @@ open class BugsnagGenerateProguardTask @Inject constructor(
         val mappingFile = mappingFileProperty.filter(File::exists).singleFile
         if (!mappingFile.exists()) {
             logger.warn("Bugsnag: Mapping file not found: $mappingFile")
-            if (failOnUploadError.get()) {
-                throw IllegalStateException("Mapping file not found: $mappingFile")
-            }
+            check(failOnUploadError.get()) { "Mapping file not found: $mappingFile" }
         }
         return mappingFile
     }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
@@ -218,18 +218,7 @@ internal abstract class BugsnagGenerateUnitySoMappingTask @Inject constructor(
             val enabled = bugsnag.uploadNdkUnityLibraryMappings.orNull
             return when {
                 enabled != null -> enabled
-                else -> {
-                    // workaround to avoid exception as noCompress was null until AGP 4.1
-                    runCatching {
-                        val clz = android.aaptOptions.javaClass
-                        val method = clz.getMethod("getNoCompress")
-                        val noCompress = method.invoke(android.aaptOptions)
-                        if (noCompress is Collection<*>) {
-                            return noCompress.contains(".unity3d")
-                        }
-                    }
-                    return false
-                }
+                else -> android.aaptOptions.noCompress.contains(".unity3d")
             }
         }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -569,10 +569,8 @@ class BugsnagPlugin : Plugin<Project> {
                 }
             }
             if (checkSearchDirectories) {
-                val externalNativeBuildTaskUtil = ExternalNativeBuildTaskUtil(project.providers)
-
                 variant.externalNativeBuildProviders.forEach { task ->
-                    ndkMappingFileProperty.from(externalNativeBuildTaskUtil.findSearchPaths(task))
+                    ndkMappingFileProperty.from(ExternalNativeBuildTaskUtil.findSearchPath(task))
                 }
             }
             configureMetadata()

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -68,17 +68,17 @@ class BugsnagPlugin : Plugin<Project> {
 
     @Suppress("LongMethod")
     override fun apply(project: Project) {
-        if (AgpVersions.CURRENT < AgpVersions.VERSION_7_0) {
+        if (AgpVersions.CURRENT < AgpVersions.VERSION_8_0) {
             throw StopExecutionException(
-                "Using com.bugsnag.android.gradle:7+ with Android Gradle Plugin < 7 " +
-                    "is not supported. Either upgrade the Android Gradle Plugin to 7, or use an " +
+                "Using com.bugsnag.android.gradle:8+ with Android Gradle Plugin < 8 " +
+                    "is not supported. Either upgrade the Android Gradle Plugin to 8, or use an " +
                     "earlier version of the BugSnag Gradle Plugin. " +
                     "For more information about this change, see " +
                     "https://docs.bugsnag.com/build-integrations/gradle/"
             )
-        } else if (AgpVersions.CURRENT >= AgpVersions.VERSION_8_0) {
+        } else if (AgpVersions.CURRENT >= AgpVersions.VERSION_9_0) {
             project.logger.warn(
-                "Using com.bugsnag.android.gradle:7+ with Android Gradle Plugin 8+ is not " +
+                "Using com.bugsnag.android.gradle:8+ with Android Gradle Plugin 9+ is not " +
                     "formally supported, and may lead to compatibility errors. " +
                     "For more information, please see " +
                     "https://docs.bugsnag.com/build-integrations/gradle/"

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
@@ -30,7 +30,7 @@ import org.gradle.process.ExecOperations
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
 import org.gradle.process.internal.ExecException
-import org.gradle.util.VersionNumber
+import org.semver.Version
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -277,7 +277,7 @@ open class BugsnagReleasesTask @Inject constructor(
     internal fun configureMetadata() {
         val gradleVersionNumber = gradleVersion.orNull?.let {
             gradleVersion.set(it)
-            VersionNumber.parse(it)
+            Version.parse(it)
         }
         gitVersion.set(providerFactory.provider { runCmd(VCS_COMMAND, "--version") })
         osArch.set(providerFactory.systemPropertyCompat(MK_OS_ARCH, gradleVersionNumber))

--- a/src/main/kotlin/com/bugsnag/android/gradle/MappingFileProvider.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/MappingFileProvider.kt
@@ -4,11 +4,12 @@ import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
 import com.bugsnag.android.gradle.internal.findMappingFileDexguard9
 import com.bugsnag.android.gradle.internal.findMappingFileDexguardLegacy
-import com.bugsnag.android.gradle.internal.getDexguardMajorVersionInt
+import com.bugsnag.android.gradle.internal.getDexguardVersion
 import com.bugsnag.android.gradle.internal.hasDexguardPlugin
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
+import org.semver.Version
 
 /**
  * Creates a Provider which finds the mapping file for a given variantOutput and filters out
@@ -30,7 +31,8 @@ private fun findMappingFiles(
 ): Provider<FileCollection> {
     return when {
         project.hasDexguardPlugin() -> {
-            if (getDexguardMajorVersionInt(project) >= 9) {
+            val dexguardVersion = getDexguardVersion(project)
+            if (dexguardVersion != null && dexguardVersion >= Version(9, 0, 0)) {
                 project.provider {
                     val files = findMappingFileDexguard9(project, variant, variantOutput)
                     project.layout.files(files)

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/AbstractSoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/AbstractSoMappingTask.kt
@@ -61,11 +61,7 @@ abstract class AbstractSoMappingTask : DefaultTask() {
         outputZipFile(process.inputStream, dst)
 
         val exitCode = process.waitFor()
-        if (exitCode != 0) {
-            throw IllegalStateException(
-                "Failed to generate symbols for $dst, objdump exited with code $exitCode"
-            )
-        }
+        check(exitCode == 0) { "Failed to generate symbols for $dst, objdump exited with code $exitCode" }
     }
 
     protected open fun outputFileFor(soFile: File, abi: Abi): File {

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
@@ -4,7 +4,7 @@ import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
 import com.bugsnag.android.gradle.GroovyCompat
 import org.gradle.api.Project
-import org.gradle.util.VersionNumber
+import org.semver.Version
 import java.io.File
 import java.nio.file.Paths
 
@@ -77,10 +77,9 @@ internal fun Project.isDexguardEnabledForVariant(variant: BaseVariant): Boolean 
 /**
  * Retrieves the major version of DexGuard in use in the project
  */
-internal fun getDexguardMajorVersionInt(project: Project): Int {
-    val version = GroovyCompat.getDexguardVersionString(project) ?: ""
-    val versionNumber = VersionNumber.parse(version)
-    return versionNumber.major
+internal fun getDexguardVersion(project: Project): Version? {
+    val version = GroovyCompat.getDexguardVersionString(project) ?: return null
+    return Version.parse(version)
 }
 
 /**

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/ExternalNativeBuildTaskUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/ExternalNativeBuildTaskUtil.kt
@@ -1,31 +1,13 @@
 package com.bugsnag.android.gradle.internal
 
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderFactory
-import java.io.File
-import kotlin.reflect.full.memberProperties
 
-class ExternalNativeBuildTaskUtil(private val providerFactory: ProviderFactory) {
-    private fun getSearchDir(buildTask: Provider<ExternalNativeBuildTask>, propName: String): Provider<File> =
-        buildTask.flatMap { task ->
-            val soFolder = ExternalNativeBuildTask::class.memberProperties.find { it.name == propName }?.get(task)!!
-            when (soFolder) {
-                is File -> providerFactory.provider { fixNativeOutputPath(soFolder) }
-                is DirectoryProperty -> soFolder.map { fixNativeOutputPath(it.asFile) }
-                else -> throw IllegalArgumentException("Unknown type of $propName: $soFolder")
-            }
+object ExternalNativeBuildTaskUtil {
+    fun findSearchPath(buildTask: Provider<ExternalNativeBuildTask>) =
+        buildTask.flatMap { it.soFolder }.map { soFolder ->
+            soFolder.asFile.parentFile.parentFile.takeIf { it.parentFile.name == "cxx" }
+                ?: soFolder.asFile.parentFile.parentFile.parentFile.takeIf { it.parentFile.name == "cxx" }
+                ?: soFolder.asFile
         }
-
-    private fun fixNativeOutputPath(taskFolder: File): File {
-        return taskFolder.parentFile.parentFile.takeIf { it.parentFile.name == "cxx" }
-            ?: taskFolder.parentFile.parentFile.parentFile.takeIf { it.parentFile.name == "cxx" }
-            ?: taskFolder
-    }
-
-    fun findSearchPaths(buildTask: Provider<ExternalNativeBuildTask>) = arrayOf(
-        getSearchDir(buildTask, "objFolder"),
-        getSearchDir(buildTask, "soFolder")
-    )
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
@@ -25,18 +25,18 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.util.VersionNumber
+import org.semver.Version
 import java.io.File
 
 internal object GradleVersions {
-    val VERSION_6_1: VersionNumber = VersionNumber.parse("6.1")
+    val VERSION_6_1: Version = Version.parse("6.1")
 }
 
 internal object AgpVersions {
     // Use baseVersion to avoid any qualifiers like `-alpha06`
-    val CURRENT: VersionNumber = VersionNumber.parse(ANDROID_GRADLE_PLUGIN_VERSION).baseVersion
-    val VERSION_8_0: VersionNumber = VersionNumber.parse("8.0.0")
-    val VERSION_9_0: VersionNumber = VersionNumber.parse("9.0.0")
+    val CURRENT: Version = Version.parse(ANDROID_GRADLE_PLUGIN_VERSION).toReleaseVersion()
+    val VERSION_8_0: Version = Version.parse("8.0.0")
+    val VERSION_9_0: Version = Version.parse("9.0.0")
 }
 
 /** A fast file hash that don't load the entire file contents into memory at once. */
@@ -117,7 +117,7 @@ internal fun ApkVariantOutput.includesAbi(abi: String): Boolean {
 /** Returns a String provider for a system property. */
 internal fun ProviderFactory.systemPropertyCompat(
     name: String,
-    gradleVersion: VersionNumber?
+    gradleVersion: Version?
 ): Provider<String> {
     return if (gradleVersion != null && gradleVersion >= GradleVersions.VERSION_6_1) {
         systemProperty(name)

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
@@ -48,6 +48,7 @@ internal object AgpVersions {
     val VERSION_4_2: VersionNumber = VersionNumber.parse("4.2.0")
     val VERSION_7_0: VersionNumber = VersionNumber.parse("7.0.0")
     val VERSION_8_0: VersionNumber = VersionNumber.parse("8.0.0")
+    val VERSION_9_0: VersionNumber = VersionNumber.parse("9.0.0")
 }
 
 /** A fast file hash that don't load the entire file contents into memory at once. */

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
@@ -16,7 +16,6 @@ import okio.source
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.invocation.Gradle
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
@@ -30,23 +29,12 @@ import org.gradle.util.VersionNumber
 import java.io.File
 
 internal object GradleVersions {
-    val VERSION_5_3: VersionNumber = VersionNumber.parse("5.3")
-    val VERSION_6: VersionNumber = VersionNumber.parse("6.0")
     val VERSION_6_1: VersionNumber = VersionNumber.parse("6.1")
-    val VERSION_6_6: VersionNumber = VersionNumber.parse("6.6")
 }
-
-internal fun Gradle.versionNumber(): VersionNumber = VersionNumber.parse(gradleVersion)
 
 internal object AgpVersions {
     // Use baseVersion to avoid any qualifiers like `-alpha06`
     val CURRENT: VersionNumber = VersionNumber.parse(ANDROID_GRADLE_PLUGIN_VERSION).baseVersion
-    val VERSION_3_4: VersionNumber = VersionNumber.parse("3.4.0")
-    val VERSION_3_5: VersionNumber = VersionNumber.parse("3.5.0")
-    val VERSION_4_0: VersionNumber = VersionNumber.parse("4.0.0")
-    val VERSION_4_1: VersionNumber = VersionNumber.parse("4.1.0")
-    val VERSION_4_2: VersionNumber = VersionNumber.parse("4.2.0")
-    val VERSION_7_0: VersionNumber = VersionNumber.parse("7.0.0")
     val VERSION_8_0: VersionNumber = VersionNumber.parse("8.0.0")
     val VERSION_9_0: VersionNumber = VersionNumber.parse("9.0.0")
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/NdkToolchain.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/NdkToolchain.kt
@@ -16,7 +16,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.StopExecutionException
-import org.gradle.util.VersionNumber
+import org.semver.Version
 import java.io.File
 
 abstract class NdkToolchain {
@@ -42,7 +42,7 @@ abstract class NdkToolchain {
 
     fun preferredMappingTool(): MappingTool {
         var legacyUploadRequired = bugsnagNdkVersion.orNull
-            ?.let { VersionNumber.parse(it) }
+            ?.let { Version.parse(it) }
             ?.let { it < MIN_BUGSNAG_ANDROID_VERSION }
         if (legacyUploadRequired == null) {
             logger.warn(
@@ -129,17 +129,17 @@ abstract class NdkToolchain {
          * Minimum `bugsnag-android` version where the new symbol uploading is available, using `objcopy` to produce
          * the symbol files instead of `objdump`
          */
-        internal val MIN_BUGSNAG_ANDROID_VERSION = VersionNumber.version(5, 26)
+        internal val MIN_BUGSNAG_ANDROID_VERSION = Version(5, 26, 0)
 
         /**
          * The minimum NDK version where we will use `objcopy` instead of `objdump` to produce the symbol files
          */
-        internal val MIN_NDK_OBJCOPY_VERSION = VersionNumber.version(21)
+        internal val MIN_NDK_OBJCOPY_VERSION = Version(21, 0, 0)
 
         /**
          * The minimum NDK version where we will use the LLVM toolchain instead of the GNU toolchain
          */
-        internal val MIN_NDK_LLVM_VERSION = VersionNumber.version(23)
+        internal val MIN_NDK_LLVM_VERSION = Version(23, 0, 0)
 
         private val osName = when {
             Os.isFamily(Os.FAMILY_MAC) -> "darwin-x86_64"
@@ -195,5 +195,5 @@ abstract class NdkToolchain {
     }
 }
 
-private val NdkToolchain.version get() = baseDir.map { VersionNumber.parse(it.asFile.name) }
+private val NdkToolchain.version get() = baseDir.map { Version.parse(it.asFile.name) }
 private val NdkToolchain.isLLVMPreferred get() = version.map { it >= NdkToolchain.MIN_NDK_LLVM_VERSION }

--- a/src/main/resources/META-INF/gradle-plugins/com.bugsnag.android.gradle.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.bugsnag.android.gradle.properties
@@ -1,1 +1,0 @@
-implementation-class=com.bugsnag.android.gradle.BugsnagPlugin

--- a/src/test/kotlin/com/bugsnag/android/gradle/internal/DexguardCompatKtTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/internal/DexguardCompatKtTest.kt
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
+import org.semver.Version
 import java.io.File
 
 @RunWith(MockitoJUnitRunner::class)
@@ -75,14 +76,14 @@ class DexguardCompatKtTest {
     fun dexguardMajorVersionNull() {
         // handles when dexguard is not applied
         `when`(extensions.findByName("dexguard")).thenReturn(null)
-        assertEquals(0, getDexguardMajorVersionInt(proj))
+        assertNull(getDexguardVersion(proj))
     }
 
     @Test
     fun dexguardMajorFromVersion() {
         // dexguard.version set
         `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("version", "8.7.02")))
-        assertEquals(8, getDexguardMajorVersionInt(proj))
+        assertEquals(Version(8, 7, 2), getDexguardVersion(proj))
     }
 
     @Test


### PR DESCRIPTION
## Goal
Update the `bugsnag-android-gradle-plugin` to support Android Gradle Plugin 8.

## Changelog

- Update dependencies to support AGP-8 / Gradle 8
- Change the CI pipeline to use Java 14 (required by AGP-8)
- Remove the use of Gradle's deprecated `VersionNumber` class

## Testing
Modified existing test fixtures to be compatible with AGP-8.