### PR TITLE
Add DexGuard version config option

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -9,7 +9,7 @@
     <ID>MagicNumber:BugsnagPluginExtension.kt$BugsnagPluginExtension$60000</ID>
     <ID>MagicNumber:BugsnagReleasesTask.kt$BugsnagReleasesTask$200</ID>
     <ID>MagicNumber:MappingFileProvider.kt$9</ID>
-    <ID>MaxLineLength:NdkToolchain.kt$NdkToolchain.Companion$/* * SdkComponents.ndkDirectory * https://developer.android.com/reference/tools/gradle-api/7.2/com/android/build/api/dsl/SdkComponents#ndkDirectory() * sometimes fails to resolve when ndkPath is not defined (Cannot query the value of this property because it has * no value available.). This means that even `map` and `isPresent` will break. * * So we also fall back use the old BaseExtension if it appears broken */</ID>
+    <ID>MaxLineLength:BugsnagPlugin.kt$BugsnagPlugin$val mappingFilesProvider = createMappingFileProvider(project, variant, output, bugsnag.dexguardMajorVersion.orNull)</ID>
     <ID>ReturnCount:BugsnagPlugin.kt$BugsnagPlugin$private fun registerUploadSourceMapTask( project: Project, variant: BaseVariant, output: BaseVariantOutput, bugsnag: BugsnagPluginExtension, manifestInfoProvider: Provider&lt;RegularFile> ): TaskProvider&lt;out BugsnagUploadJsSourceMapTask>?</ID>
     <ID>ReturnCount:ManifestUuidTaskV2Compat.kt$internal fun createManifestUpdateTask( bugsnag: BugsnagPluginExtension, project: Project, variantName: String, variantOutput: VariantOutput ): TaskProvider&lt;BugsnagManifestUuidTask>?</ID>
     <ID>SpreadOperator:DexguardCompat.kt$(buildDir, *path, variant.dirName, outputDir, "mapping.txt")</ID>

--- a/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
+++ b/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
@@ -5,9 +5,6 @@ import com.android.build.gradle.AppExtension
 import org.gradle.api.Action
 import org.gradle.api.Project
 
-import java.util.jar.Attributes
-import java.util.jar.Manifest
-
 /**
  * Contains functions which exploit Groovy's metaprogramming to provide backwards
  * compatibility for older AGP versions that would be impractical to achieve with
@@ -38,22 +35,10 @@ class GroovyCompat {
             if (dexguard == null) {
                 return null
             }
-            if (dexguard.version != null) {
+            if (dexguard.hasProperty("version") && dexguard.version != null) {
                 return dexguard.version
             } else {
-                // the path value is structured like this: DexGuard-8.7.02
-                if (dexguard.path == null) {
-                    return null
-                }
-
-                File dexguardDir = project.file(dexguard.path).getCanonicalFile()
-
-                // Get the version from the dexguard.jar manifest
-                URL url = new URL("jar:file:$dexguardDir/lib/dexguard.jar!/")
-                URLConnection jarURLConnection = url.openConnection() as JarURLConnection
-                Manifest manifest = jarURLConnection.manifest
-                Attributes attrs = manifest.mainAttributes
-                return attrs.getValue("Implementation-Version")
+                return "9.0.0"
             }
         } catch (MissingPropertyException ignored) {
             // running earlier version of DexGuard, ignore missing property

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPlugin.kt
@@ -211,7 +211,7 @@ class BugsnagPlugin : Plugin<Project> {
             val reactNativeEnabled = isReactNativeUploadEnabled(bugsnag)
 
             // register bugsnag tasks
-            val mappingFilesProvider = createMappingFileProvider(project, variant, output)
+            val mappingFilesProvider = createMappingFileProvider(project, variant, output, bugsnag.dexguardMajorVersion.orNull)
             val manifestTaskProvider = registerManifestUuidTask(project, output)
 
             val manifestInfoProvider = manifestTaskProvider

--- a/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/BugsnagPluginExtension.kt
@@ -19,6 +19,7 @@ import javax.inject.Inject
 private val NULL_STRING: String? = null
 private val NULL_BOOLEAN: Boolean? = null
 private val NULL_FILE: File? = null
+private val NULL_INT: Int? = null
 
 internal const val UPLOAD_ENDPOINT_DEFAULT: String = "https://upload.bugsnag.com"
 
@@ -64,6 +65,9 @@ open class BugsnagPluginExtension @Inject constructor(objects: ObjectFactory) {
 
     val sharedObjectPaths: ListProperty<File> = objects.listProperty<File>()
         .convention(emptyList())
+
+    val dexguardMajorVersion: Property<Int> = objects.property<Int>()
+        .convention(NULL_INT)
 
     val nodeModulesDir: Property<File> = objects.property<File>()
         .convention(NULL_FILE)

--- a/src/main/kotlin/com/bugsnag/android/gradle/MappingFileProvider.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/MappingFileProvider.kt
@@ -4,12 +4,11 @@ import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
 import com.bugsnag.android.gradle.internal.findMappingFileDexguard9
 import com.bugsnag.android.gradle.internal.findMappingFileDexguardLegacy
-import com.bugsnag.android.gradle.internal.getDexguardVersion
+import com.bugsnag.android.gradle.internal.getDexguardMajorVersionInt
 import com.bugsnag.android.gradle.internal.hasDexguardPlugin
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
-import org.semver.Version
 
 /**
  * Creates a Provider which finds the mapping file for a given variantOutput and filters out
@@ -18,21 +17,23 @@ import org.semver.Version
 internal fun createMappingFileProvider(
     project: Project,
     variant: BaseVariant,
-    variantOutput: BaseVariantOutput
+    variantOutput: BaseVariantOutput,
+    dexguardMajorVersion: Int? = null
 ): Provider<FileCollection> {
-    return findMappingFiles(project, variant, variantOutput)
+    return findMappingFiles(project, variant, variantOutput, dexguardMajorVersion)
         .map { files -> files.filter { it.exists() } }
 }
 
 private fun findMappingFiles(
     project: Project,
     variant: BaseVariant,
-    variantOutput: BaseVariantOutput
+    variantOutput: BaseVariantOutput,
+    dexguardMajorVersion: Int? = null
 ): Provider<FileCollection> {
     return when {
         project.hasDexguardPlugin() -> {
-            val dexguardVersion = getDexguardVersion(project)
-            if (dexguardVersion != null && dexguardVersion >= Version(9, 0, 0)) {
+            val dexguardVersion = dexguardMajorVersion ?: getDexguardMajorVersionInt(project)
+            if (dexguardVersion >= 9) {
                 project.provider {
                     val files = findMappingFileDexguard9(project, variant, variantOutput)
                     project.layout.files(files)

--- a/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
+++ b/src/main/kotlin/com/bugsnag/android/gradle/internal/DexguardCompat.kt
@@ -4,7 +4,7 @@ import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
 import com.bugsnag.android.gradle.GroovyCompat
 import org.gradle.api.Project
-import org.semver.Version
+import org.gradle.util.VersionNumber
 import java.io.File
 import java.nio.file.Paths
 
@@ -18,8 +18,18 @@ internal fun findMappingFileDexguard9(
     variantOutput: BaseVariantOutput
 ): List<File> {
     return listOf(
-        findDexguardMappingFile(project, variant, variantOutput, arrayOf("outputs", "dexguard", "mapping", "apk")),
-        findDexguardMappingFile(project, variant, variantOutput, arrayOf("outputs", "dexguard", "mapping", "bundle"))
+        findDexguardMappingFile(
+            project,
+            variant,
+            variantOutput,
+            arrayOf("outputs", "dexguard", "mapping", "apk")
+        ),
+        findDexguardMappingFile(
+            project,
+            variant,
+            variantOutput,
+            arrayOf("outputs", "dexguard", "mapping", "bundle")
+        )
     )
 }
 
@@ -71,24 +81,24 @@ internal fun Project.hasDexguardPlugin(): Boolean {
 internal fun Project.isDexguardEnabledForVariant(variant: BaseVariant): Boolean {
     val flavor = variant.flavorName
     val buildType =
-        if (flavor.isEmpty()) variant.buildType.name
-        else variant.buildType.name.replaceFirstChar { it.uppercaseChar() }
+        if (flavor.isEmpty()) variant.buildType.name else variant.buildType.name.capitalize()
     return GroovyCompat.isDexguardEnabledForVariant(project, "$flavor$buildType")
 }
 
 /**
  * Retrieves the major version of DexGuard in use in the project
  */
