### PR TITLE
Remove external process execution from configuration phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug Fixes
+
+* Removed `git --version` run from the configuration phase, improving compatibility with Gradle configuration caching
+  [#524](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/524)
+
 ## 8.0.0 (2023-04-24)
 
 ### Enhancements

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.gradle
 
 import com.bugsnag.android.gradle.internal.BugsnagHttpClientHelper
+import com.bugsnag.android.gradle.internal.GitVersionValueSource
 import com.bugsnag.android.gradle.internal.UploadRequestClient
 import com.bugsnag.android.gradle.internal.mapProperty
 import com.bugsnag.android.gradle.internal.property
@@ -268,7 +269,8 @@ open class BugsnagReleasesTask @Inject constructor(
                 execSpec.standardOutput = baos
                 logging.captureStandardError(LogLevel.INFO)
             }
-            String(baos.toByteArray(), Charset.forName(CHARSET_UTF8)).trim { it <= ' ' }
+
+            baos.toString(Charset.defaultCharset()).trim { it <= ' ' }
         } catch (ignored: ExecException) {
             null
         }
@@ -279,7 +281,7 @@ open class BugsnagReleasesTask @Inject constructor(
             gradleVersion.set(it)
             Version.parse(it)
         }
-        gitVersion.set(providerFactory.provider { runCmd(VCS_COMMAND, "--version") })
+        gitVersion.set(providerFactory.of(GitVersionValueSource::class.java) {})
         osArch.set(providerFactory.systemPropertyCompat(MK_OS_ARCH, gradleVersionNumber))
         osName.set(providerFactory.systemPropertyCompat(MK_OS_NAME, gradleVersionNumber))
         osVersion.set(providerFactory.systemPropertyCompat(MK_OS_VERSION, gradleVersionNumber))
@@ -300,7 +302,6 @@ open class BugsnagReleasesTask @Inject constructor(
         private const val MK_OS_VERSION = "os.version"
         private const val MK_JAVA_VERSION = "java.version"
         private const val VCS_COMMAND = "git"
-        private const val CHARSET_UTF8 = "UTF-8"
 
         @JvmStatic
         fun isValidVcsProvider(provider: String?): Boolean {

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GitVersionValueSource.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GitVersionValueSource.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android.gradle.internal
+
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.process.ExecOperations
+import java.io.ByteArrayOutputStream
+import java.nio.charset.Charset
+import javax.inject.Inject
+
+abstract class GitVersionValueSource : ValueSource<String, ValueSourceParameters.None> {
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
+    override fun obtain(): String {
+        val output = ByteArrayOutputStream()
+        execOperations.exec {
+            it.commandLine("git", "--version")
+            it.standardOutput = output
+        }
+        return output.toString(Charset.defaultCharset())
+    }
+}


### PR DESCRIPTION
## Goal
Replace external process execution that happens during the configuration phase (used for `git --version`) with a `ValueHolder` to avoid breaking the configuration cache.

## Testing
Manually tested with Gradle 8.0 and 8.1