### PR TITLE
Make objcopy the default NDK symbol extraction tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,21 @@
 ## TBD
 
+### Enhancements
+
+* Support for Android Gradle Plugin 8.0+
+  [#500](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/500)
+* NDK: `objcopy` is now the default symbol-extraction mechanism (useLegacyNdkSymbolUpload is `false` by default)
+  [#505](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/505)
+
+## 7.4.1 (2023-02-22)
+
 ### Bug Fixes
 
 * Fix task ordering when using DexGuard and a `bundle***` task
-  [496](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/496)
+  [#496](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/496)
+* Improve support for Gradle Configuration Caching
+  [#491](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/491)
+  [#499](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/499)
 
 ## 7.4.0 (2022-11-10)
 

--- a/features/fixtures/config/ndk/objcopy.gradle
+++ b/features/fixtures/config/ndk/objcopy.gradle
@@ -3,4 +3,3 @@ dependencies {
 }
 
 android.ndkVersion = "24.0.8215888"
-bugsnag.useLegacyNdkSymbolUpload = false

--- a/features/fixtures/config/ndk/objdump.gradle
+++ b/features/fixtures/config/ndk/objdump.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    implementation 'com.bugsnag:bugsnag-android:5.26.0'
+}
+
+android.ndkVersion = "16.1.4479499"
+bugsnag.useLegacyNdkSymbolUpload = true

--- a/features/fixtures/config/ndk/standard.gradle
+++ b/features/fixtures/config/ndk/standard.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation 'com.bugsnag:bugsnag-android:5.9.4'
+    implementation 'com.bugsnag:bugsnag-android:5.26.0'
 }

--- a/features/fixtures/ndkapp/app/build.gradle
+++ b/features/fixtures/ndkapp/app/build.gradle
@@ -6,7 +6,7 @@ ext.abiCodes = ['arm64-v8a': 2, 'armeabi-v7a': 3, 'x86': 4, 'x86_64': 5]
 android {
     compileSdkVersion 29
     namespace "com.bugsnag.android.ndkapp"
-    ndkVersion "16.1.4479499"
+    ndkVersion "24.0.8215888"
 
     defaultConfig {
         applicationId "com.bugsnag.android.ndkapp"

--- a/features/fixtures/ndkapp/app/src/main/cpp/Application.mk
+++ b/features/fixtures/ndkapp/app/src/main/cpp/Application.mk
@@ -1,3 +1,3 @@
 APP_PLATFORM := android-14
 APP_ABI      := arm64-v8a armeabi-v7a x86 x86_64
-APP_STL      := stlport_static
+APP_STL      := c++_static

--- a/features/ndk_app.feature
+++ b/features/ndk_app.feature
@@ -8,12 +8,12 @@ Scenario: NDK apps send requests
       | appVersionCode | appVersion | buildTool      |
       | 1              | 1.0        | gradle-android |
 
-    And 4 requests are valid for the android NDK mapping API and match the following:
-      | arch        | projectRoot | sharedObjectName |
-      | arm64-v8a   | /\S+/       | libnative-lib.so |
-      | armeabi-v7a | /\S+/       | libnative-lib.so |
-      | x86         | /\S+/       | libnative-lib.so |
-      | x86_64      | /\S+/       | libnative-lib.so |
+    And 4 requests are valid for the android so symbol mapping API and match the following:
+      | projectRoot | sharedObjectName |
+      | /\S+/       | libnative-lib.so |
+      | /\S+/       | libnative-lib.so |
+      | /\S+/       | libnative-lib.so |
+      | /\S+/       | libnative-lib.so |
 
     And 1 requests are valid for the android mapping API and match the following:
       | appId                      |
@@ -32,12 +32,12 @@ Scenario: ndkBuild apps send requests
         | appVersionCode | appVersion | buildTool      |
         | 1              | 1.0        | gradle-android |
 
-    And 4 requests are valid for the android NDK mapping API and match the following:
-        | arch        | projectRoot | sharedObjectName |
-        | arm64-v8a   | /\S+/       | libnative-lib.so |
-        | armeabi-v7a | /\S+/       | libnative-lib.so |
-        | x86         | /\S+/       | libnative-lib.so |
-        | x86_64      | /\S+/       | libnative-lib.so |
+    And 4 requests are valid for the android so symbol mapping API and match the following:
+        | projectRoot | sharedObjectName |
+        | /\S+/       | libnative-lib.so |
+        | /\S+/       | libnative-lib.so |
+        | /\S+/       | libnative-lib.so |
+        | /\S+/       | libnative-lib.so |
 
     And 1 requests are valid for the android mapping API and match the following:
         | appId                      |
@@ -57,12 +57,12 @@ Scenario: Custom projectRoot is added to payload
       | appVersionCode | appVersion | buildTool      |
       | 1              | 1.0        | gradle-android |
 
-    And 4 requests are valid for the android NDK mapping API and match the following:
-      | arch        | projectRoot          |
-      | arm64-v8a   | /repos/custom/my-app |
-      | armeabi-v7a | /repos/custom/my-app |
-      | x86         | /repos/custom/my-app |
-      | x86_64      | /repos/custom/my-app |
+    And 4 requests are valid for the android so symbol mapping API and match the following:
+      | projectRoot          |
+      | /repos/custom/my-app |
+      | /repos/custom/my-app |
+      | /repos/custom/my-app |
+      | /repos/custom/my-app |
 
     And 1 requests are valid for the android mapping API and match the following:
         | appId                      |
@@ -71,7 +71,7 @@ Scenario: Custom projectRoot is added to payload
 # Sets a non-existent objdump location for x86 and arm64-v8a, delivery should proceed as normal for other files
 Scenario: Custom objdump location
     When I set environment variable "OBJDUMP_LOCATION" to "/fake/objdump"
-    And I build the NDK app
+    And I build the NDK app using the "objdump" config
     And I wait to receive 4 builds
 
     Then 1 requests are valid for the build API and match the following:
@@ -87,6 +87,25 @@ Scenario: Custom objdump location
         | appId                      |
         | com.bugsnag.android.ndkapp |
 
+Scenario: objdump upload
+    And I build the NDK app using the "objdump" config
+    And I wait to receive 6 builds
+
+    Then 1 requests are valid for the build API and match the following:
+        | appVersionCode | appVersion | buildTool      |
+        | 1              | 1.0        | gradle-android |
+
+    And 4 requests are valid for the android NDK mapping API and match the following:
+        | arch        | projectRoot | sharedObjectName |
+        | arm64-v8a   | /\S+/       | libnative-lib.so |
+        | armeabi-v7a | /\S+/       | libnative-lib.so |
+        | x86         | /\S+/       | libnative-lib.so |
+        | x86_64      | /\S+/       | libnative-lib.so |
+
+    And 1 requests are valid for the android mapping API and match the following:
+        | appId                      |
+        | com.bugsnag.android.ndkapp |
+
 Scenario: Mapping files uploaded for custom sharedObjectPaths
     When I set environment variable "USE_SHARED_OBJECT_PATH" to "true"
     When I build the NDK app
@@ -96,16 +115,16 @@ Scenario: Mapping files uploaded for custom sharedObjectPaths
         | appVersionCode | appVersion | buildTool      |
         | 1              | 1.0        | gradle-android |
 
-    And 8 requests are valid for the android NDK mapping API and match the following:
-        | arch        | projectRoot | sharedObjectName |
-        | arm64-v8a   | /\S+/       | libnative-lib.so |
-        | arm64-v8a   | /\S+/       | libmonochrome.so |
-        | armeabi-v7a | /\S+/       | libnative-lib.so |
-        | armeabi-v7a | /\S+/       | libmonochrome.so |
-        | x86         | /\S+/       | libnative-lib.so |
-        | x86         | /\S+/       | libmonochrome.so |
-        | x86_64      | /\S+/       | libnative-lib.so |
-        | x86_64      | /\S+/       | libmonochrome.so |
+    And 8 requests are valid for the android so symbol mapping API and match the following:
+        | projectRoot | sharedObjectName |
+        | /\S+/       | libnative-lib.so |
+        | /\S+/       | libmonochrome.so |
+        | /\S+/       | libnative-lib.so |
+        | /\S+/       | libmonochrome.so |
+        | /\S+/       | libnative-lib.so |
+        | /\S+/       | libmonochrome.so |
+        | /\S+/       | libnative-lib.so |
+        | /\S+/       | libmonochrome.so |
 
     And 1 requests are valid for the android mapping API and match the following:
         | appId                      |

--- a/features/proxy.feature
+++ b/features/proxy.feature
@@ -49,12 +49,12 @@ Scenario: NDK request for basic HTTP proxy
         | appVersionCode | appVersion | buildTool      |
         | 1              | 1.0        | gradle-android |
 
-    And 4 requests are valid for the android NDK mapping API and match the following:
-        | arch        |
-        | arm64-v8a   |
-        | armeabi-v7a |
-        | x86         |
-        | x86_64      |
+    And 4 requests are valid for the android so symbol mapping API and match the following:
+        | projectRoot | sharedObjectName |
+        | /\S+/       | libnative-lib.so |
+        | /\S+/       | libnative-lib.so |
+        | /\S+/       | libnative-lib.so |
+        | /\S+/       | libnative-lib.so |
 
     And 1 requests are valid for the android mapping API and match the following:
         | appId                      |

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
@@ -85,7 +85,8 @@ open class BugsnagPluginExtension @Inject constructor(objects: ObjectFactory) {
     val objdumpPaths: MapProperty<String, String> = objects.mapProperty<String, String>()
         .convention(emptyMap())
 
-    val useLegacyNdkSymbolUpload: Property<Boolean> = objects.property<Boolean>().convention(true)
+    val useLegacyNdkSymbolUpload: Property<Boolean> = objects.property<Boolean>()
+        .convention(false)
 
     // exposes sourceControl as a nested object on the extension,
     // see https://docs.gradle.org/current/userguide/custom_gradle_types.html#nested_objects


### PR DESCRIPTION
## Goal
Change `useLegacyNdkSymbolUpload` to be `false` by default, making `objcopy` the default symbols extraction mechanism for NDK builds.

## Testing
Updated the end to end tests to reflect the change from `objdump` to `objcopy`