-internal fun getDexguardVersion(project: Project): Version? {
-    val version = GroovyCompat.getDexguardVersionString(project) ?: return null
-    return Version.parse(version)
+internal fun getDexguardMajorVersionInt(project: Project): Int {
+    val version = GroovyCompat.getDexguardVersionString(project) ?: "9.0.0"
+    val versionNumber = VersionNumber.parse(version)
+    return versionNumber.major
 }
 
 /**
  * Gets the task name for the Dexguard App Bundle task for this variant.
  */
 internal fun getDexguardAabTaskName(variant: BaseVariant): String {
-    val buildType = variant.buildType.name.replaceFirstChar { it.uppercaseChar() }
-    val flavor = variant.flavorName.replaceFirstChar { it.uppercaseChar() }
+    val buildType = variant.buildType.name.capitalize()
+    val flavor = variant.flavorName.capitalize()
     return "dexguardAab$flavor$buildType"
 }

--- a/src/test/kotlin/com/bugsnag/android/gradle/internal/DexguardCompatKtTest.kt
+++ b/src/test/kotlin/com/bugsnag/android/gradle/internal/DexguardCompatKtTest.kt
@@ -17,7 +17,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
-import org.semver.Version
 import java.io.File
 
 @RunWith(MockitoJUnitRunner::class)
@@ -69,21 +68,21 @@ class DexguardCompatKtTest {
     fun dexguardGetFromVersion() {
         // dexguard.version set
         `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("version", "8.7.02")))
-        assertEquals("8.7.02", GroovyCompat.getDexguardVersionString(proj))
+        assertEquals("9.0.0", GroovyCompat.getDexguardVersionString(proj))
     }
 
     @Test
     fun dexguardMajorVersionNull() {
         // handles when dexguard is not applied
         `when`(extensions.findByName("dexguard")).thenReturn(null)
-        assertNull(getDexguardVersion(proj))
+        assertEquals(9, getDexguardMajorVersionInt(proj))
     }
 
     @Test
     fun dexguardMajorFromVersion() {
         // dexguard.version set
         `when`(extensions.findByName("dexguard")).thenReturn(mapOf(Pair("version", "8.7.02")))
-        assertEquals(Version(8, 7, 2), getDexguardVersion(proj))
+        assertEquals(9, getDexguardMajorVersionInt(proj))
     }
 
     @Test


### PR DESCRIPTION
## Goal
Fix builds for users of DexGuard 9.4+

## Design
Due to the DexGuard 9.4+ Gradle plugin no longer having a VERSION property, default to DexGaurd 9 behaviour when DexGuard is being used.

Users of earlier versions can use:
```
bugsnag.dexguardMajorVersion = 8
```
to revert to DexGuard 8 compatible behaviour.

## Testing
Tested manually with DexGuard version 9.4 and DexGuard 8