### PR TITLE
Fix Gradle-nightly compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Removed `git --version` run from the configuration phase, improving compatibility with Gradle configuration caching
   [#524](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/524)
+* Fixed a Version parse bug which blocked the use of Gradle Nightly builds
+  []()
 
 ## 8.0.0 (2023-04-24)
 

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagReleasesTask.kt
@@ -7,7 +7,6 @@ import com.bugsnag.android.gradle.internal.mapProperty
 import com.bugsnag.android.gradle.internal.property
 import com.bugsnag.android.gradle.internal.register
 import com.bugsnag.android.gradle.internal.runRequestWithRetries
-import com.bugsnag.android.gradle.internal.systemPropertyCompat
 import com.squareup.moshi.JsonClass
 import okhttp3.OkHttpClient
 import org.gradle.api.DefaultTask
@@ -31,7 +30,6 @@ import org.gradle.process.ExecOperations
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
 import org.gradle.process.internal.ExecException
-import org.semver.Version
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -277,15 +275,11 @@ open class BugsnagReleasesTask @Inject constructor(
     }
 
     internal fun configureMetadata() {
-        val gradleVersionNumber = gradleVersion.orNull?.let {
-            gradleVersion.set(it)
-            Version.parse(it)
-        }
         gitVersion.set(providerFactory.of(GitVersionValueSource::class.java) {})
-        osArch.set(providerFactory.systemPropertyCompat(MK_OS_ARCH, gradleVersionNumber))
-        osName.set(providerFactory.systemPropertyCompat(MK_OS_NAME, gradleVersionNumber))
-        osVersion.set(providerFactory.systemPropertyCompat(MK_OS_VERSION, gradleVersionNumber))
-        javaVersion.set(providerFactory.systemPropertyCompat(MK_JAVA_VERSION, gradleVersionNumber))
+        osArch.set(providerFactory.systemProperty(MK_OS_ARCH))
+        osName.set(providerFactory.systemProperty(MK_OS_NAME))
+        osVersion.set(providerFactory.systemProperty(MK_OS_VERSION))
+        javaVersion.set(providerFactory.systemProperty(MK_JAVA_VERSION))
     }
 
     companion object {

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/GradleUtil.kt
@@ -20,20 +20,14 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.semver.Version
 import java.io.File
 
-internal object GradleVersions {
-    val VERSION_6_1: Version = Version.parse("6.1")
-}
-
 internal object AgpVersions {
-    // Use baseVersion to avoid any qualifiers like `-alpha06`
+    // Use releaseVersion to avoid any qualifiers like `-alpha06`
     val CURRENT: Version = Version.parse(ANDROID_GRADLE_PLUGIN_VERSION).toReleaseVersion()
     val VERSION_8_0: Version = Version.parse("8.0.0")
     val VERSION_9_0: Version = Version.parse("9.0.0")
@@ -112,18 +106,6 @@ internal fun AppExtension.hasMultipleOutputs(): Boolean {
 internal fun ApkVariantOutput.includesAbi(abi: String): Boolean {
     val splitArch = getFilter(VariantOutput.FilterType.ABI)
     return splitArch == null || abi == splitArch
-}
-
-/** Returns a String provider for a system property. */
-internal fun ProviderFactory.systemPropertyCompat(
-    name: String,
-    gradleVersion: Version?
-): Provider<String> {
-    return if (gradleVersion != null && gradleVersion >= GradleVersions.VERSION_6_1) {
-        systemProperty(name)
-    } else {
-        provider { System.getProperty(name) }
-    }
 }
 
 /**


### PR DESCRIPTION
## Goal
Fix https://github.com/bugsnag/bugsnag-android-gradle-plugin/issues/522 by removing the (now redundant) Gradle version parsing.

## Changeset
The parsing of the Gradle version was used to provide backwards-compatible system-property providers on older versions of Gradle. As BugSnag Gradle Plugin 8+ does not support these old versions the parse and check are no longer required.

## Testing
Manually tested with the current Gradle nightly version and Gradle 8.0 / 8.1