### PR TITLE
build: security patch for nokogiri >1.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: a2fadd12aee3eb3bc8da72e2d35ec8801cf2c186
-  tag: v6.1.0
+  revision: bd5308f3705c63b88dca229c4da387a11cb83a5d
+  tag: v6.2.0
   specs:
-    bugsnag-maze-runner (6.1.0)
+    bugsnag-maze-runner (6.2.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
@@ -42,11 +42,11 @@ GEM
       mime-types (~> 3.3, >= 3.3.1)
       multi_test (~> 0.1, >= 0.1.2)
       sys-uname (~> 1.2, >= 1.2.2)
-    cucumber-core (10.1.0)
+    cucumber-core (10.1.1)
       cucumber-gherkin (~> 22.0, >= 22.0.0)
       cucumber-messages (~> 17.1, >= 17.1.1)
-      cucumber-tag-expressions (~> 4.0, >= 4.0.2)
-    cucumber-create-meta (6.0.2)
+      cucumber-tag-expressions (~> 4.1, >= 4.1.0)
+    cucumber-create-meta (6.0.4)
       cucumber-messages (~> 17.1, >= 17.1.1)
       sys-uname (~> 1.2, >= 1.2.2)
     cucumber-cucumber-expressions (14.0.0)
@@ -57,34 +57,33 @@ GEM
       cucumber-messages (~> 17.1, >= 17.1.0)
     cucumber-messages (17.1.1)
     cucumber-tag-expressions (4.1.0)
-    cucumber-wire (6.2.0)
+    cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-      cucumber-messages (~> 17.1, >= 17.1.1)
     curb (0.9.11)
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     eventmachine (1.2.7)
-    faye-websocket (0.11.1)
+    faye-websocket (0.11.2)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    ffi (1.15.4)
-    mime-types (3.3.1)
+    ffi (1.15.5)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0901)
-    minitest (5.14.4)
+    mime-types-data (3.2023.0218.1)
+    minitest (5.18.1)
     multi_test (0.1.2)
-    nokogiri (1.12.5-x86_64-darwin)
+    nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
-    power_assert (2.0.1)
-    racc (1.6.0)
+    power_assert (2.0.3)
+    racc (1.7.1)
     rake (12.3.3)
     rubyzip (2.3.2)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sys-uname (1.2.2)
+    sys-uname (1.2.3)
       ffi (~> 1.1)
     test-unit (3.3.9)
       power_assert
@@ -96,9 +95,10 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   bugsnag-maze-runner!
 
 BUNDLED WITH
-   2.2.20
+   2.4.8


### PR DESCRIPTION
## Goal

Updating gem dependencies to get latest patches

## Testing

Changes apply to MR tests - relying on CI to prove.