### PR TITLE
NDK version detection based on package.xml (v8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Enhancements
+
+* Determine the NDK version being used based on the `package.xml` files within the NDK directories, with a fallback to the directory-name.
+  [#515](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/515)
+
 ## 8.0.0-beta01 (2023-03-01)
 
 ### Enhancements

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
@@ -86,7 +86,7 @@ open class BugsnagPluginExtension @Inject constructor(objects: ObjectFactory) {
         .convention(emptyMap())
 
     val useLegacyNdkSymbolUpload: Property<Boolean> = objects.property<Boolean>()
-        .convention(false)
+        .convention(NULL_BOOLEAN)
 
     // exposes sourceControl as a nested object on the extension,
     // see https://docs.gradle.org/current/userguide/custom_gradle_types.html#nested_objects

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/NdkPackageXmlParser.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/NdkPackageXmlParser.kt
@@ -1,0 +1,60 @@
+package com.bugsnag.android.gradle.internal
+
+import org.semver.Version
+import org.w3c.dom.Document
+import org.w3c.dom.Node
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+internal object NdkPackageXmlParser {
+    private const val PACKAGE_XML_FILENAME = "package.xml"
+    private const val TAG_REVISION = "revision"
+    private const val TAG_MAJOR = "major"
+    private const val TAG_MINOR = "minor"
+    private const val TAG_MICRO = "micro"
+
+    internal fun loadVersionFromPackageXml(ndkDir: File): Version {
+        val packageFile = File(ndkDir, PACKAGE_XML_FILENAME)
+        var versionNumber: Version? = null
+        if (packageFile.canRead()) {
+            versionNumber = loadPackageXml(packageFile) { doc ->
+                val revision = doc.getElementsByTagName(TAG_REVISION).item(0)
+                val major = revision.getChildValue(TAG_MAJOR)
+                val minor = revision.getChildValue(TAG_MINOR)
+                val micro = revision.getChildValue(TAG_MICRO)
+
+                Version(
+                    major?.toIntOrNull() ?: 0,
+                    minor?.toIntOrNull() ?: 0,
+                    micro?.toIntOrNull() ?: 0,
+                )
+            }
+        }
+
+        return versionNumber ?: Version.parse(ndkDir.name) // fallback to trying to parse the dir name
+    }
+
+    private inline fun <T> loadPackageXml(packageFile: File, action: (Document) -> T): T? {
+        return packageFile.inputStream().buffered().use { stream ->
+            @Suppress("TooGenericExceptionCaught", "SwallowedException")
+            try {
+                val builder = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                val document = builder.parse(stream)
+                action(document)
+            } catch (ex: Exception) {
+                null
+            }
+        }
+    }
+
+    private fun Node.getChildValue(elementName: String): String? {
+        val children = childNodes
+        repeat(children.length) { index ->
+            if (children.item(index).nodeName == elementName) {
+                return children.item(index).textContent
+            }
+        }
+
+        return null
+    }
+}

--- a/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/PluginExtensionTest.kt
@@ -75,6 +75,7 @@ class PluginExtensionTest {
             assertNull(sourceControl.revision.orNull)
             assertNull(sourceControl.provider.orNull)
             assertNull(nodeModulesDir.orNull)
+            assertNull(useLegacyNdkSymbolUpload.orNull)
         }
 
         // ndk/unity upload defaults to false
@@ -112,6 +113,7 @@ class PluginExtensionTest {
             objdumpPaths.set(mapOf(Pair("armeabi-v7a", "/test/foo")))
             sharedObjectPaths.set(listOf(File("/test/bar")))
             nodeModulesDir.set(File("/test/foo/node_modules"))
+            useLegacyNdkSymbolUpload.set(true)
 
             sourceControl.repository.set("https://github.com")
             sourceControl.revision.set("d0e98fc")
@@ -136,6 +138,8 @@ class PluginExtensionTest {
             assertEquals(mapOf(Pair("armeabi-v7a", "/test/foo")), objdumpPaths.get())
             assertEquals(listOf(File("/test/bar")), sharedObjectPaths.get())
             assertEquals(File("/test/foo/node_modules"), nodeModulesDir.get())
+            assertTrue(useLegacyNdkSymbolUpload.get())
+
             assertEquals("https://github.com", sourceControl.repository.get())
             assertEquals("d0e98fc", sourceControl.revision.get())
             assertEquals("github", sourceControl.provider.get())


### PR DESCRIPTION
## Goal
Determine the NDK version being used based on the `package.xml` files within the NDK directories, with a fallback to the directory-name.

## Changelog

- Parse the `package.xml` in the NDK directory to retrieve the version number, allowing more flexible use of `ndkDir`
- Setting `useLegacyNdkSymbolUpload` now overrides the defaults inferred from the NDK version

## Testing
Manually tested with various NDK directories and options