### PR TITLE
Replaced use of deprecated `capitalize` function

### DIFF
--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateNdkSoMappingTask.kt
@@ -126,6 +126,6 @@ internal abstract class BugsnagGenerateNdkSoMappingTask @Inject constructor(
         }
 
         override fun taskNameFor(variantOutputName: String) =
-            "generateBugsnagNdk${variantOutputName.capitalize()}Mapping"
+            "generateBugsnagNdk${variantOutputName.replaceFirstChar { it.uppercaseChar() }}Mapping"
     }
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateProguardTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateProguardTask.kt
@@ -72,7 +72,8 @@ open class BugsnagGenerateProguardTask @Inject constructor(
     }
 
     companion object : VariantTaskCompanion<BugsnagGenerateProguardTask> {
-        override fun taskNameFor(variantOutputName: String) = "generateBugsnag${variantOutputName.capitalize()}Mapping"
+        override fun taskNameFor(variantOutputName: String) =
+            "generateBugsnag${variantOutputName.replaceFirstChar { it.uppercaseChar() }}Mapping"
 
         fun archiveOutputFile(project: Project, output: BaseVariantOutput): Provider<RegularFile> =
             forBuildOutput(project, output).flatMap { it.archiveOutputFile }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagGenerateUnitySoMappingTask.kt
@@ -223,6 +223,6 @@ internal abstract class BugsnagGenerateUnitySoMappingTask @Inject constructor(
         }
 
         override fun taskNameFor(variantOutputName: String) =
-            "generateBugsnagUnity${variantOutputName.capitalize()}Mapping"
+            "generateBugsnagUnity${variantOutputName.replaceFirstChar { it.uppercaseChar() }}Mapping"
     }
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagManifestUuidTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagManifestUuidTask.kt
@@ -74,6 +74,6 @@ abstract class BugsnagManifestUuidTask @Inject constructor(
             forBuildOutput(project, output).flatMap { it.manifestInfoProvider }
 
         override fun taskNameFor(variantOutputName: String): String =
-            "processBugsnag${variantOutputName.capitalize()}Manifest"
+            "processBugsnag${variantOutputName.replaceFirstChar { it.uppercaseChar() }}Manifest"
     }
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -482,7 +482,7 @@ class BugsnagPlugin : Plugin<Project> {
 
         // lookup the react-native task by its name
         // https://github.com/facebook/react-native/blob/master/react.gradle#L132
-        val rnTaskName = "bundle${variant.name.capitalize()}JsAndAssets"
+        val rnTaskName = "bundle${variant.name.replaceFirstChar { it.uppercaseChar() }}JsAndAssets"
         val rnTask: Task? = project.tasks.findByName(rnTaskName)
         if (rnTask == null) {
             project.logger.error("Bugsnag: unable to find ReactNative bundle task '$rnTaskName'")

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadSoSymTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagUploadSoSymTask.kt
@@ -156,7 +156,8 @@ internal abstract class BugsnagUploadSoSymTask : DefaultTask(), AndroidManifestI
         private const val VALID_SO_FILE_THRESHOLD = 1024
 
         fun taskNameFor(variant: BaseVariantOutput, uploadType: UploadType) =
-            "uploadBugsnag${uploadType.name.toLowerCase().capitalize()}${variant.baseName.capitalize()}Mapping"
+            "uploadBugsnag${uploadType.name.toLowerCase().replaceFirstChar { it.uppercaseChar() }}" +
+                "${variant.baseName.replaceFirstChar { it.uppercaseChar() }}Mapping"
 
         internal fun requestOutputFileFor(project: Project, output: BaseVariantOutput): Provider<RegularFile> {
             val path = "intermediates/bugsnag/requests/symFor${output.taskNameSuffix()}.json"

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagIntermediates.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagIntermediates.kt
@@ -30,7 +30,7 @@ internal const val UNITY_SO_MAPPING_DIR = "intermediates/bugsnag/soMappings/unit
 /**
  * Gets a unique suffix for a [BaseVariantOutput] which is used in tasks and intermediate directories
  */
-internal fun BaseVariantOutput.taskNameSuffix() = name.capitalize()
+internal fun BaseVariantOutput.taskNameSuffix() = name.replaceFirstChar { it.uppercaseChar() }
 
 /** Intermediate locations for task outputs/inputs **/
 
@@ -70,7 +70,7 @@ internal fun intermediateForRescuedReactNativeBundle(project: Project, output: B
 }
 
 internal fun Project.computeManifestInfoOutputV2(variant: String): Provider<RegularFile> {
-    val path = "intermediates/bugsnag/manifestInfoFor${variant.capitalize()}.json"
+    val path = "intermediates/bugsnag/manifestInfoFor${variant.replaceFirstChar { it.uppercaseChar() }}.json"
     return layout.buildDirectory.file(path)
 }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagTasks.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/BugsnagTasks.kt
@@ -13,7 +13,7 @@ internal fun taskNameForUploadRelease(output: BaseVariantOutput) =
     "bugsnagRelease${output.taskNameSuffix()}Task"
 
 internal fun taskNameForManifestUuid(variantOutput: String) =
-    "processBugsnag${variantOutput.capitalize()}Manifest"
+    "processBugsnag${variantOutput.replaceFirstChar { it.uppercaseChar() }}Manifest"
 
 internal fun taskNameForUploadSourcemaps(output: BaseVariantOutput) =
     "uploadBugsnag${output.taskNameSuffix()}SourceMaps"

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
@@ -70,7 +70,9 @@ internal fun Project.hasDexguardPlugin(): Boolean {
  */
 internal fun Project.isDexguardEnabledForVariant(variant: BaseVariant): Boolean {
     val flavor = variant.flavorName
-    val buildType = if (flavor.isEmpty()) variant.buildType.name else variant.buildType.name.capitalize()
+    val buildType =
+        if (flavor.isEmpty()) variant.buildType.name
+        else variant.buildType.name.replaceFirstChar { it.uppercaseChar() }
     return GroovyCompat.isDexguardEnabledForVariant(project, "$flavor$buildType")
 }
 
@@ -86,7 +88,7 @@ internal fun getDexguardVersion(project: Project): Version? {
  * Gets the task name for the Dexguard App Bundle task for this variant.
  */
 internal fun getDexguardAabTaskName(variant: BaseVariant): String {
-    val buildType = variant.buildType.name.capitalize()
-    val flavor = variant.flavorName.capitalize()
+    val buildType = variant.buildType.name.replaceFirstChar { it.uppercaseChar() }
+    val flavor = variant.flavorName.replaceFirstChar { it.uppercaseChar() }
     return "dexguardAab$flavor$buildType"
 }

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/UploadRequestClient.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/UploadRequestClient.kt
@@ -48,7 +48,7 @@ abstract class UploadRequestClient : AutoCloseable, BuildService<BuildServicePar
 
 internal fun newUploadRequestClientProvider(project: Project, prefix: String): Provider<out UploadRequestClient> {
     return project.gradle.sharedServices.registerIfAbsent(
-        "bugsnag${prefix.capitalize()}UploadRequestClient",
+        "bugsnag${prefix.replaceFirstChar { it.uppercaseChar() }}UploadRequestClient",
         UploadRequestClient::class.java
     ) {
         // No parameters!


### PR DESCRIPTION
## Goal
Remove our usage of the `capitalize` function, which has been deprecated.

## Design
Replace `capitalize` with `replaceFirstChar { it.uppercaseChar() }` which uses a non-locale-specific uppercase.

## Testing
Relied on existing tests