### PR TITLE
Supp 3933 fix documentation links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ If you aren't using Gradle or need more manual control, [see the API docs](https
 ## Getting started
 
 1. [Create a Bugsnag account](https://bugsnag.com)
-1. Complete the instructions in the [integration guide](https://docs.bugsnag.com/build-integrations/gradle/) to setup the Gradle Plugin
-1. Customize your integration using the [configuration options](http://docs.bugsnag.com/build-integrations/gradle/#additional-configuration)
+1. Complete the instructions in the [integration guide](https://docs.bugsnag.com/build-integrations/android-gradle-plugin/) to setup the Gradle Plugin
+1. Customize your integration using the [configuration options](https://docs.bugsnag.com/build-integrations/android-gradle-plugin/#additional-configuration)
 
 ## Support
 
-* [Read the integration guide](https://docs.bugsnag.com/build-integrations/gradle/) or [configuration options documentation](http://docs.bugsnag.com/build-integrations/gradle/#additional-configuration)
+* [Read the integration guide](https://docs.bugsnag.com/build-integrations/android-gradle-plugin/) or [configuration options documentation](https://docs.bugsnag.com/build-integrations/android-gradle-plugin/#additional-configuration)
 * [Search open and closed issues](https://github.com/bugsnag/bugsnag-android-gradle-plugin/issues?utf8=✓&q=is%3Aissue) for similar problems
 * [Report a bug or request a feature](https://github.com/bugsnag/bugsnag-android-gradle-plugin/issues/new)
 - [Additional Documentation](https://docs.bugsnag.com/api/android-mapping-upload/)

--- a/dockerfiles/Dockerfile.android-ci
+++ b/dockerfiles/Dockerfile.android-ci
@@ -47,7 +47,7 @@ RUN yes | sdkmanager 'ndk;16.1.4479499' >/dev/null
 ENV ANDROID_NDK_HOME="/sdk/ndk/16.1.4479499"
 
 # Install Ruby and other maze-runner requirements
-RUN gem install bundler
+RUN gem install bundler -v 2.4.22
 RUN gem update --system 3.0.6
 
 # Install node, npm and yarn


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
Documentation links were outdated and lead to a 404 page.

## Changeset

<!-- What changed? -->
Changed links from 
```https://docs.bugsnag.com/build-integrations/gradle/```

to

```https://docs.bugsnag.com/build-integrations/android-gradle-plugin/```

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->