### PR TITLE
release v8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 8.2.0 (2025-01-23)
+
+### Changes
+* Changed the default endpoint for `mapping.txt` files to the new `/proguard` endpoint
+  [#544](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/544)
+
 ## 8.1.0 (2023-09-28)
 
 ### Enhancements

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ POM_ARTIFACT_ID=bugsnag-android-gradle-plugin
 POM_PACKAGING=jar
 
 GROUP=com.bugsnag
-VERSION_NAME=8.1.0
+VERSION_NAME=8.2.0
 POM_DESCRIPTION=Gradle plugin to automatically upload ProGuard mapping files to Bugsnag.
 
 POM_URL=https://github.com/bugsnag/bugsnag-android-gradle-plugin/


### PR DESCRIPTION
### Changes
* Changed the default endpoint for `mapping.txt` files to the new `/proguard` endpoint
  [#544](https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/544)