### PR TITLE
NDK version detection based on package.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Enhancements
+
+* Determine the NDK version being used based on the `package.xml` files within the NDK directories, with a fallback to the directory-name.
+  [#514](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/514)
+
 ## 7.4.1 (2023-02-22)
 
 ### Bug Fixes

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
@@ -85,7 +85,8 @@ open class BugsnagPluginExtension @Inject constructor(objects: ObjectFactory) {
     val objdumpPaths: MapProperty<String, String> = objects.mapProperty<String, String>()
         .convention(emptyMap())
 
-    val useLegacyNdkSymbolUpload: Property<Boolean> = objects.property<Boolean>().convention(true)
+    val useLegacyNdkSymbolUpload: Property<Boolean> = objects.property<Boolean>()
+        .convention(NULL_BOOLEAN)
 
     // exposes sourceControl as a nested object on the extension,
     // see https://docs.gradle.org/current/userguide/custom_gradle_types.html#nested_objects

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/NdkPackageXmlParser.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/NdkPackageXmlParser.kt
@@ -1,0 +1,61 @@
+package com.bugsnag.android.gradle.internal
+
+import org.gradle.util.VersionNumber
+import org.w3c.dom.Document
+import org.w3c.dom.Node
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+internal object NdkPackageXmlParser {
+    private const val PACKAGE_XML_FILENAME = "package.xml"
+    private const val TAG_REVISION = "revision"
+    private const val TAG_MAJOR = "major"
+    private const val TAG_MINOR = "minor"
+    private const val TAG_MICRO = "micro"
+
+    internal fun loadVersionFromPackageXml(ndkDir: File): VersionNumber {
+        val packageFile = File(ndkDir, PACKAGE_XML_FILENAME)
+        var versionNumber: VersionNumber? = null
+        if (packageFile.canRead()) {
+            versionNumber = loadPackageXml(packageFile) { doc ->
+                val revision = doc.getElementsByTagName(TAG_REVISION).item(0)
+                val major = revision.getChildValue(TAG_MAJOR)
+                val minor = revision.getChildValue(TAG_MINOR)
+                val micro = revision.getChildValue(TAG_MICRO)
+
+                VersionNumber(
+                    major?.toIntOrNull() ?: 0,
+                    minor?.toIntOrNull() ?: 0,
+                    micro?.toIntOrNull() ?: 0,
+                    null
+                )
+            }
+        }
+
+        return versionNumber ?: VersionNumber.parse(ndkDir.name) // fallback to trying to parse the dir name
+    }
+
+    private inline fun <T> loadPackageXml(packageFile: File, action: (Document) -> T): T? {
+        return packageFile.inputStream().buffered().use { stream ->
+            @Suppress("TooGenericExceptionCaught", "SwallowedException")
+            try {
+                val builder = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                val document = builder.parse(stream)
+                action(document)
+            } catch (ex: Exception) {
+                null
+            }
+        }
+    }
+
+    private fun Node.getChildValue(elementName: String): String? {
+        val children = childNodes
+        repeat(children.length) { index ->
+            if (children.item(index).nodeName == elementName) {
+                return children.item(index).textContent
+            }
+        }
+
+        return null
+    }
+}

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/NdkToolchain.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/NdkToolchain.kt
@@ -12,10 +12,10 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.StopExecutionException
 import org.gradle.util.VersionNumber
 import java.io.File
 
@@ -26,6 +26,7 @@ abstract class NdkToolchain {
     abstract val baseDir: DirectoryProperty
 
     @get:Input
+    @get:Optional
     abstract val useLegacyNdkSymbolUpload: Property<Boolean>
 
     @get:Input
@@ -41,6 +42,15 @@ abstract class NdkToolchain {
     private val logger: Logger = Logging.getLogger(this::class.java)
 
     fun preferredMappingTool(): MappingTool {
+        val forceNdkSymbolTool = useLegacyNdkSymbolUpload.orNull
+        if (forceNdkSymbolTool != null) {
+            return if (forceNdkSymbolTool == true) MappingTool.OBJDUMP else MappingTool.OBJCOPY
+        }
+
+        return detectMappingTool()
+    }
+
+    private fun detectMappingTool(): MappingTool {
         var legacyUploadRequired = bugsnagNdkVersion.orNull
             ?.let { VersionNumber.parse(it) }
             ?.let { it < MIN_BUGSNAG_ANDROID_VERSION }
@@ -56,35 +66,11 @@ abstract class NdkToolchain {
             legacyUploadRequired = false
         }
 
-        if (!useLegacyNdkSymbolUpload.get() && legacyUploadRequired) {
-            throw StopExecutionException(
-                "Your Bugsnag SDK configured for variant ${variantName.get()} does not support the new NDK " +
-                    "symbols upload mechanism. Please set legacyNDKSymbolsUpload or upgrade your " +
-                    "Bugsnag SDK. See https://docs.bugsnag.com/api/ndk-symbol-mapping-upload/ for details."
-            )
-        }
-
-        // useLegacyNdkSymbolUpload force overrides any defaults or options
-        if (useLegacyNdkSymbolUpload.get()) {
-            return MappingTool.OBJDUMP
-        }
-
         val ndkVersion = version.get()
         return when {
-            ndkVersion >= MIN_NDK_OBJCOPY_VERSION -> MappingTool.OBJCOPY
+            !legacyUploadRequired && ndkVersion >= MIN_NDK_OBJCOPY_VERSION -> MappingTool.OBJCOPY
             else -> MappingTool.OBJDUMP
         }
-    }
-
-    /**
-     * Set all the fields of this `NdkToolchain` based on the given [other] `NdkToolchain`
-     */
-    fun configureWith(other: NdkToolchain) {
-        baseDir.set(other.baseDir)
-        overrides.set(other.overrides)
-        useLegacyNdkSymbolUpload.set(other.useLegacyNdkSymbolUpload)
-        bugsnagNdkVersion.set(other.bugsnagNdkVersion)
-        variantName.set(other.variantName)
     }
 
     private fun executableName(cmdName: String): String {
@@ -174,7 +160,7 @@ abstract class NdkToolchain {
             bugsnag: BugsnagPluginExtension,
             variant: ApkVariant
         ): NdkToolchain {
-            val useLegacyNdkSymbolUpload = bugsnag.useLegacyNdkSymbolUpload.get()
+            val useLegacyNdkSymbolUpload = bugsnag.useLegacyNdkSymbolUpload.orNull
             val overrides = bugsnag.objdumpPaths.map { it.mapKeys { (abi, _) -> Abi.findByName(abi)!! } }
 
             val ndkToolchain = project.objects.newInstance<NdkToolchain>()
@@ -183,8 +169,13 @@ abstract class NdkToolchain {
             ndkToolchain.overrides.set(overrides)
 
             // we disable the bugsnag-android version check if Unity is enabled otherwise we end up with mutation errors
-            if (!BugsnagGenerateUnitySoMappingTask
-                .isUnityLibraryUploadEnabled(bugsnag, project.extensions.findByType(BaseExtension::class.java)!!)
+            // we also disable the check if 'useLegacyNdkSymbolUpload' has been set
+            if (
+                useLegacyNdkSymbolUpload == null ||
+                !BugsnagGenerateUnitySoMappingTask.isUnityLibraryUploadEnabled(
+                    bugsnag,
+                    project.extensions.findByType(BaseExtension::class.java)!!
+                )
             ) {
                 ndkToolchain.bugsnagNdkVersion.set(project.provider { getBugsnagAndroidNDKVersion(variant) })
             }
@@ -195,5 +186,9 @@ abstract class NdkToolchain {
     }
 }
 
-private val NdkToolchain.version get() = baseDir.map { VersionNumber.parse(it.asFile.name) }
+private val NdkToolchain.version: Provider<VersionNumber>
+    get() = baseDir.map {
+        NdkPackageXmlParser.loadVersionFromPackageXml(it.asFile)
+    }
+
 private val NdkToolchain.isLLVMPreferred get() = version.map { it >= NdkToolchain.MIN_NDK_LLVM_VERSION }

--- a/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
@@ -75,6 +75,7 @@ class PluginExtensionTest {
             assertNull(sourceControl.revision.orNull)
             assertNull(sourceControl.provider.orNull)
             assertNull(nodeModulesDir.orNull)
+            assertNull(useLegacyNdkSymbolUpload.orNull)
         }
 
         // ndk/unity upload defaults to false
@@ -112,6 +113,7 @@ class PluginExtensionTest {
             objdumpPaths.set(mapOf(Pair("armeabi-v7a", "/test/foo")))
             sharedObjectPaths.set(listOf(File("/test/bar")))
             nodeModulesDir.set(File("/test/foo/node_modules"))
+            useLegacyNdkSymbolUpload.set(true)
 
             sourceControl.repository.set("https://github.com")
             sourceControl.revision.set("d0e98fc")
@@ -136,6 +138,8 @@ class PluginExtensionTest {
             assertEquals(mapOf(Pair("armeabi-v7a", "/test/foo")), objdumpPaths.get())
             assertEquals(listOf(File("/test/bar")), sharedObjectPaths.get())
             assertEquals(File("/test/foo/node_modules"), nodeModulesDir.get())
+            assertTrue(useLegacyNdkSymbolUpload.get())
+
             assertEquals("https://github.com", sourceControl.repository.get())
             assertEquals("d0e98fc", sourceControl.revision.get())
             assertEquals("github", sourceControl.provider.get())


### PR DESCRIPTION
## Goal
Determine the NDK version being used based on the `package.xml` files within the NDK directories, with a fallback to the directory-name.

## Changelog

- Parse the `package.xml` in the NDK directory to retrieve the version number, allowing more flexible use of `ndkDir`
- Setting `useLegacyNdkSymbolUpload` now overrides the defaults inferred from the NDK version

## Testing
Manually tested with various NDK directories and options