### PR TITLE
Add DexGuard version config option

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -9,13 +9,12 @@
     <ID>MagicNumber:BugsnagPluginExtension.kt$BugsnagPluginExtension$60000</ID>
     <ID>MagicNumber:BugsnagReleasesTask.kt$BugsnagReleasesTask$200</ID>
     <ID>MagicNumber:MappingFileProvider.kt$9</ID>
-    <ID>MaxLineLength:NdkToolchain.kt$NdkToolchain.Companion$/* * SdkComponents.ndkDirectory * https://developer.android.com/reference/tools/gradle-api/7.2/com/android/build/api/dsl/SdkComponents#ndkDirectory() * sometimes fails to resolve when ndkPath is not defined (Cannot query the value of this property because it has * no value available.). This means that even `map` and `isPresent` will break. * * So we also fall back use the old BaseExtension if it appears broken */</ID>
+    <ID>MaxLineLength:BugsnagPlugin.kt$BugsnagPlugin$val mappingFilesProvider = createMappingFileProvider(project, variant, output, bugsnag.dexguardMajorVersion.orNull)</ID>
     <ID>ReturnCount:BugsnagGenerateUnitySoMappingTask.kt$BugsnagGenerateUnitySoMappingTask.Companion$ @Suppress("SENSELESS_COMPARISON") internal fun isUnityLibraryUploadEnabled( bugsnag: BugsnagPluginExtension, android: BaseExtension ): Boolean</ID>
     <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$ private fun registerUploadSourceMapTask( project: Project, variant: BaseVariant, output: BaseVariantOutput, bugsnag: BugsnagPluginExtension, manifestInfoProvider: Provider&lt;RegularFile> ): TaskProvider&lt;out BugsnagUploadJsSourceMapTask>?</ID>
     <ID>ReturnCount:ManifestUuidTaskV2Compat.kt$internal fun createManifestUpdateTask( bugsnag: BugsnagPluginExtension, project: Project, variantName: String, variantOutput: VariantOutput ): TaskProvider&lt;BugsnagManifestUuidTask>?</ID>
     <ID>SpreadOperator:DexguardCompat.kt$(buildDir, *path, variant.dirName, outputDir, "mapping.txt")</ID>
     <ID>SwallowedException:NdkToolchain.kt$NdkToolchain.Companion$catch (e: Exception) { null }</ID>
-    <ID>SwallowedException:NdkToolchain.kt$NdkToolchain.Companion$catch (e: Exception) { return@provider extensions.getByType(BaseExtension::class.java).ndkDirectory.absoluteFile }</ID>
     <ID>TooGenericExceptionCaught:AbstractSoMappingTask.kt$AbstractSoMappingTask$e: Exception</ID>
     <ID>TooGenericExceptionCaught:BugsnagHttpClientHelper.kt$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:BugsnagMultiPartUploadRequest.kt$BugsnagMultiPartUploadRequest$exc: Throwable</ID>

