### PR TITLE
Allow the `bugsnagInstallJniLibsTask` to be suppressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Determine the NDK version being used based on the `package.xml` files within the NDK directories, with a fallback to the directory-name.
   [#515](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/515)
+* `bugsnag.enableNdkLinkage` can be set to `false` to suppress the extraction of the `bugsnag-plugin-android-ndk` package in projects that don't require it, suppressing "Configuration was resolved at configuration time" warnings as a result.
+  [#520](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/520)
 
 ## 8.0.0-beta01 (2023-03-01)
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -101,7 +101,9 @@ class BugsnagPlugin : Plugin<Project> {
                         " produces your APK instead."
                 )
                 project.afterEvaluate {
-                    registerNdkLibInstallTask(project)
+                    if (bugsnag.enableNdkLinkage.get()) {
+                        registerNdkLibInstallTask(project)
+                    }
                 }
             }
             project.pluginManager.withPlugin("com.android.application") {
@@ -157,7 +159,9 @@ class BugsnagPlugin : Plugin<Project> {
                     unityUploadClientProvider
                 )
             }
-            registerNdkLibInstallTask(project)
+            if (bugsnag.enableNdkLinkage.get()) {
+                registerNdkLibInstallTask(project)
+            }
         }
     }
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
@@ -88,6 +88,13 @@ open class BugsnagPluginExtension @Inject constructor(objects: ObjectFactory) {
     val useLegacyNdkSymbolUpload: Property<Boolean> = objects.property<Boolean>()
         .convention(NULL_BOOLEAN)
 
+    /**
+     * Whether to unpack the `bugsnag-plugin-android-ndk` library to allow NDK code to link directly with the BugSnag
+     * NDK C library and headers. Defaults to `true` but can be turned off if not required.
+     */
+    val enableNdkLinkage: Property<Boolean> = objects.property<Boolean>()
+        .convention(true)
+
     // exposes sourceControl as a nested object on the extension,
     // see https://docs.gradle.org/current/userguide/custom_gradle_types.html#nested_objects
 


### PR DESCRIPTION
## Goal
Allow the `bugsnagInstallJniLibsTask` to be suppressed completely for projects that don't need it, and therefore reduce the build overhead and also suppress the "Configuration resolved during configuration time" warnings in Gradle 8.

## Design
Unfortunately we cannot currently fix this warning completely, as moving the resolution into the task will break configuration caching. Including this option allows the task to be suppressed completely for projects that include NDK components (and therefore `externalNativeBuildProviders`) but do not link with the BugSnag NDK headers or `.so` files.

## Testing
Manually tested