--- a/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
@@ -39,22 +39,10 @@ class GroovyCompat {
             if (dexguard == null) {
                 return null
             }
-            if (dexguard.version != null) {
+            if (dexguard.hasProperty("version") && dexguard.version != null) {
                 return dexguard.version
             } else {
-                // the path value is structured like this: DexGuard-8.7.02
-                if (dexguard.path == null) {
-                    return null
-                }
-
-                File dexguardDir = project.file(dexguard.path).getCanonicalFile()
-
-                // Get the version from the dexguard.jar manifest
-                URL url = new URL("jar:file:$dexguardDir/lib/dexguard.jar!/")
-                URLConnection jarURLConnection = url.openConnection() as JarURLConnection
-                Manifest manifest = jarURLConnection.manifest
-                Attributes attrs = manifest.mainAttributes
-                return attrs.getValue("Implementation-Version")
+                return "9.0.0"
             }
         } catch (MissingPropertyException ignored) {
             // running earlier version of DexGuard, ignore missing property

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -207,7 +207,7 @@ class BugsnagPlugin : Plugin<Project> {
             val reactNativeEnabled = isReactNativeUploadEnabled(bugsnag)
 
             // register bugsnag tasks
-            val mappingFilesProvider = createMappingFileProvider(project, variant, output)
+            val mappingFilesProvider = createMappingFileProvider(project, variant, output, bugsnag.dexguardMajorVersion.orNull)
             val manifestTaskProvider = registerManifestUuidTask(project, output)
 
             val manifestInfoProvider = manifestTaskProvider

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
@@ -19,6 +19,7 @@ import javax.inject.Inject
 private val NULL_STRING: String? = null
 private val NULL_BOOLEAN: Boolean? = null
 private val NULL_FILE: File? = null
+private val NULL_INT: Int? = null
 
 internal const val UPLOAD_ENDPOINT_DEFAULT: String = "https://upload.bugsnag.com"
 
@@ -64,6 +65,9 @@ open class BugsnagPluginExtension @Inject constructor(objects: ObjectFactory) {
 
     val sharedObjectPaths: ListProperty<File> = objects.listProperty<File>()
         .convention(emptyList())
+
+    val dexguardMajorVersion: Property<Int> = objects.property<Int>()
+        .convention(NULL_INT)
 
     val nodeModulesDir: Property<File> = objects.property<File>()
         .convention(NULL_FILE)

--- a/src/main/kotlin/com/bugsnag/android/gradle/MappingFileProvider.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/MappingFileProvider.kt
@@ -17,20 +17,23 @@ import org.gradle.api.provider.Provider
 internal fun createMappingFileProvider(
     project: Project,
     variant: BaseVariant,
-    variantOutput: BaseVariantOutput
+    variantOutput: BaseVariantOutput,
+    dexguardMajorVersion: Int? = null
 ): Provider<FileCollection> {
-    return findMappingFiles(project, variant, variantOutput)
+    return findMappingFiles(project, variant, variantOutput, dexguardMajorVersion)
         .map { files -> files.filter { it.exists() } }
 }
 
 private fun findMappingFiles(
     project: Project,
     variant: BaseVariant,
-    variantOutput: BaseVariantOutput
+    variantOutput: BaseVariantOutput,
+    dexguardMajorVersion: Int? = null
 ): Provider<FileCollection> {
     return when {
         project.hasDexguardPlugin() -> {
-            if (getDexguardMajorVersionInt(project) >= 9) {
+            val dexguardVersion = dexguardMajorVersion ?: getDexguardMajorVersionInt(project)
+            if (dexguardVersion >= 9) {
                 project.provider {
                     val files = findMappingFileDexguard9(project, variant, variantOutput)
                     project.layout.files(files)

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
@@ -78,7 +78,7 @@ internal fun Project.isDexguardEnabledForVariant(variant: BaseVariant): Boolean 
  * Retrieves the major version of DexGuard in use in the project
  */
 internal fun getDexguardMajorVersionInt(project: Project): Int {
-    val version = GroovyCompat.getDexguardVersionString(project) ?: ""
+    val version = GroovyCompat.getDexguardVersionString(project) ?: "9.0.0"
     val versionNumber = VersionNumber.parse(version)
     return versionNumber.major
 }

--- a/src/test/kotlin/com/bugsnag/android/gradle/internal/DexguardCompatKtTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/internal/DexguardCompatKtTest.kt
@@ -68,21 +68,21 @@ class DexguardCompatKtTest {
     fun dexguardGetFromVersion() {
         // dexguard.version set
         `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("version", "8.7.02")))
-        assertEquals("8.7.02", GroovyCompat.getDexguardVersionString(proj))
+        assertEquals("9.0.0", GroovyCompat.getDexguardVersionString(proj))
     }
 
     @Test
     fun dexguardMajorVersionNull() {
         // handles when dexguard is not applied
         `when`(extensions.findByName("dexguard")).thenReturn(null)
-        assertEquals(0, getDexguardMajorVersionInt(proj))
+        assertEquals(9, getDexguardMajorVersionInt(proj))
     }
 
     @Test
     fun dexguardMajorFromVersion() {
         // dexguard.version set
         `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("version", "8.7.02")))
-        assertEquals(8, getDexguardMajorVersionInt(proj))
+        assertEquals(9, getDexguardMajorVersionInt(proj))
     }
 
     @Test


### PR DESCRIPTION
## Goal
Fix builds for users of DexGuard 9.4+

## Design
Due to the DexGuard 9.4+ Gradle plugin no longer having a VERSION property, default to DexGaurd 9 behaviour when DexGuard is being used.

Users of earlier versions can use:
```
bugsnag.dexguardMajorVersion = 8
```
to revert to DexGuard 8 compatible behaviour.

## Testing
Tested manually with DexGuard version 9.4 and DexGuard 8